### PR TITLE
SVHS and CVBS improvements

### DIFF
--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -200,6 +200,11 @@ def main(args=None):
         if vhsd.fields_written < 100 or ((vhsd.fields_written % 500) == 0):
             jsondumper.put(vhsd.build_json())
 
+    if vhsd.rf.DecoderParams["lowest_agc_gain"] is not None:
+        print("Lowest detected gain:  ", vhsd.rf.DecoderParams["lowest_agc_gain"], file=sys.stderr)
+        print("Highest detected gain: ", vhsd.rf.DecoderParams["highest_agc_gain"], file=sys.stderr)
+        print("Lowest used gain:      ", vhsd.rf.DecoderParams["lowest_used_agc_gain"], file=sys.stderr)
+        print("Highest used gain:     ", vhsd.rf.DecoderParams["highest_used_agc_gain"], file=sys.stderr)
     print("saving JSON and exiting")
     cleanup(outname)
     sys.exit(0)

--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -37,6 +37,35 @@ def main(args=None):
         help="Enable auto sync level detection.",
     )
     parser.add_argument(
+        "-C",
+        "--clamp_agc",
+        dest="clamp_agc",
+        action="store_true",
+        default=False,
+        help="Clamp signal (black level) and enable automatic gain control.",
+    )
+    parser.add_argument(
+        "--agc_speed",
+        metavar="speed",
+        type=float,
+        default=0.1,
+        help="sets how fast the AGC should react (0 = never, 1 = immediate).",
+    )
+    parser.add_argument(
+        "--agc_gain_factor",
+        metavar="factor",
+        type=float,
+        default=1.0,
+        help="adjusts the AGC white level by given factor.",
+    )
+    parser.add_argument(
+        "--agc_set_gain",
+        metavar="gain",
+        type=float,
+        default=0.0,
+        help="override gain of AGC.",
+    )
+    parser.add_argument(
         "--right_hand_hsync",
         dest="rhs_hsync",
         action="store_true",
@@ -71,6 +100,10 @@ def main(args=None):
 
     rf_options = get_rf_options(args)
     rf_options["auto_sync"] = args.auto_sync
+    rf_options["clamp_agc"] = args.clamp_agc
+    rf_options["agc_speed"] = args.agc_speed
+    rf_options["agc_gain_factor"] = args.agc_gain_factor
+    rf_options["agc_set_gain"] = args.agc_set_gain
     rf_options["rhs_hsync"] = args.rhs_hsync
 
     extra_options = get_extra_options(args)

--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -200,7 +200,7 @@ def main(args=None):
         if vhsd.fields_written < 100 or ((vhsd.fields_written % 500) == 0):
             jsondumper.put(vhsd.build_json())
 
-    if vhsd.rf.DecoderParams["lowest_agc_gain"] is not None:
+    if "lowest_agc_gain" in vhsd.rf.DecoderParams:
         print("Lowest detected gain:  ", vhsd.rf.DecoderParams["lowest_agc_gain"], file=sys.stderr)
         print("Highest detected gain: ", vhsd.rf.DecoderParams["highest_agc_gain"], file=sys.stderr)
         print("Lowest used gain:      ", vhsd.rf.DecoderParams["lowest_used_agc_gain"], file=sys.stderr)

--- a/filter_tune/filter_tune.py
+++ b/filter_tune/filter_tune.py
@@ -172,7 +172,7 @@ def _gen_sub_emphasis_params_from_sliders(format_params, filter_params):
 class FilterPlot:
     sub_emphasis_reference = {
         "SVHS": {
-            "levels": [0, -10, -20, 30],
+            "levels": [0, -10, -20, -30],
             "x": [200000, 500000, 1000000, 2000000, 3000000, 5000000],
             "y": [[1.73,  1.60,  1.04,  0.37,  0.07,  0.06],
                   [1.30,  0.73, -0.69, -1.75, -2.10, -2.02],

--- a/vhsdecode/filter_plot.py
+++ b/vhsdecode/filter_plot.py
@@ -19,6 +19,8 @@ def plot_filters(
     figure,
     sub_emph_plotter=None,
     sub_emphasis_params=None,
+    sub_emphasis_levels=[0, -3, -6, -10, -15, -20],
+    sub_emphasis_reference=None
 ):
     import matplotlib.pyplot as plt
 
@@ -30,12 +32,11 @@ def plot_filters(
     ax[2].plot(freqs, to_db(filters["FVideo"]))
 
     if sub_emph_plotter and sub_emphasis_params:
-        sub_emph_plotter.plot_sub_emphasis(0, ax[1], sub_emphasis_params)
-        sub_emph_plotter.plot_sub_emphasis(-3, ax[1], sub_emphasis_params)
-        sub_emph_plotter.plot_sub_emphasis(-6, ax[1], sub_emphasis_params)
-        sub_emph_plotter.plot_sub_emphasis(-10, ax[1], sub_emphasis_params)
-        sub_emph_plotter.plot_sub_emphasis(-15, ax[1], sub_emphasis_params)
-        sub_emph_plotter.plot_sub_emphasis(-20, ax[1], sub_emphasis_params)
+        colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2',  '#7f7f7f', '#bcbd22', '#17becf']
+        for idx, db in enumerate(sub_emphasis_levels):
+            sub_emph_plotter.plot_sub_emphasis(db, ax[1], sub_emphasis_params, color = colors[idx % 10])
+            if sub_emphasis_reference is not None:
+                ax[1].scatter(sub_emphasis_reference["x"], sub_emphasis_reference["y"][idx], color = colors[idx % 10], marker = "x")
 
 
 class SubEmphPlotter:

--- a/vhsdecode/format_defs/vhs.py
+++ b/vhsdecode/format_defs/vhs.py
@@ -58,8 +58,18 @@ def fill_rfparams_svhs_shared(rfparams):
     # adjusting the corner frequency here makes it look a bit closer
     # than just using the values for VHS, it needs to be properly
     # sorted though.
-    rfparams["deemph_mid"] = 350000
-    #rfparams["deemph_gain"] = 14
+    rfparams["deemph_mid"] = 440000
+    rfparams["deemph_q"] = 0.5
+
+    rfparams["nonlinear_highpass_freq"] = 320000
+    rfparams["nonlinear_exp_scaling"] = 0.26
+    rfparams["nonlinear_scaling_1"] = 1.2
+    rfparams["use_sub_deemphasis"] = True
+
+    rfparams["use_linear_sub_deemphasis"] = True
+    rfparams["subdeemph_linear_mid"] = 1000000
+    rfparams["subdeemph_linear_gain_factor"] = 1.25
+    rfparams["subdeemph_linear_slope"] = 0.5
 
 
 def get_rfparams_pal_vhs(rfparams_pal):
@@ -155,7 +165,7 @@ def get_rfparams_pal_svhs(sysparams_pal):
 
     fill_rfparams_svhs_shared(RFParams_PAL_SVHS)
 
-    RFParams_PAL_SVHS["nonlinear_highpass_freq"] = 500000
+    #RFParams_PAL_SVHS["nonlinear_highpass_freq"] = 500000
     RFParams_PAL_SVHS["nonlinear_highpass_limit_h"] = 5000
     RFParams_PAL_SVHS["nonlinear_highpass_limit_l"] = -250000
 

--- a/vhsdecode/nonlinear_filter.py
+++ b/vhsdecode/nonlinear_filter.py
@@ -57,6 +57,11 @@ def sub_deemphasis_inner(
     Returns:
         _type_: video signal with filtering applied
     """
+    # this filter is applied with all other linear filters. To make plot of filter-tune work it needs to be applied here
+    #if filters["subdeemph_linear"] is not None :
+    #    out_video_fft = out_video_fft * filters["subdeemph_linear"]
+    #    out_video = npfft.irfft(out_video_fft).real
+
     hf_part = npfft.irfft(out_video_fft * filters["NLHighPassF"])
     # hf_part = sps.filtfilt(filters["NLHighPassFB"][0], filters["NLHighPassFB"][1], out_video)
 


### PR DESCRIPTION
Implemented a CVBS automatic gain adjustment / clamping:
- It will take the sync and the black level after time-base-correction as reference
- It will calculate the median of all blank and sync levels of all lines (except top/bottom) to calculate the gain for the entire field
- The gain is averaged over time
- It will clamp based an on the median of the blank level of the line and 2 last and 2 next lines (to compensate for dropouts)
- The sync/blank levels of the last field are used for sync detection of the next field
- Added options: Enable this functionality, set gain multiplier, set fixed gain, set gain average speed

Improved S-VHS sub de-emphasis
- Added second linear de-emphasis
- Adjusted linear & non-linear sub de-emphasis values to match the spec
- Eyeballed de-emphasis values to reduce phase errors as much as possible

Filter-plot:
- Removed old SVHS-specific experiment
- Added reference values to plot (only S-VHS at the moment, but designed for other formats to be added, currently incorrect as only non-linear de-emphasis is plotted)
- Added QSplitter to make image and plot division adjustable with mouse