### PR TITLE
Option to auto-adjust the level of 0 IRE based on the back porch

### DIFF
--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -109,6 +109,13 @@ def main(args=None, use_gui=False):
         help="Multiply top/bottom IRE in json by 1 +/- this value (used to avoid clipping on RGB conversion in chroma decoder).",
     )
     luma_group.add_argument(
+        "--ire0_adjust",
+        dest="ire0_adjust",
+        action="store_true",
+        default=False,
+        help="Automatic adjust of ire0 based blanking level",
+    )
+    luma_group.add_argument(
         "--high_boost",
         metavar="High frequency boost multiplier",
         type=float,
@@ -391,6 +398,7 @@ def main(args=None, use_gui=False):
     rf_options["skip_hsync_refine"] = args.skip_hsync_refine
     rf_options["export_raw_tbc"] = args.export_raw_tbc
     rf_options["tape_speed"] = args.tape_speed
+    rf_options["ire0_adjust"] = args.ire0_adjust
 
     extra_options = get_extra_options(args, not use_gui)
     extra_options["params_file"] = args.params_file

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -569,6 +569,7 @@ class VHSRFDecode(ldd.RFDecode):
         )
 
         export_raw_tbc = rf_options.get("export_raw_tbc", False)
+        ire0_adjust = rf_options.get("ire0_adjust", False)
         is_color_under = vhs_formats.is_color_under(tape_format)
         write_chroma = (
             is_color_under
@@ -602,6 +603,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "export_raw_tbc",
                 "fm_audio_notch",
                 "chroma_offset",
+                "ire0_adjust",
             ],
         )(
             self.iretohz(100) * 2,
@@ -631,6 +633,7 @@ class VHSRFDecode(ldd.RFDecode):
             export_raw_tbc,
             rf_options.get("fm_audio_notch", 0),
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
+            ire0_adjust,
         )
 
         # As agc can alter these sysParams values, store a copy to then


### PR DESCRIPTION
This introduces the new option `--ire0_adjust`, which will calculate the value of 0 IRE like this:
- It's all done in the `hz_to_output` function
- The position of the back porch is set as an fixed attribute in the `FieldNTSCShared` and `FieldPALShared` classes
- Calculate the median value of the back porch in each line (median is a better choice than mean, if there is for example a spike in the signal it will have no influence)
- Sort the all median values and calculate the mean of the middle third. This will remove all values with very high/low back porch median (noise, tbc didn't work, sync lines) and only uses the "best third" for calculating the average
- This value is used instead of the default ire0 value when subtracting ire0. This is only done when the input is a complete field, not for a single value
- It deliberately does not do any calculation over multiple fields (floating average etc.), as formats like VHS-HQ or S-VHS have an offset every other field. This code is able to fully compensate that.

Proposal: As the VHS-HQ track_ire0_offset does not work reliable, as the track phase derived from chroma is not related to the track_ire0_offset phase and there doesn't seem to be away to figure the phase out, this code could be removed and selecting the VHS-HQ format could just result in turning on `--ire0_adjust`