### PR TITLE
Cython Performance Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,15 +28,8 @@ option(USE_QWT
 if(MSVC)
     add_compile_options(/permissive-)
 else()
-    add_compile_options(-O3 -flto)
-    add_link_options(-O3 -flto)
-endif()
-
-# Only use native architecture for local builds
-if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(-march=native)
-    add_link_options(-march=native)
-    message(WARNING "Adding -march=native to compile flags. This build will be architecture specific to this machine. Use a Release build if you intend on publishing this binary.")
+    add_compile_options(-O3)
+    add_link_options(-O3)
 endif()
 
 set(USE_QT_VERSION "" CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,15 @@ option(USE_QWT
 if(MSVC)
     add_compile_options(/permissive-)
 else()
-    add_compile_options(-O3 -march=native)
-    add_link_options(-flto)
+    add_compile_options(-O3 -flto)
+    add_link_options(-O3 -flto)
+endif()
+
+# Only use native architecture for local builds
+if(NOT CMAKE_BUILD_TYPE MATCHES "Release")
+    add_compile_options(-march=native)
+    add_link_options(-march=native)
+    message(WARNING "Adding -march=native to compile flags. This build will be architecture specific to this machine. Use a Release build if you intend on publishing this binary.")
 endif()
 
 set(USE_QT_VERSION "" CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ option(USE_QWT
 # Needed for ezpwd as it uses alternative operators
 if(MSVC)
     add_compile_options(/permissive-)
+else()
+    add_compile_options(-O3 -march=native)
+    add_link_options(-flto)
 endif()
 
 set(USE_QT_VERSION "" CACHE STRING

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Compile and Install ld-tools suite: (Required)
 
     mkdir build2
     cd build2
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT_VERSION=5
+    CXXFLAGS="-march=native" CFLAGS="-march=native" cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_QT_VERSION=5
     make -j4
     sudo make install
 

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -66,16 +66,9 @@ class FieldCVBSShared:
             )
             # Make sore to not move backwards here
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
-        
-        validpulses_arr = np.sort(np.asarray(
-            [
-                p[1].start
-                for p in validpulses
-            ], dtype=np.int32
-        ))
 
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
-            validpulses_arr,
+            validpulses,
             line0loc,
             0,
             meanlinelen,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 from setuptools import setup
+from distutils.extension import Extension
 from Cython.Build import cythonize
+
+import Cython.Compiler.Options
+Cython.Compiler.Options.annotate = True
+
 import numpy
 
 setup(
@@ -41,7 +46,29 @@ setup(
     #    'cvbs-decode',
     #    'hifi-decode',
     # ],
-    ext_modules=cythonize(["vhsdecode/*.pyx"], language_level=3),
+    ext_modules=cythonize([
+        Extension(
+            "vhsdecode.sync",
+            ["vhsdecode/sync.pyx"],
+            language_level=3,
+            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
+            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+        ),
+        Extension(
+            "vhsdecode.hilbert",
+            ["vhsdecode/hilbert.pyx"],
+            language_level=3,
+            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
+            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+        ),
+        Extension(
+            "vhsdecode.linear_filter",
+            ["vhsdecode/linear_filter.pyx"],
+            language_level=3,
+            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
+            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+        )
+    ]),
     # Needed for using numpy in cython.
     include_dirs=[numpy.get_include()],
     # These are just the minimal runtime dependencies for the Python scripts --

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ from setuptools import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
 
-import Cython.Compiler.Options
-Cython.Compiler.Options.annotate = True
+# Uncomment to view C code generated from Cython files
+# import Cython.Compiler.Options
+# Cython.Compiler.Options.annotate = True
 
 import numpy
 
@@ -51,21 +52,21 @@ setup(
             "vhsdecode.sync",
             ["vhsdecode/sync.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native"],
+            extra_compile_args=["-O3", "-flto"],
             extra_link_args=["-O3", "-flto"]
         ),
         Extension(
             "vhsdecode.hilbert",
             ["vhsdecode/hilbert.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native"],
+            extra_compile_args=["-O3", "-flto"],
             extra_link_args=["-O3", "-flto"]
         ),
         Extension(
             "vhsdecode.linear_filter",
             ["vhsdecode/linear_filter.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native"],
+            extra_compile_args=["-O3", "-flto"],
             extra_link_args=["-O3", "-flto"]
         )
     ]),

--- a/setup.py
+++ b/setup.py
@@ -51,22 +51,22 @@ setup(
             "vhsdecode.sync",
             ["vhsdecode/sync.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
-            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+            extra_compile_args=["-O3", "-march=native"],
+            extra_link_args=["-O3", "-flto"]
         ),
         Extension(
             "vhsdecode.hilbert",
             ["vhsdecode/hilbert.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
-            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+            extra_compile_args=["-O3", "-march=native"],
+            extra_link_args=["-O3", "-flto"]
         ),
         Extension(
             "vhsdecode.linear_filter",
             ["vhsdecode/linear_filter.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-march=native", "-fprofile-generate"],
-            extra_link_args=["-O3", "-flto", "-fprofile-generate"]
+            extra_compile_args=["-O3", "-march=native"],
+            extra_link_args=["-O3", "-flto"]
         )
     ]),
     # Needed for using numpy in cython.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import distutils.ccompiler
 from distutils.extension import Extension
 from Cython.Build import cythonize
 
@@ -7,6 +8,15 @@ from Cython.Build import cythonize
 # Cython.Compiler.Options.annotate = True
 
 import numpy
+
+compiler = distutils.ccompiler.new_compiler()
+
+if compiler.compiler_type == "unix":
+    extra_compile_args=["-O3", "-flto"]
+    extra_link_args=["-O3", "-flto"]
+else:
+    extra_compile_args=[]
+    extra_link_args=[]
 
 setup(
     # name='ld-decode',
@@ -52,22 +62,22 @@ setup(
             "vhsdecode.sync",
             ["vhsdecode/sync.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-flto"],
-            extra_link_args=["-O3", "-flto"]
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args
         ),
         Extension(
             "vhsdecode.hilbert",
             ["vhsdecode/hilbert.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-flto"],
-            extra_link_args=["-O3", "-flto"]
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args
         ),
         Extension(
             "vhsdecode.linear_filter",
             ["vhsdecode/linear_filter.pyx"],
             language_level=3,
-            extra_compile_args=["-O3", "-flto"],
-            extra_link_args=["-O3", "-flto"]
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args
         )
     ]),
     # Needed for using numpy in cython.

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -743,7 +743,10 @@ class FieldShared:
                 else self.rf.iretohz(self.rf.SysParams["vsync_ire"] / 2)
             )
 
-            return sync.refine_linelocs_hsync(self, self.linebad, threshold)
+            linelocs_refined, linebad = sync.refine_linelocs_hsync(self, self.linebad, threshold)
+            self.linebad = linebad
+
+            return linelocs_refined
         else:
             return self.linelocs1.copy()
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -696,7 +696,6 @@ class FieldShared:
             1.9
         )
 
-        lineloc_errs = np.full(proclines, 0, dtype=np.int32)
         self.linelocs0 = linelocs.copy()
 
         # ldd.logger.info("line0loc %s %s", int(line0loc), int(self.meanlinelen))
@@ -743,10 +742,7 @@ class FieldShared:
                 else self.rf.iretohz(self.rf.SysParams["vsync_ire"] / 2)
             )
 
-            linelocs_refined, linebad = sync.refine_linelocs_hsync(self, self.linebad, threshold)
-            self.linebad = linebad
-
-            return linelocs_refined
+            return sync.refine_linelocs_hsync(self, self.linebad, threshold)
         else:
             return self.linelocs1.copy()
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -685,16 +685,9 @@ class FieldShared:
                 )
                 ldd.logger.info("lastline < proclines , skipping a tiny bit")
             return None, None, max(line0loc - (meanlinelen * 20), self.inlinelen)
