### PR TITLE
Fix shell scripts as recommended by shellcheck

### DIFF
--- a/gen_chroma_vid_ntsc.sh
+++ b/gen_chroma_vid_ntsc.sh
@@ -9,33 +9,33 @@ if [ -f "$1.wav" ] ; then
   ffmpeg -hide_banner -thread_queue_size 1024 \
     -color_range tv \
     -i <( \
-      ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-      ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+      ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+      ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
     ) \
     -i <( \
-      ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-      ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --ntsc-phase-comp --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - -\
+      ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+      ld-chroma-decoder -f "$CHROMA_DECODER" --luma-nr 0 --ntsc-phase-comp --chroma-gain "$CHROMA_GAIN" -p y4m --input-json "$1.tbc.json" - -\
     ) \
-    -itsoffset -00:00:00.000 -i $1.wav \
-    -filter_complex $FILTER_COMPLEX \
+    -itsoffset -00:00:00.000 -i "$1.wav" \
+    -filter_complex "$FILTER_COMPLEX" \
     -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
     -pixel_format yuv422p10le -color_range tv -color_primaries smpte170m -color_trc smpte170m \
-    -colorspace smpte170m -c:a flac -compression_level 12 -map 2:a? -shortest -y $1.mkv
+    -colorspace smpte170m -c:a flac -compression_level 12 -map 2:a? -shortest -y "$1.mkv"
 else
   ffmpeg -hide_banner -thread_queue_size 1024  \
   -color_range tv \
   -i <(\
-    ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
   ) \
   -i <(\
-    ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --ntsc-phase-comp --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+    ld-chroma-decoder -f "$CHROMA_DECODER" --luma-nr 0 --ntsc-phase-comp --chroma-gain "$CHROMA_GAIN" -p y4m --input-json "$1.tbc.json" - - \
   ) \
-  -filter_complex $FILTER_COMPLEX \
+  -filter_complex "$FILTER_COMPLEX" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries smpte170m \
-  -color_trc smpte170m -colorspace smpte170m -shortest -y $1.mkv
+  -color_trc smpte170m -colorspace smpte170m -shortest -y "$1.mkv"
 fi
 
 # Encode internet-friendly clip of previous lossless result:

--- a/gen_chroma_vid_pal.sh
+++ b/gen_chroma_vid_pal.sh
@@ -9,34 +9,34 @@ if [ -f "$1.wav" ] ; then
   ffmpeg -hide_banner -thread_queue_size 4096 \
   -color_range tv \
   -i <( \
-    ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
   ) \
   -i <( \
-    ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json "$1.tbc.json" - - \
   ) \
-  -itsoffset -00:00:00.000 -i $1.wav \
-  -filter_complex $FILTER_COMPLEX \
+  -itsoffset -00:00:00.000 -i "$1.wav" \
+  -filter_complex "$FILTER_COMPLEX" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 25 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries bt470bg -color_trc gamma28 \
-  -colorspace bt470bg -c:a flac -compression_level 12 -map 2:a? -shortest -y $1.mkv
+  -colorspace bt470bg -c:a flac -compression_level 12 -map 2:a? -shortest -y "$1.mkv"
 else
   ffmpeg -hide_banner -thread_queue_size 4096\
   -color_range tv \
   -i <( \
-    ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
   ) \
   -i <( \
-    ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - -
+    ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json "$1.tbc.json" - -
   ) \
-  -filter_complex $FILTER_COMPLEX \
+  -filter_complex "$FILTER_COMPLEX" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 25 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries bt470bg -color_trc gamma28 \
-  -colorspace bt470bg -shortest -y $1.mkv
+  -colorspace bt470bg -shortest -y "$1.mkv"
 fi
 
 # Encode internet-friendly clip of previous lossless result:
