### PR TITLE
Added VHS-HQ format (level shift for one track)

### DIFF
--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -173,8 +173,18 @@ def get_sysparams_pal_svhs(sysparams_pal):
     # 0 IRE level after demodulation
     SysParams_PAL_SVHS["ire0"] = 7e6 - (SysParams_PAL_SVHS["hz_ire"] * 100)
 
+    # One track has an offset of f_h/2
+    # SysParams_PAL_SVHS["track_ire0_offset"] = [7812.5, 0]
+
     return SysParams_PAL_SVHS
 
+def get_sysparams_pal_vhshq(sysparams_pal):
+    SysParams_PAL_VHSHQ = get_sysparams_pal_vhs(sysparams_pal)
+
+    # One track has an offset of f_h/2
+    SysParams_PAL_VHSHQ["track_ire0_offset"] = [7812.5, 0]
+
+    return SysParams_PAL_VHSHQ
 
 def get_rfparams_ntsc_vhs(rfparams_ntsc):
     """Get RF params for NTSC VHS"""
@@ -261,8 +271,18 @@ def get_sysparams_ntsc_svhs(sysparams_ntsc):
     # 0 IRE level after demodulation
     SysParams_NTSC_SVHS["ire0"] = 7e6 - (SysParams_NTSC_SVHS["hz_ire"] * 100)
 
+    # One track has an offset of f_h/2
+    # SysParams_NTSC_SVHS["track_ire0_offset"] = [7867, 0]
+
     return SysParams_NTSC_SVHS
 
+def get_sysparams_ntsc_vhshq(sysparams_ntsc):
+    SysParams_NTSC_VHSHQ = get_sysparams_ntsc_vhs(sysparams_ntsc)
+
+    # One track has an offset of f_h/2
+    SysParams_NTSC_VHSHQ["track_ire0_offset"] = [7867, 0]
+
+    return SysParams_NTSC_VHSHQ
 
 def get_rfparams_mpal_vhs(rfparams_ntsc):
     params = get_rfparams_ntsc_vhs(rfparams_ntsc)

--- a/vhsdecode/formats.py
+++ b/vhsdecode/formats.py
@@ -59,6 +59,15 @@ def get_format_params(system: str, tape_format: str, logger):
             return get_sysparams_pal_betamax(SysParams_PAL), get_rfparams_pal_betamax(
                 RFParams_PAL
             )
+        elif tape_format == "VHSHQ":
+            from vhsdecode.format_defs.vhs import (
+                get_rfparams_pal_vhs,
+                get_sysparams_pal_vhshq,
+            )
+
+            return get_sysparams_pal_vhshq(SysParams_PAL), get_rfparams_pal_vhs(
+                RFParams_PAL
+            )
         elif tape_format == "SVHS":
             from vhsdecode.format_defs.vhs import (
                 get_rfparams_pal_svhs,
@@ -154,7 +163,15 @@ def get_format_params(system: str, tape_format: str, logger):
             return get_sysparams_ntsc_umatic(SysParams_NTSC), get_rfparams_ntsc_umatic(
                 RFParams_NTSC
             )
+        elif tape_format == "VHSHQ":
+            from vhsdecode.format_defs.vhs import (
+                get_rfparams_ntsc_vhs,
+                get_sysparams_ntsc_vhshq,
+            )
 
+            return get_sysparams_ntsc_vhshq(SysParams_NTSC), get_rfparams_ntsc_vhs(
+                RFParams_NTSC
+            )
         elif tape_format == "SVHS":
             from vhsdecode.format_defs.vhs import (
                 get_rfparams_ntsc_svhs,

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -27,6 +27,7 @@ from vhsdecode.cmdcommons import (
 
 supported_tape_formats = {
     "VHS",
+    "VHSHQ",
     "SVHS",
     "UMATIC",
     "UMATIC_HI",
@@ -72,7 +73,7 @@ def main(args=None, use_gui=False):
         metavar="tape_format",
         default="VHS",
         choices=supported_tape_formats,
-        help="Tape format, currently VHS (Default), SVHS, UMATIC, UMATIC_HI, BETAMAX, BETAMAX_HIFI, VIDEO8, HI8 ,EIAJ, VCR, VCR_LP, TYPEC and TYPEB, are supported",
+        help="Tape format, currently VHS (Default), VHSHQ, SVHS, UMATIC, UMATIC_HI, BETAMAX, BETAMAX_HIFI, VIDEO8, HI8 ,EIAJ, VCR, VCR_LP, TYPEC and TYPEB, are supported",
     )
     parser.add_argument(
         "--params_file",

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -587,6 +587,7 @@ class VHSRFDecode(ldd.RFDecode):
         self.DecoderParams["ire0"] = self.SysParams["ire0"]
         self.DecoderParams["hz_ire"] = self.SysParams["hz_ire"]
         self.DecoderParams["vsync_ire"] = self.SysParams["vsync_ire"]
+        self.DecoderParams["track_ire0_offset"] = self.SysParams.get("track_ire0_offset", [0, 0])
 
         write_chroma = is_color_under = vhs_formats.is_color_under(tape_format)
 
@@ -622,7 +623,7 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("disable_right_hsync", False),
             rf_options.get("sync_clip", False),
             rf_options.get("disable_dc_offset", False),
-            tape_format == "VHS",
+            tape_format == "VHS" or tape_format == "VHSHQ",
             # Always use this if we are decoding TYPEC since it doesn't have normal vsync.
             # also enable by default with EIAJ since that was typically used with a primitive sync gen
             # which output not quite standard vsync.


### PR DESCRIPTION
This adds the VHS-HQ format, which is mostly compatible with VHS, but shifts the level every other track by half of the horizontal line frequency. This can cause a small, but visible, brightness difference between odd and even fields. The VHS-HQ format will compensate that shift resulting in more uniform fields (only implemented difference to the standard VHS format).

Even though the the same shift is defined for S-VHS, it is currently not activated for this format, as the not yet implemented sub-deemphasis changes the levels in a non-linear way and it's currently no improvement.