-        
-        validpulses_arr = np.sort(np.asarray(
-            [
-                p[1].start
-                for p in validpulses
-            ], dtype=np.int32
-        ))
 
         linelocs, lineloc_errs, last_validpulse = sync.valid_pulses_to_linelocs(
-            validpulses_arr,
+            validpulses,
             first_hsync_loc,
             first_hsync_loc_line,
             meanlinelen,
@@ -703,6 +696,7 @@ class FieldShared:
             1.9
         )
 
+        lineloc_errs = np.full(proclines, 0, dtype=np.int32)
         self.linelocs0 = linelocs.copy()
 
         # ldd.logger.info("line0loc %s %s", int(line0loc), int(self.meanlinelen))

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -203,7 +203,7 @@ cdef struct s_sync_distance_output:
 cdef inline void calc_sync_from_known_distances(
     s_sync_distance_input *sync_distance_input, 
     s_sync_distance_output *sync_distance_output
-) nogil:
+) nogil noexcept:
     sync_distance_output.distance_offset = 0
     sync_distance_output.hsync_loc = 0
     sync_distance_output.valid_locations = 0

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -36,7 +36,7 @@ def pulse_qualitycheck(prev_pulse, pulse, int in_line_len):
     else:  # transition to/from regular hsyncs can be .5 or 1H
         exprange = (0.4, 1.1)
 
