### PR TITLE
Fix line number rounding

### DIFF
--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -66,9 +66,16 @@ class FieldCVBSShared:
             )
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
+        
+        validpulses_arr = np.asarray(
+            [
+                p[1].start
+                for p in validpulses
+            ], dtype=np.int32
+        )
 
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
-            validpulses,
+            validpulses_arr,
             line0loc,
             0,
             meanlinelen,

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -70,84 +70,21 @@ class FieldCVBSShared:
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
-            self.skipdetected,
+            0,
             meanlinelen,
-            self.linecount,
             self.rf.hsync_tolerance,
-            lastlineloc,
             proclines,
             1.9
         )
 
-        rv_err = np.full(proclines, False)
-
-        linelocs_filled = linelocs.copy()
-
         self.linelocs0 = linelocs.copy()
 
-        if linelocs_filled[0] < 0:
-            next_valid = None
-            for i in range(0, self.outlinecount + 1):
-                if linelocs[i] > 0:
-                    next_valid = i
-                    break
-
-            if next_valid is None:
-                return None, None, line0loc + (self.inlinelen * self.outlinecount - 7)
-
-            linelocs_filled[0] = linelocs_filled[next_valid] - (
-                next_valid * meanlinelen
-            )
-
-            if linelocs_filled[0] < self.inlinelen:
-                return None, None, line0loc + (self.inlinelen * self.outlinecount - 7)
-
-        for l in range(1, proclines):
-            if linelocs_filled[l] < 0:
-                rv_err[l] = True
-
-                prev_valid = None
-                next_valid = None
-
-                for i in range(l, -1, -1):
-                    if linelocs[i] > 0:
-                        prev_valid = i
-                        break
-                for i in range(l, self.outlinecount + 1):
-                    if linelocs[i] > 0:
-                        next_valid = i
-                        break
-
-                # print(l, prev_valid, next_valid)
-
-                if prev_valid is None:
-                    avglen = self.inlinelen
-                    linelocs_filled[l] = linelocs[next_valid] - (
-                        avglen * (next_valid - l)
-                    )
-                elif next_valid is not None:
-                    avglen = (linelocs[next_valid] - linelocs[prev_valid]) / (
-                        next_valid - prev_valid
-                    )
-                    linelocs_filled[l] = linelocs[prev_valid] + (
-                        avglen * (l - prev_valid)
-                    )
-                else:
-                    avglen = self.inlinelen
-                    linelocs_filled[l] = linelocs[prev_valid] + (
-                        avglen * (l - prev_valid)
-                    )
-
-        # *finally* done :)
-
-        rv_ll = [linelocs_filled[l] for l in range(0, proclines)]
-
         if self.vblank_next is None:
-            nextfield = linelocs_filled[self.outlinecount - 7]
+            nextfield = linelocs[self.outlinecount - 7]
         else:
             nextfield = self.vblank_next - (self.inlinelen * 8)
 
-        return rv_ll, rv_err, nextfield
+        return linelocs, lineloc_errs, nextfield
 
 
 def chroma_to_u16(chroma):

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -67,12 +67,12 @@ class FieldCVBSShared:
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
         
-        validpulses_arr = np.asarray(
+        validpulses_arr = np.sort(np.asarray(
             [
                 p[1].start
                 for p in validpulses
             ], dtype=np.int32
-        )
+        ))
 
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
             validpulses_arr,

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -67,7 +67,7 @@ class FieldCVBSShared:
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
 
-        linelocs, lineloc_errs, _ = sync.valid_pulses_to_linelocs(
+        linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
             self.skipdetected,

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -76,7 +76,7 @@ class FieldCVBSShared:
             self.rf.hsync_tolerance,
             lastlineloc,
             proclines,
-            1.8
+            1.9
         )
 
         rv_err = np.full(proclines, False)

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -76,6 +76,7 @@ class FieldCVBSShared:
             self.rf.hsync_tolerance,
             lastlineloc,
             proclines,
+            1.8
         )
 
         rv_err = np.full(proclines, False)

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -67,7 +67,7 @@ class FieldCVBSShared:
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
 
