### PR TITLE
[workaround] Alias "PAL-M" to "MPAL" in get_format_parameters

### DIFF
--- a/vhsdecode/formats.py
+++ b/vhsdecode/formats.py
@@ -92,6 +92,11 @@ def get_format_params(system: str, tape_format: str, tape_speed: int, logger) ->
 
     assert tape_speed <= 4, "Tape speed was > 4!"
 
+    # TBC/JSON uses "PAL-M" instead of "MPAL".
+    # For later: define color systems codename (i.e. refer to it as "PAL-M" only)
+    if system == "PAL-M":
+        system = "MPAL"
+    
     if system == "PAL":
         if tape_format == "UMATIC":
             from vhsdecode.format_defs.umatic import (


### PR DESCRIPTION
PAL-M TBCs were not opening in filter_tune tool because .tbc.json file stores "PAL-M", but whatever reason the vhs-decode code calls PAL-M as "MPAL". This aliases "PAL-M" to "MPAL" and makes filter_tune work again.

For later: decide if PAL-M will be named only either "PAL-M", "MPAL" or "PALM". 

I suggest calling It "PAL-M" because even though the entire code calls It "MPAL", It's a simple string with no more than 5 characters (in SECAM's case, no more than 8), and nobody calls PAL-M like that. Also, If so, you would need to change the TBC/JSON specifications, and that would break everything.