### PR TITLE
Add more sounddevice checks to hifi-decode

### DIFF
--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -30,6 +30,7 @@ class MainUIParameters:
         self.automatic_fine_tuning: bool = True
         self.grc = False
         self.preview: bool = False
+        self.preview_available: bool = True
         self.audio_sample_rate: int = 44100
         self.standard: str = "PAL"
         self.format: str = "VHS"
@@ -45,6 +46,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.sidechain_gain = decode_options["nr_side_gain"] / 100.0
     values.noise_reduction = decode_options["noise_reduction"]
     values.automatic_fine_tuning = decode_options["auto_fine_tune"]
+    values.preview_available = decode_options["preview_available"]
     values.audio_sample_rate = decode_options["audio_rate"]
     values.standard = "PAL" if decode_options["standard"] == "p" else "NTSC"
     values.format = "VHS" if decode_options["format"] == "vhs" else "Video8/Hi8"
@@ -216,6 +218,7 @@ class HifiUi(QMainWindow):
         self.noise_reduction_checkbox = QCheckBox("Noise reduction")
         self.automatic_fine_tuning_checkbox = QCheckBox("Automatic fine tuning")
         self.preview_checkbox = QCheckBox("Preview")
+        self.preview_checkbox.setCheckable(params.preview_available)
         middle_layout.addWidget(self.noise_reduction_checkbox)
         middle_layout.addWidget(self.automatic_fine_tuning_checkbox)
         middle_layout.addWidget(self.preview_checkbox)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -639,18 +639,23 @@ def decode_parallel(
                     try:
                         w.write(stereo)
                         if decode_options["preview"]:
-                            if (
-                                len(stereo_play_buffer)
-                                > decode_options["audio_rate"] * 5
-                            ):
-                                sd.wait()
-                                sd.play(
-                                    stereo_play_buffer,
-                                    decode_options["audio_rate"],
-                                    blocking=False,
+                            if SOUNDDEVICE_AVAILABLE:
+                                if (
+                                    len(stereo_play_buffer)
+                                    > decode_options["audio_rate"] * 5
+                                ):
+                                    sd.wait()
+                                    sd.play(
+                                        stereo_play_buffer,
+                                        decode_options["audio_rate"],
+                                        blocking=False,
+                                    )
+                                    stereo_play_buffer = list()
+                                stereo_play_buffer += stereo
+                            else:
+                                print(
+                                    "Import of sounddevice failed, preview is not available!"
                                 )
-                                stereo_play_buffer = list()
-                            stereo_play_buffer += stereo
                     except ValueError:
                         pass
 

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -772,6 +772,7 @@ def main() -> int:
         "standard": "p" if system == "PAL" else "n",
         "format": "vhs" if not args.H8 else "h8",
         "preview": args.preview,
+        "preview_available": SOUNDDEVICE_AVAILABLE,
         "original": args.original,
         "noise_reduction": args.noise_reduction == "on" if not args.preview else False,
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,


### PR DESCRIPTION
Unsure if adding `preview_available` to `decode_options` is the best option?