-#ffmpeg -hide_banner -i $1.mkv -vf scale=in_color_matrix=bt601:out_color_matrix=bt709:768x576,bwdif=1:0:0 -c:v libx264 -preset veryslow -b:v 6M -maxrate 6M -bufsize 6M -pixel_format yuv420p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -aspect 4:3 -c:a libopus -b:a 192k -strict -2 -movflags +faststart -y $1_lossy.mp4
+#ffmpeg -hide_banner -i "$1.mkv" -vf scale=in_color_matrix=bt601:out_color_matrix=bt709:768x576,bwdif=1:0:0 -c:v libx264 -preset veryslow -b:v 6M -maxrate 6M -bufsize 6M -pixel_format yuv420p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -aspect 4:3 -c:a libopus -b:a 192k -strict -2 -movflags +faststart -y "$1_lossy.mp4"

--- a/gen_chroma_vid_palm.sh
+++ b/gen_chroma_vid_palm.sh
@@ -9,34 +9,34 @@ if [ -f "$1.wav" ] ; then
   ffmpeg -hide_banner -thread_queue_size 4096 \
   -color_range tv \
   -i <( \
-        ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-            ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+        ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+            ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
   ) \
   -i <( \
-        ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-            ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - - \
+        ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+            ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json "$1.tbc.json" - - \
   ) \
-  -itsoffset -00:00:00.000 -i $1.wav \
-  -filter_complex $FILTER_COMPLEX \
+  -itsoffset -00:00:00.000 -i "$1.wav" \
+  -filter_complex "$FILTER_COMPLEX" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries bt470bg -color_trc gamma28 \
-  -colorspace bt470bg -aspect 4:3 -c:a flac -compression_level 12 -map 2:a? -shortest -y $1.mkv
+  -colorspace bt470bg -aspect 4:3 -c:a flac -compression_level 12 -map 2:a? -shortest -y "$1.mkv"
 else
   ffmpeg -hide_banner -thread_queue_size 4096 \
   -color_range tv \
   -i <( \
-    ld-dropout-correct -i $1.tbc --output-json /dev/null - | \
-    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | \
+    ld-chroma-decoder --chroma-gain 0 -f mono -p y4m --input-json "$1.tbc.json" - - \
   ) \
   -i <( \
-    ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | \
-    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json $1.tbc.json - - \
+    ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | \
+    ld-chroma-decoder -f $CHROMA_DECODER --luma-nr 0 --chroma-gain $CHROMA_GAIN -p y4m --input-json "$1.tbc.json" - - \
   ) \
-  -filter_complex $FILTER_COMPLEX \
+  -filter_complex "$FILTER_COMPLEX" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries bt470bg -color_trc gamma28 \
-  -colorspace bt470bg -aspect 4:3 -shortest -y $1.mkv
+  -colorspace bt470bg -aspect 4:3 -shortest -y "$1.mkv"
 fi
 
 # Encode internet-friendly clip of previous lossless result:
-#ffmpeg -hide_banner -i $1.mkv -vf scale=in_color_matrix=bt601:out_color_matrix=bt709:768x576,bwdif=1:0:0 -c:v libx264 -preset veryslow -b:v 6M -maxrate 6M -bufsize 6M -pixel_format yuv420p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -aspect 4:3 -c:a libopus -b:a 192k -strict -2 -movflags +faststart -y $1_lossy.mp4
+#ffmpeg -hide_banner -i "$1.mkv" -vf scale=in_color_matrix=bt601:out_color_matrix=bt709:768x576,bwdif=1:0:0 -c:v libx264 -preset veryslow -b:v 6M -maxrate 6M -bufsize 6M -pixel_format yuv420p -color_primaries bt709 -color_trc bt709 -colorspace bt709 -aspect 4:3 -c:a libopus -b:a 192k -strict -2 -movflags +faststart -y "$1_lossy.mp4"