-        linelocs, _ = sync.valid_pulses_to_linelocs(
+        linelocs, lineloc_errs, _ = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
             self.skipdetected,

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -67,7 +67,7 @@ class FieldCVBSShared:
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
 
-        linelocs_dict, _ = sync.valid_pulses_to_linelocs(
+        linelocs, _ = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
             self.skipdetected,
@@ -75,17 +75,11 @@ class FieldCVBSShared:
             self.linecount,
             self.rf.hsync_tolerance,
             lastlineloc,
+            proclines,
         )
 
         rv_err = np.full(proclines, False)
 
-        # Convert dictionary into array, then fill in gaps
-        linelocs = np.asarray(
-            [
-                linelocs_dict[l] if l in linelocs_dict else -1
-                for l in range(0, proclines)
-            ]
-        )
         linelocs_filled = linelocs.copy()
 
         self.linelocs0 = linelocs.copy()

--- a/vhsdecode/debug_plot.py
+++ b/vhsdecode/debug_plot.py
@@ -21,6 +21,7 @@ def plot_data_and_pulses(
     linelocs=None,
     pulses=None,
     extra_lines=None,
+    vblank_lines=None,
     threshold=None,
 ):
     import matplotlib.pyplot as plt
@@ -39,6 +40,8 @@ def plot_data_and_pulses(
         if pulses is not None:
             plots += 1
         if extra_lines is not None:
+            plots += 1
+        if vblank_lines is not None:
             plots += 1
 
         plots = max(2, plots)
@@ -70,6 +73,12 @@ def plot_data_and_pulses(
             ax_number += 1
             ax[ax_number].set_title("Calculated line locations")
             for ll in linelocs:
+                ax[ax_number].axvline(ll)
+
+        if vblank_lines is not None:
+            ax_number += 1
+            ax[ax_number].set_title("V-blanking Pulses")
+            for ll in vblank_lines:
                 ax[ax_number].axvline(ll)
 
         if extra_lines is not None:

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -549,32 +549,31 @@ class FieldShared:
         else:
             prev_first_field = -1
 
-        if hasattr(self.prevfield, "readloc") and hasattr(self.prevfield, "first_hsync_loc"):
-            self.last_field_offset = self.prevfield.readloc - self.readloc
-            self.prev_first_hsync_loc = self.prevfield.first_hsync_loc
-            self.prev_hsync_diff = self.prevfield.prev_hsync_diff
+        if not hasattr(self.rf, "prev_first_hsync_loc"):
+            self.rf.prev_first_hsync_readloc = -1
+            self.rf.prev_first_hsync_loc =  -1
+            self.rf.prev_first_hsync_first_field = prev_first_field
+            self.rf.prev_first_hsync_diff =  -1
 
-        elif hasattr(self.prevfield, "prev_first_hsync_loc"):
-            self.last_field_offset = self.prevfield.last_field_offset
-            self.prev_first_hsync_loc = self.prevfield.prev_first_hsync_loc
-            self.prev_hsync_diff = self.prevfield.prev_hsync_diff
-            
-        else:
-            self.last_field_offset = -1
-            self.prev_first_hsync_loc = -1
-            self.prev_hsync_diff = -1
+        prev_first_hsync_offset = self.rf.prev_first_hsync_readloc - self.readloc
 
-        line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField, self.prev_hsync_diff = sync.get_first_hsync_loc(
+        line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField, prev_hsync_diff = sync.get_first_hsync_loc(
             validpulses, 
             meanlinelen, 
             1 if self.rf.system == "NTSC" else 0,
             self.rf.SysParams["field_lines"],
             self.rf.SysParams["numPulses"],
             prev_first_field,
-            self.last_field_offset,
-            self.prev_first_hsync_loc,
-            self.prev_hsync_diff
+            prev_first_hsync_offset,
+            self.rf.prev_first_hsync_loc,
+            self.rf.prev_first_hsync_diff
         )
+
+        if self.first_hsync_loc != None:
+            self.rf.prev_first_hsync_readloc = self.readloc
+            self.rf.prev_first_hsync_loc = self.first_hsync_loc
+            self.rf.prev_first_hsync_first_field = self.isFirstField
+            self.rf.prev_first_hsync_diff = prev_hsync_diff
 
         if self.vblank_next == -1:
             self.vblank_next = None

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -557,19 +557,25 @@ class FieldShared:
         else:
             prev_first_hsync_offset_lines = 0
 
+        fallback_line0loc = None
+        if self.rf.options.fallback_vsync:
+            fallback_line0loc, _, _ = self._get_line0_fallback(validpulses)
+        if fallback_line0loc == None:
+            fallback_line0loc = -1
+
         # find the location of the first hsync pulse (first line of video after the vsync pulses)
         # this function relies on the pulse type (hsync, vsync, eq pulse) being accurate in validpulses
         line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField, prev_hsync_diff, vblank_pulses = sync.get_first_hsync_loc(
             validpulses, 
             meanlinelen, 
             1 if self.rf.system == "NTSC" else 0,
-            self.rf.options.fallback_vsync,
             self.rf.SysParams["field_lines"],
             self.rf.SysParams["numPulses"],
             self.rf.prev_first_field,
             prev_first_hsync_offset_lines,
             self.rf.prev_first_hsync_loc,
-            self.rf.prev_first_hsync_diff
+            self.rf.prev_first_hsync_diff,
+            fallback_line0loc
         )
 
         # save the current hsync pulse location to the previous hsync pulse

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -662,7 +662,7 @@ class FieldShared:
             self.rf.hsync_tolerance,
             lastlineloc_or_0,
             proclines,
-            1.5
+            1.9
         )
 
         self.linelocs0 = linelocs.copy()

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -550,21 +550,30 @@ class FieldShared:
             prev_first_field = -1
 
         if hasattr(self.prevfield, "readloc") and hasattr(self.prevfield, "first_hsync_loc"):
-            last_field_offset = self.prevfield.readloc - self.readloc
-            prev_first_hsync_loc = self.prevfield.first_hsync_loc
-        else:
-            last_field_offset = -1
-            prev_first_hsync_loc = -1
+            self.last_field_offset = self.prevfield.readloc - self.readloc
+            self.prev_first_hsync_loc = self.prevfield.first_hsync_loc
+            self.prev_hsync_diff = self.prevfield.prev_hsync_diff
 
-        line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField = sync.get_first_hsync_loc(
+        elif hasattr(self.prevfield, "prev_first_hsync_loc"):
+            self.last_field_offset = self.prevfield.last_field_offset
+            self.prev_first_hsync_loc = self.prevfield.prev_first_hsync_loc
+            self.prev_hsync_diff = self.prevfield.prev_hsync_diff
+            
+        else:
+            self.last_field_offset = -1
+            self.prev_first_hsync_loc = -1
+            self.prev_hsync_diff = -1
+
+        line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField, self.prev_hsync_diff = sync.get_first_hsync_loc(
             validpulses, 
             meanlinelen, 
             1 if self.rf.system == "NTSC" else 0,
             self.rf.SysParams["field_lines"],
             self.rf.SysParams["numPulses"],
-            last_field_offset,
             prev_first_field,
-            prev_first_hsync_loc
+            self.last_field_offset,
+            self.prev_first_hsync_loc,
+            self.prev_hsync_diff
         )
 
         if self.vblank_next == -1:

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -635,7 +635,6 @@ class FieldShared:
 
         # TODO: This is set here for NTSC, but in the PAL base class for PAL in process() it seems..
         # For 405-line it's done in fieldTypeC.process as of now to override that.
-        # TODO: This will cause problem with the skipdetected part in valid_pulses_to_linelocs
         self.linecount = 263 if self.isFirstField else 262
 
         # Number of lines to actually process.  This is set so that the entire following
@@ -676,9 +675,16 @@ class FieldShared:
                 )
                 ldd.logger.info("lastline < proclines , skipping a tiny bit")
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
+        
+        validpulses_arr = np.asarray(
+            [
+                p[1].start
+                for p in validpulses
+            ], dtype=np.int32
+        )
 
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
-            validpulses,
+            validpulses_arr,
             first_hsync_loc,
             first_hsync_loc_line,
             meanlinelen,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -563,6 +563,7 @@ class FieldShared:
             validpulses, 
             meanlinelen, 
             1 if self.rf.system == "NTSC" else 0,
+            self.rf.options.fallback_vsync,
             self.rf.SysParams["field_lines"],
             self.rf.SysParams["numPulses"],
             self.rf.prev_first_field,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -662,6 +662,8 @@ class FieldShared:
             self.rf.hsync_tolerance,
             lastlineloc_or_0,
             proclines,
+            self.getBlankLength(self.isFirstField),
+            self.getBlankLength(not self.isFirstField),
             1.9
         )
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -555,11 +555,11 @@ class FieldShared:
             else:
                 self.rf.prev_first_field = -1
 
-        # only calculate when we have a previous hsync pulse to use
+        # calculate in terms of lines to prevent integer overflow when seeking ahead large amounts
         if self.rf.prev_first_hsync_readloc != -1:
-            prev_first_hsync_offset = self.rf.prev_first_hsync_readloc - self.readloc
+            prev_first_hsync_offset_lines = (self.rf.prev_first_hsync_readloc - self.readloc) / meanlinelen
         else:
-            prev_first_hsync_offset = 0
+            prev_first_hsync_offset_lines = 0
 
         # find the location of the first hsync pulse (first line of video after the vsync pulses)
         line0loc, self.first_hsync_loc, self.first_hsync_loc_line, self.vblank_next, self.isFirstField, prev_hsync_diff = sync.get_first_hsync_loc(
@@ -569,7 +569,7 @@ class FieldShared:
             self.rf.SysParams["field_lines"],
             self.rf.SysParams["numPulses"],
             self.rf.prev_first_field,
-            prev_first_hsync_offset,
+            prev_first_hsync_offset_lines,
             self.rf.prev_first_hsync_loc,
             self.rf.prev_first_hsync_diff
         )

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -653,7 +653,7 @@ class FieldShared:
                 ldd.logger.info("lastline < proclines , skipping a tiny bit")
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
 
-        linelocs, lineloc_errs, _ = sync.valid_pulses_to_linelocs(
+        linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
             self.skipdetected,
@@ -664,6 +664,10 @@ class FieldShared:
             proclines,
             1.9
         )
+
+        # not a full field, skip over to the last detected pulse
+        if linelocs[proclines-1] == -1:
+            return None, None, last_validpulse
 
         self.linelocs0 = linelocs.copy()
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -534,7 +534,7 @@ class FieldShared:
         self.rawpulses = self.rf.resync.get_pulses(self, check_levels)
         # self.rawpulses = self.getpulses()
         if self.rawpulses is None or len(self.rawpulses) == 0:
-            return NO_PULSES_FOUND, None
+            return NO_PULSES_FOUND
 
         self.validpulses = validpulses = self.refinepulses()
         meanlinelen = self.computeLineLen(validpulses)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -692,12 +692,24 @@ class FieldShared:
         # ldd.logger.info("line0loc %s %s", int(line0loc), int(self.meanlinelen))
 
         if self.rf.debug_plot and self.rf.debug_plot.is_plot_requested("line_locs"):
+            line0loc_plot = -1 if line0loc == None else line0loc
+            first_hsync_loc_plot = -1 if first_hsync_loc == None else first_hsync_loc
+            vblank_next_plot = -1 if self.vblank_next == None else self.vblank_next
+            last_validpulse_plot = -1 if last_validpulse == None else last_validpulse
+
+            print(
+                "line0loc", line0loc_plot,
+                "first_hsync_loc", first_hsync_loc_plot,
+                "vblank_next", vblank_next_plot,
+                "last_validpulse", last_validpulse_plot,
+            )
+
             plot_data_and_pulses(
                 self.data["video"]["demod"],
                 raw_pulses=self.rawpulses,
                 linelocs=linelocs,
                 pulses=validpulses,
-                extra_lines=[line0loc, first_hsync_loc, self.vblank_next, last_validpulse]
+                extra_lines=[line0loc_plot, first_hsync_loc_plot, vblank_next_plot, last_validpulse_plot]
             )
 
         if self.vblank_next is None:

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -662,6 +662,7 @@ class FieldShared:
             self.rf.hsync_tolerance,
             lastlineloc_or_0,
             proclines,
+            1.5
         )
 
         rv_err = np.full(proclines, False)

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -532,8 +532,12 @@ class FieldShared:
 
     def _try_get_pulses(self, check_levels):
         self.rawpulses = self.rf.resync.get_pulses(self, check_levels)
-        # self.rawpulses = self.getpulses()
-        if self.rawpulses is None or len(self.rawpulses) == 0:
+
+        if (
+            self.rawpulses is None or 
+            # when no pulses are found and there has not been a previous sync location and fallback vsync is not enabled
+            (len(self.rawpulses) == 0 and (not hasattr(self.rf, "prev_first_hsync_loc") or self.rf.options.fallback_vsync))
+        ):
             return NO_PULSES_FOUND
 
         self.validpulses = validpulses = self.refinepulses()

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -264,7 +264,7 @@ def get_line0_fallback(
 
 
 def _run_vblank_state_machine(raw_pulses, line_timings, num_pulses, in_line_len):
-    """Look though raw_pulses for a set valid vertical sync pulse seires.
+    """Look though raw_pulses for a set valid vertical sync pulse series.
     num_pulses_half: number of equalization pulses per section / 2
     """
     done = False
@@ -653,7 +653,7 @@ class FieldShared:
                 ldd.logger.info("lastline < proclines , skipping a tiny bit")
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
 
-        linelocs_dict, _ = sync.valid_pulses_to_linelocs(
+        linelocs, _ = sync.valid_pulses_to_linelocs(
             validpulses,
             line0loc,
             self.skipdetected,
@@ -661,17 +661,13 @@ class FieldShared:
             self.linecount,
             self.rf.hsync_tolerance,
             lastlineloc_or_0,
+            proclines,
         )
 
         rv_err = np.full(proclines, False)
 
         # Convert dictionary into array, then fill in gaps
-        linelocs = np.asarray(
-            [
-                linelocs_dict[l] if l in linelocs_dict else -1
-                for l in range(0, proclines)
-            ]
-        )
+        linelocs
         linelocs_filled = linelocs.copy()
 
         self.linelocs0 = linelocs.copy()

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -656,7 +656,8 @@ class FieldShared:
             return None, None, self.inlinelen * 100
 
         # If we don't have enough data at the end, move onto the next field
-        lastline = (self.rawpulses[-1].start - line0loc) / meanlinelen
+        lastline = (len(self.data["input"]) - line0loc) / meanlinelen - 1
+
         if self.rf.debug_plot and self.rf.debug_plot.is_plot_requested("raw_pulses"):
             plot_data_and_pulses(
                 self.data["video"]["demod"],

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -614,7 +614,13 @@ class VHSRFDecode(ldd.RFDecode):
             or rf_options.get("subdeemp", False),
             rf_options.get("disable_right_hsync", False),
             rf_options.get("disable_dc_offset", False),
-            rf_options.get("fallback_vsync", False),
+            # Always use this if we are decoding TYPEC since it doesn't have normal vsync.
+            # also enable by default with EIAJ since that was typically used with a primitive sync gen
+            # which output not quite standard vsync.
+            rf_options.get("fallback_vsync", False)
+            or tape_format == "TYPEC"
+            or tape_format == "EIAJ"
+            or system == "405",
             rf_options.get("saved_levels", False),
             rf_options.get("y_comb", 0) * self.SysParams["hz_ire"],
             write_chroma,

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -614,13 +614,7 @@ class VHSRFDecode(ldd.RFDecode):
             or rf_options.get("subdeemp", False),
             rf_options.get("disable_right_hsync", False),
             rf_options.get("disable_dc_offset", False),
-            # Always use this if we are decoding TYPEC since it doesn't have normal vsync.
-            # also enable by default with EIAJ since that was typically used with a primitive sync gen
-            # which output not quite standard vsync.
-            rf_options.get("fallback_vsync", False)
-            or tape_format == "TYPEC"
-            or tape_format == "EIAJ"
-            or system == "405",
+            rf_options.get("fallback_vsync", False),
             rf_options.get("saved_levels", False),
             rf_options.get("y_comb", 0) * self.SysParams["hz_ire"],
             write_chroma,

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -303,14 +303,12 @@ def get_first_hsync_loc(
         LAST_VBLANK_EQ_2_END
     ]
 
-    # check all possible known distances bewteen vblanking pulses and average the differences to derive the hsync_start_line
-    for first_index in pulse_indexes:
-        # only check unchecked pulses
-        for second_index in range(first_index, len(pulse_indexes)):
-            # dont check the same pulse
-            if first_index == second_index:
-                continue
+    print()
 
+    # check all possible known distances bewteen vblanking pulses and average the differences to derive the hsync_start_line
+    for first_index in range(0, len(pulse_indexes)):
+        # only care about distances one way, so no need to check the other direction
+        for second_index in range(first_index+1, len(pulse_indexes)):
             first_pulse = vblank_pulses[first_index]
             second_pulse = vblank_pulses[second_index]
             first_line = vblank_lines[first_index]

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -41,6 +41,9 @@ cdef c_median(np.ndarray data):
 cdef bint is_out_of_range(double[:] data, double min, double max) nogil:
     """Check if data stays between min and max, returns fals if not."""
     cdef Py_ssize_t i
+    if len(data) == 0:
+        return True
+
     for i in range(0, len(data)):
         if data[i] < min or data[i] > max:
             return True
@@ -453,15 +456,14 @@ def get_first_hsync_loc(
         prev_hsync_diff = (first_hsync_loc - estimated_hsync_loc) / meanlinelen
     else:
         # no sync pulses found
-        # print("no sync pulses found")
+        print("no sync pulses found")
         return None, None, hsync_start_line, None, first_field, prev_hsync_diff
 
     next_field = first_hsync_loc + meanlinelen * (vblank_lines[LAST_VBLANK_EQ_1_START] - hsync_start_line)
 
     # print(
     #     "next field",
-    #     vblank_pulses[LAST_VBLANK_EQ_1_START], 
-    #     validpulses[-1][1].start,
+    #     first_hsync_loc,
     #     next_field
     # )
 

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -148,7 +148,9 @@ def get_first_hsync_loc(
 ):
     """
     Returns: 
+       * line0loc: Location of line 0 (last hsync pulse of the previous field)
        * first_hsync_loc: Location of the first hsync pulse (first line after the vblanking)
+       * hsync_start_line: Line where the first hsync pulse is found
        * next_field: Location of the next field (last line + 1 after this field)
        * first_field: True if this is the first field
     """    

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -368,8 +368,8 @@ def valid_pulses_to_linelocs(
             rlineloc < 0 or rlineloc >= proclines
 
             # only record if it's closer to the (probable) beginning of the line
-            # or lineloc_distance > hsync_tolerance or
-            # (line_locations[rlineloc] != -1 and lineloc_distance > line_distances[rlineloc])
+            or lineloc_distance > hsync_tolerance or
+            (line_locations[rlineloc] != -1 and lineloc_distance > line_distances[rlineloc])
         ):
             continue
 
@@ -419,7 +419,7 @@ def valid_pulses_to_linelocs(
             # line_hsync_gap_detected
             or (
                 previous_line > -1 and
-                line_locations[i] - previous_line > meanlinelen * 1.3
+                line_locations[i] - previous_line > meanlinelen * 1.2
             )
         ):
             distance = -1
@@ -440,7 +440,7 @@ def valid_pulses_to_linelocs(
             estimated_location = line_locations[nearest_line] + meanlinelen * (i - nearest_line)
 
             # check if a pulse exists that is closer than the estimate within the gap detection threshold
-            distance = meanlinelen / 3
+            distance = meanlinelen / 2
             nearest_pulse = -1
 
             for p in validpulses:


### PR DESCRIPTION
* More resilient vsync logic and frame order detection that is able to better deal with greater variances found on tape.
  * Replaced the `self.getLine0` which was part of ld-decode, with `sync.get_first_hsync_loc`
  * This new function returns the first hsync, first hsync pulse after the vsync in the field
  * It handles vsync detection, which is based on the known distances between and locations of the vsync pulses
  * It also handles the frame order detection, which is based on the previous frame order and the known pulse widths that should exist for a given frame order.

* Minor refactoring of dictionaries into arrays for more performance
* Removed old code that did the line gap and error detection, since this is now handled in `sync.valid_pulses_to_linelocs`

Todo:
- [x] Test with the original erroring tapes.
   * These changes really improved the original samples. See:https://discord.com/channels/665557267189334046/665834485975351307/1301365960816459827
- [x] Verify that all format specific values are handled properly. Currently, it's hard-coded based on NTSC
- [x] Try to use the previous field line locations when processing a current field, may improve things further
- [x] Make sure cvbs-decode is compatible with the new changes
- [x] Align start line against hsync pulses to preventing skipping (may also help with Type C / Type B formats that don't have proper vsync pulses.
- [x] Test Type C / Type B / Other open reel formats, if not working, ensure `--fallback_vsync` still works with these
   - This works when the `validpulses` have the vsync areas properly identified, but this isn't always the case. If the vsync transitions can be identified, then the rest of the code should work.