-    linelen = (pulse[1].start - prev_pulse[1].start) / in_line_len
+    linelen = (pulse[1].start - prev_pulse[1].start) / <double> in_line_len
     inorder = inrange(linelen, exprange[0], exprange[1])
 
     return inorder
@@ -387,7 +387,7 @@ def get_first_hsync_loc(
         field_boundaries_detected == field_order_lengths_len or
 
         # otherwise, need more than half a consensus
-        (fallback_line0loc == -1 and prev_first_hsync_loc < 0 and field_boundaries_detected >= field_order_lengths_len / 2)
+        (fallback_line0loc == -1 and prev_first_hsync_loc < 0 and field_boundaries_detected >= field_order_lengths_len / 2.0)
     ):
         if field_boundaries_consensus / field_boundaries_detected == 1:
             first_field = True
@@ -398,7 +398,7 @@ def get_first_hsync_loc(
     # calculate the expected line locations for each vblank pulse
     # ***********************************************************
     cdef double line0loc_line = 0
-    cdef double vsync_section_lines = num_eq_pulses / 2
+    cdef double vsync_section_lines = num_eq_pulses / 2.0
     cdef double hsync_start_line
     cdef double current_field_lines
     cdef double previous_field_lines
@@ -853,7 +853,7 @@ def valid_pulses_to_linelocs(
 @cython.inline
 @cython.cdivision(True)
 cdef inline double round_nearest_line_loc(double line_number) nogil:
-    return round(0.5 * round(line_number / 0.5) * 10) / 10
+    return round(0.5 * round(line_number / 0.5) * 10) / 10.0
 
 @cython.boundscheck(False)
 def refine_linelocs_hsync(field, int[::1] linebad, double hsync_threshold):
@@ -872,7 +872,7 @@ def refine_linelocs_hsync(field, int[::1] linebad, double hsync_threshold):
     cdef float sample_rate_mhz = rf.freq
     cdef bint is_pal = rf.system == "PAL"
     cdef bint disable_right_hsync = rf.options.disable_right_hsync
-    cdef double zc_threshold = hsync_threshold #rf.iretohz(rf.SysParams["vsync_ire"] / 2)
+    cdef double zc_threshold = hsync_threshold #rf.iretohz(rf.SysParams["vsync_ire"] / 2.0)
     cdef double ire_30 = rf.iretohz(30)
     cdef double ire_n_55 = rf.iretohz(-55)
     cdef double ire_110 = rf.iretohz(110)
@@ -961,12 +961,12 @@ def refine_linelocs_hsync(field, int[::1] linebad, double hsync_threshold):
                     zc2 = calczc_do(
                         demod_05,
                         ll1,
-                        (porch_level + sync_level) / 2,
+                        (porch_level + sync_level) / 2.0,
                         count=400,
                     )
 
                     # any wild variation here indicates a failure
-                    if not is_none_double(zc2) and c_abs(zc2 - zc) < (one_usec / 2):
+                    if not is_none_double(zc2) and c_abs(zc2 - zc) < (one_usec / 2.0):
                         linelocs_refined[i] = zc2
                         prev_porch_level = porch_level
                     else:
@@ -980,10 +980,10 @@ def refine_linelocs_hsync(field, int[::1] linebad, double hsync_threshold):
                             zc2 = calczc_do(
                                 demod_05,
                                 ll1,
-                                (prev_porch_level + sync_level) / 2,
+                                (prev_porch_level + sync_level) / 2.0,
                                 count=400,
                             )
-                            if not is_none_double(zc2) and c_abs(zc2 - zc) < (one_usec / 2):
+                            if not is_none_double(zc2) and c_abs(zc2 - zc) < (one_usec / 2.0):
                                 linelocs_refined[i] = zc2
                             else:
                                 linebad[i] = True
@@ -1022,12 +1022,12 @@ def refine_linelocs_hsync(field, int[::1] linebad, double hsync_threshold):
                     zc2 = calczc_do(
                         demod_05,
                         ll1 + normal_hsync_length - one_usec,
-                        (porch_level + sync_level) / 2,
+                        (porch_level + sync_level) / 2.0,
                         count=400,
                     )
 
                     # any wild variation here indicates a failure
-                    if not is_none_double(zc2) and c_abs(zc2 - right_cross) < (one_usec / 2):
+                    if not is_none_double(zc2) and c_abs(zc2 - right_cross) < (one_usec / 2.0):
                         # TODO: Magic value here, this seem to give be approximately correct results
                         # but may not be ideal for all inputs.
                         # Value based on default sample rate so scale if it's different.


### PR DESCRIPTION
## Fixes
* Remove `-1` assignment to initial hsync location. This should be set to 0 when not yet filled in. This will fix a possible scenario where the estimated hsync drifts over time if there is a long span of time with no vblanking intervals.

## Performance
Various performance tweaks to the cython sync code. This should help a bit with performance, especially with computers with CPUs that have modern vector instructions.

* Added C compiler flags to optimize more, i.e. `-O3 -march=native -flto`
* Refactor to use `nogil` where possible
* Use contiguous arrays to allow for better auto-vectorization
* Update types to reduce casting

Before (current vhs_decode branch):
```
$ sudo perf stat -e instructions:u,fp_arith_inst_retired.128b_packed_single:u,fp_arith_inst_retired.128b_packed_double:u,fp_arith_inst_retired.256b_packed_single:u,fp_arith_inst_retired.256b_packed_double:u,fp_arith_inst_retired.512b_packed_single:u,fp_arith_inst_retired.512b_packed_double:u -- ./vhs-decode -l 50 -n -t 3 -f 40 --overwrite [file_location].flac test
File Frame 50: VHS                                                              
Completed: saving JSON and exiting.  Took 9.12 seconds to decode 50 frames (5.79 FPS post-setup)

 Performance counter stats for './vhs-decode -l 50 -n -t 3 -f 40 --overwrite [file_location].flac test':

   195,119,171,841      instructions:u                                                        
                 0      fp_arith_inst_retired.128b_packed_single:u                                      
       526,252,196      fp_arith_inst_retired.128b_packed_double:u                                      
             1,783      fp_arith_inst_retired.256b_packed_single:u                                      
        53,500,004      fp_arith_inst_retired.256b_packed_double:u                                      
         4,688,137      fp_arith_inst_retired.512b_packed_single:u                                      
       300,630,107      fp_arith_inst_retired.512b_packed_double:u                                      

      10.112633828 seconds time elapsed

      23.986897000 seconds user
       3.288829000 seconds sys
```

After (this branch):
```
$ sudo perf stat -e instructions:u,fp_arith_inst_retired.128b_packed_single:u,fp_arith_inst_retired.128b_packed_double:u,fp_arith_inst_retired.256b_packed_single:u,fp_arith_inst_retired.256b_packed_double:u,fp_arith_inst_retired.512b_packed_single:u,fp_arith_inst_retired.512b_packed_double:u -- ./vhs-decode -l 50 -n -t 3 -f 40 --overwrite [file_location].flac test
File Frame 50: VHS                                                              
Completed: saving JSON and exiting.  Took 8.83 seconds to decode 50 frames (5.98 FPS post-setup)

 Performance counter stats for './vhs-decode -l 50 -n -t 3 -f 40 --overwrite [file_location].flac test':

   191,981,798,294      instructions:u                                                        
                 0      fp_arith_inst_retired.128b_packed_single:u                                      
       526,252,196      fp_arith_inst_retired.128b_packed_double:u                                      
             1,927      fp_arith_inst_retired.256b_packed_single:u                                      
        53,502,084      fp_arith_inst_retired.256b_packed_double:u                                      
         4,687,993      fp_arith_inst_retired.512b_packed_single:u                                      
       300,630,280      fp_arith_inst_retired.512b_packed_double:u                                      

       9.827384407 seconds time elapsed

      23.535043000 seconds user
       3.147495000 seconds sys
```