### PR TITLE
Added Ubuntu 22.04 installation dependencies in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Install all dependencies required by LD-Decode and VHS-Decode:
 
     sudo apt install clang libfann-dev python3-setuptools python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv python3-distutils make cython3 cmake
 
+For Ubuntu 22.04 that is:
+
+    sudo apt install clang libfann-dev python3-setuptools python3-numpy python3-scipy python3-matplotlib git qt5-qmake qtbase5-dev libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv python3-distutils pkg-config make cython3 cmake
+
+
 Install dependencies for GPU FLAC compression support:
 
     sudo apt install make ocl-icd-opencl-dev mono-runtime


### PR DESCRIPTION
Added installation dependencies for Ubuntu 22.04 for vhs-decode and tested it. Also ld-analyse was compiled successfully installing these dependencies.