--- a/vhs_scripts/do_test_ntsc_animation_mkv.sh
+++ b/vhs_scripts/do_test_ntsc_animation_mkv.sh
@@ -2,9 +2,9 @@
 
 ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
   -r 30000/1001 -pixel_format gray16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1.tbc --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json "$1.tbc.json" - -) \
   -f rawvideo -r 30000/1001 -pixel_format yuv444p16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | ld-chroma-decoder -f ntsc1d --ntsc-phase-comp --chroma-gain 2 -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | ld-chroma-decoder -f ntsc1d --ntsc-phase-comp --chroma-gain 2 -p yuv --input-json "$1.tbc.json" - -) \
   -filter_complex "
     [0]
       format=yuv422p10le
@@ -32,4 +32,4 @@ ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
     [output]" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries smpte170m -color_trc smpte170m \
-  -colorspace smpte170m -aspect 4:3 -shortest -y $1.mkv
+  -colorspace smpte170m -aspect 4:3 -shortest -y "$1.mkv"

--- a/vhs_scripts/do_test_ntsc_mkv.sh
+++ b/vhs_scripts/do_test_ntsc_mkv.sh
@@ -2,9 +2,9 @@
 
 ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
   -r 30000/1001 -pixel_format gray16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1.tbc --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json "$1.tbc.json" - -) \
   -f rawvideo -r 30000/1001 -pixel_format yuv444p16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | ld-chroma-decoder -f ntsc2d --ntsc-phase-comp --chroma-gain 2.0 -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | ld-chroma-decoder -f ntsc2d --ntsc-phase-comp --chroma-gain 2.0 -p yuv --input-json "$1.tbc.json" - -) \
   -filter_complex "
     [0]
       format=yuv422p10le
@@ -32,4 +32,4 @@ ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
     [output]" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries smpte170m -color_trc smpte170m \
-  -colorspace smpte170m -aspect 4:3 -shortest -y $1.mkv
+  -colorspace smpte170m -aspect 4:3 -shortest -y "$1.mkv"

--- a/vhs_scripts/do_test_ntsc_mono_mkv.sh
+++ b/vhs_scripts/do_test_ntsc_mono_mkv.sh
@@ -2,9 +2,9 @@
 
 ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
   -r 30000/1001 -pixel_format gray16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1.tbc --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1.tbc" --output-json /dev/null - | ld-chroma-decoder -f mono -p yuv --input-json "$1.tbc.json" - -) \
   -f rawvideo -r 30000/1001 -pixel_format yuv444p16le -s 760x488 \
-  -i <(ld-dropout-correct -i $1_chroma.tbc --input-json $1.tbc.json --output-json /dev/null - | ld-chroma-decoder -f ntsc2d --ntsc-phase-comp --chroma-gain 0 -p yuv --input-json $1.tbc.json - -) \
+  -i <(ld-dropout-correct -i "$1_chroma.tbc" --input-json "$1.tbc.json" --output-json /dev/null - | ld-chroma-decoder -f ntsc2d --ntsc-phase-comp --chroma-gain 0 -p yuv --input-json "$1.tbc.json" - -) \
   -filter_complex "
     [0]
       format=yuv422p10le
@@ -28,4 +28,4 @@ ffmpeg -hide_banner -thread_queue_size 1024 -f rawvideo \
     [output]" \
   -map "[output]":v -c:v ffv1 -coder 1 -context 1 -g 30 -level 3 -slices 16 -slicecrc 1 -top 1 \
   -pixel_format yuv422p10le -color_range tv -color_primaries smpte170m -color_trc smpte170m \
-  -colorspace smpte170m -aspect 4:3 -shortest -y $1.mkv
+  -colorspace smpte170m -aspect 4:3 -shortest -y "$1.mkv"


### PR DESCRIPTION
Also in `gen_chroma_vid.sh`:

- The `-f` option is already used by another option. Switch to `-d`.
- Fix reference to variable `$monochrome`.

```
sed -re 's/(\$1[^ ]+)/"\1"/g' -e 's/(\$(FILTER_COMPLEX|output_format|color_primaries|color_trc|decoder_opts|audio_opts_[0-9]))/"\1"/g' -i *.sh
```