### PR TITLE
Work around issues with stat() call for Samba shares on some systems

### DIFF
--- a/vhsdecode/cmdcommons.py
+++ b/vhsdecode/cmdcommons.py
@@ -63,7 +63,7 @@ def test_output_file(output_file: Optional[str]) -> bool:
             print(
                 f"WARN: output file directory {output_file_dir} has {sizeof_fmt(free_space)} free space"
             )
-    except AttributeError:
+    except (AttributeError, BlockingIOError):
         pass
 
     try:


### PR DESCRIPTION
Reproduces with WSL2 (kernel 5.15.146.1-microsoft-standard-WSL2).

Same issue (with investigation): https://github.com/home-assistant/operating-system/issues/3041