### PR TITLE
New Y FM Deemphasis code and --noAGC command line option

### DIFF
--- a/vhs-decode
+++ b/vhs-decode
@@ -180,6 +180,10 @@ parser.add_argument(
     help="Decode u-matic",
 )
 
+parser.add_argument(
+    "--noAGC", dest="noAGC", action="store_true", default=False, help="Disable AGC"
+)
+
 args = parser.parse_args()
 filename = args.infile
 outname = args.outfile
@@ -187,6 +191,10 @@ firstframe = args.start
 req_frames = args.length
 tape_format = "UMATIC" if args.umatic else "VHS"
 system = "PAL" if args.pal else "NTSC"
+
+extra_options = {
+    "useAGC": not args.noAGC,
+}
 
 if args.pal and args.ntsc:
     print("ERROR: Can only be PAL or NTSC")
@@ -238,6 +246,7 @@ vhsd = VHSDecode(
     dod_hysteresis=args.dod_hysteresis,
     track_phase=args.track_phase,
     level_adjust=args.level_adjust,
+    extra_options=extra_options
 )
 
 signal.signal(signal.SIGINT, original_sigint_handler)

--- a/vhsdecode/addons/FMdeemph.py
+++ b/vhsdecode/addons/FMdeemph.py
@@ -1,0 +1,110 @@
+"""
+    FM deemphasis filter borrowed from GNURadio
+    Copyright 2005,2007,2021 Free Software Foundation, Inc.
+    SPDX-License-Identifier: GPL-3.0-or-later
+"""
+import math
+
+
+class FMDeEmphasis:
+    r"""
+    FM Deemphasis IIR filter
+
+    Args:
+        fs: sampling frequency in Hz (float)
+        tau: Time constant in seconds (75us in US, 50us in EUR) (float)
+
+  An analog deemphasis filter:
+
+               R
+  o------/\/\/\/---+----o
+                   |
+                  = C
+                   |
+                  ---
+
+  Has this transfer function:
+
+               1             1
+              ----          ---
+               RC          tau
+  H(s) = ---------- = ----------
+                 1             1
+            s + ----      s + ---
+                 RC           tau
+
+  And has its -3 dB response, due to the pole, at
+
+  |H(j w_c)|^2 = 1/2  =>  s = j w_c = j (1/(RC))
+
+  Historically, this corner frequency of analog audio deemphasis filters
+  been specified by the RC time constant used, called tau.
+  So w_c = 1/tau.
+
+  FWIW, for standard tau values, some standard analog components would be:
+  tau = 75 us = (50K)(1.5 nF) = (50 ohms)(1.5 uF)
+  tau = 50 us = (50K)(1.0 nF) = (50 ohms)(1.0 uF)
+
+  In specifying tau for this digital deemphasis filter, tau specifies
+  the *digital* corner frequency, w_c, desired.
+
+  The digital deemphasis filter design below, uses the
+  "bilinear transformation" method of designing digital filters:
+
+  1. Convert digital specifications into the analog domain, by prewarping
+     digital frequency specifications into analog frequencies.
+
+     w_a = (2/T)tan(wT/2)
+
+  2. Use an analog filter design technique to design the filter.
+
+  3. Use the bilinear transformation to convert the analog filter design to a
+     digital filter design.
+
+     H(z) = H(s)|
+                     s = (2/T)(1-z^-1)/(1+z^-1)
+
+
+         w_ca         1          1 - (-1) z^-1
+  H(z) = ---- * ----------- * -----------------------
+         2 fs        -w_ca             -w_ca
+                 1 - -----         1 + -----
+                      2 fs              2 fs
+                               1 - ----------- z^-1
+                                       -w_ca
+                                   1 - -----
+                                        2 fs
+
+  We use this design technique, because it is an easy way to obtain a filter
+  design with the -6 dB/octave roll-off required of the deemphasis filter.
+
+  Jackson, Leland B., _Digital_Filters_and_Signal_Processing_Second_Edition_,
+    Kluwer Academic Publishers, 1989, pp 201-212
+
+  Orfanidis, Sophocles J., _Introduction_to_Signal_Processing_, Prentice Hall,
+    1996, pp 573-583
+    """
+
+    def __init__(self, fs, tau=1.25e-6):
+
+        # Digital corner frequency
+        w_c = 1.0 / tau
+
+        # Prewarped analog corner frequency
+        w_ca = 2.0 * fs * math.tan(w_c / (2.0 * fs))
+
+        # Resulting digital pole, zero, and gain term from the bilinear
+        # transformation of H(s) = w_ca / (s + w_ca) to
+        # H(z) = b0 (1 - z1 z^-1)/(1 - p1 z^-1)
+        k = -w_ca / (2.0 * fs)
+        z1 = -1.0
+        p1 = (1.0 + k) / (1.0 - k)
+        b0 = -k / (1.0 - k)
+
+        self.btaps = [b0 * 1.0, b0 * -z1]
+        self.ataps = [1.0, -p1]
+
+        # Since H(s = 0) = 1.0, then H(z = 1) = 1.0 and has 0 dB gain at DC
+
+    def get(self):
+        return self.btaps, self.ataps

--- a/vhsdecode/formats.py
+++ b/vhsdecode/formats.py
@@ -36,11 +36,8 @@ RFParams_PAL_VHS["video_lpf_order"] = 6
 # PAL color under carrier is 40H + 1953
 RFParams_PAL_VHS["color_under_carrier"] = ((625 * 25) * 40) + 1953
 
-# -3dB frequency for deemph filter, subject to change
-# as filter generation isn't quite right at the moment.
-RFParams_PAL_VHS["deemph_corner"] = 260000
-RFParams_PAL_VHS["deemph_gain"] = 15
-
+#Video Y FM de-emphasis (1.25~1.35µs)
+RFParams_PAL_VHS["deemph_tau"] = 1.30e-6
 
 # Band-pass filter for Video rf.
 # TODO: Needs tweaking
@@ -56,7 +53,7 @@ RFParams_NTSC_VHS["video_hpf_extra"] = 1690000
 RFParams_NTSC_VHS["video_hpf_extra_order"] = 1
 
 # Low-pass filter on Y after demodulation
-RFParams_NTSC_VHS["video_lpf_freq"] = 3000000
+RFParams_NTSC_VHS["video_lpf_freq"] = 3200000
 
 # Order may be fine as is.
 RFParams_NTSC_VHS["video_lpf_order"] = 1
@@ -65,8 +62,8 @@ RFParams_NTSC_VHS["video_lpf_order"] = 1
 RFParams_NTSC_VHS["color_under_carrier"] = (525 * (30 / 1.001)) * 40
 RFParams_NTSC_VHS["luma_carrier"] = 455.0 * ((525 * (30 / 1.001)) / 2.0)
 
-RFParams_NTSC_VHS["deemph_corner"] = 260000
-RFParams_NTSC_VHS["deemph_gain"] = 14
+#Video Y FM de-emphasis (1.25~1.35µs)
+RFParams_NTSC_VHS["deemph_tau"] = 1.30e-6
 
 
 RFParams_NTSC_UMATIC["video_bpf_low"] = 3200000
@@ -79,9 +76,9 @@ RFParams_NTSC_UMATIC["video_hpf_extra_order"] = 1
 RFParams_NTSC_UMATIC["video_lpf_freq"] = 4000000
 RFParams_NTSC_UMATIC["video_lpf_order"] = 2
 RFParams_NTSC_UMATIC["color_under_carrier"] = 688373
-# This is prob wrong, just eyeballed for now.
-RFParams_NTSC_UMATIC["deemph_corner"] = 450000
-RFParams_NTSC_UMATIC["deemph_gain"] = 11
+
+#Video Y FM de-emphasis (550 ~ 650ns)
+RFParams_NTSC_UMATIC["deemph_tau"] = 600e-9
 
 SysParams_PAL_VHS = {**SysParams_PAL}
 SysParams_NTSC_VHS = {**SysParams_NTSC}

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -1094,6 +1094,7 @@ class VHSDecode(ldd.LDdecode):
         dod_hysteresis=vhs_formats.DEFAULT_HYSTERESIS,
         track_phase=0,
         level_adjust=0.2,
+        extra_options={},
     ):
         super(VHSDecode, self).__init__(
             fname_in,
@@ -1104,6 +1105,7 @@ class VHSDecode(ldd.LDdecode):
             system=system,
             doDOD=doDOD,
             threads=threads,
+            extra_options=extra_options,
         )
         # Adjustment for output to avoid clipping.
         self.level_adjust = level_adjust

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -11,7 +11,7 @@ from lddecode.utils import unwrap_hilbert, inrange
 import vhsdecode.utils as utils
 
 import vhsdecode.formats as vhs_formats
-
+from vhsdecode.addons.FMdeemph import FMDeEmphasis
 
 def toDB(val):
     return 20 * np.log10(val)
@@ -1315,12 +1315,7 @@ class VHSRFDecode(ldd.RFDecode):
         self.Filters["RFVideo"] = y_fm_filter
 
         # Video (luma) de-emphasis
-        # Not sure about the math of this but, by using a high-shelf filter and then
-        # swapping b and a we get a low-shelf filter that goes from 0 to -14 dB rather
-        # than from 14 to 0 which the high shelf function gives.
-        da, db = gen_high_shelf(
-            DP["deemph_corner"] / 1.0e6, DP["deemph_gain"], 1 / 2, inputfreq
-        )
+        db, da = FMDeEmphasis(self.freq_hz, tau=DP["deemph_tau"]).get()
 
         self.Filters["FEnvPost"] = sps.butter(
             1, [1000000 / self.freq_hz_half], btype="lowpass"


### PR DESCRIPTION
I added the IIR deemphasis filter as in GNURadio implementation, it changes the way the deemph parameters are defined.
Now, it only takes tau as the main argument.

I also added the --noAGC command line flag to turn off automatic AGC on the luma channel for the case where the source tape is noisy.

Without --noAGC option, the "hz_ire" parameter in formats.py is only used at initialization, then the AGC overrides it.
