### PR TITLE
hifi-decode: Better resampling, Spectral Noise Reduction, Multi processing

### DIFF
--- a/filter_tune/filter_tune.py
+++ b/filter_tune/filter_tune.py
@@ -110,7 +110,6 @@ from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as Navigation
 from matplotlib.figure import Figure
 
 from vhsdecode.utils import filtfft
-from vhsdecode.addons.FMdeemph import gen_high_shelf
 from vhsdecode.formats import get_format_params
 from vhsdecode import compute_video_filters
 from vhsdecode.main import supported_tape_formats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib, "noisereduce>=2.0.0""
+    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0"
 ]
 dynamic = ["version"]
 # version = "0.2.1dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib"
+    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib, "noisereduce>=2.0.0""
 ]
 dynamic = ["version"]
 # version = "0.2.1dev0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ samplerate
 scipy >=1.10,<=1.12
 soundfile
 sounddevice
+noisereduce

--- a/vhsdecode/compute_video_filters.py
+++ b/vhsdecode/compute_video_filters.py
@@ -12,7 +12,7 @@ else:
     from importlib.resources import files
 
 from vhsdecode.utils import filtfft
-from vhsdecode.addons.FMdeemph import FMDeEmphasisB, gen_low_shelf, gen_high_shelf
+from vhsdecode.addons.FMdeemph import FMDeEmphasisB, gen_shelf
 
 NONLINEAR_AMP_LPF_FREQ_DEFAULT = 700000
 NONLINEAR_STATIC_FACTOR_DEFAULT = None
@@ -77,10 +77,10 @@ def gen_custom_video_filters(filter_list, freq_hz, block_len):
                         file=sys.stderr,
                     )
             case "highshelf":
-                db, da = gen_high_shelf(f["midfreq"], f["gain"], f["q"], freq_hz / 2.0)
+                db, da = gen_shelf(f["midfreq"], f["gain"], "high", freq_hz / 2.0, qfactor=f["q"])
                 ret *= filtfft((db, da), block_len, whole=False)
             case "lowshelf":
-                db, da = gen_low_shelf(f["midfreq"], f["gain"], f["q"], freq_hz / 2.0)
+                db, da = gen_shelf(f["midfreq"], f["gain"], "low", freq_hz / 2.0, qfactor=f["q"])
                 ret *= filtfft((db, da), block_len, whole=False)
     return ret
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -307,19 +307,20 @@ class SpectralNoiseReduction():
         chunks.append(audio)
 
         for i in range(self.chunk_count):
-            chunk[:, self.padding + self.chunk_size*i : self.padding + self.chunk_size*(i+1)] = chunks[i]
+            position = self.padding + self.chunk_size*i
+            chunk[:, position : position + len(chunks[i])] = chunks[i]
 
         return chunk
     
-    def _trim_chunk(self, nr):
+    def _trim_chunk(self, nr, audio_len):
         last_chunk = self.chunk_size * (self.chunk_count-1) + self.padding
 
-        return nr[0][last_chunk:last_chunk+self.chunk_size]
+        return nr[0][last_chunk:last_chunk+audio_len]
     
     def _nr_channel(self, audio, gate_instance, chunk_instance):
         chunk = self._get_chunk(audio, chunk_instance)
         nr = gate_instance.spectral_gating_nonstationary(chunk)
-        trimmed = self._trim_chunk(nr)
+        trimmed = self._trim_chunk(nr, len(audio))
 
         return trimmed
 
@@ -683,10 +684,10 @@ class HiFiDecode:
         preAudioResampleL = self.preAudioResampleL.lfilt(ifL)
         preAudioResampleR = self.preAudioResampleR.lfilt(ifR)
         preL = samplerate_resample(
-            preAudioResampleL, self.audioRes_numerator, self.audioRes_denominator
+            preAudioResampleL, self.audioRes_numerator, self.audioRes_denominator, converter_type="sinc_fastest"
         )
         preR = samplerate_resample(
-            preAudioResampleR, self.audioRes_numerator, self.audioRes_denominator
+            preAudioResampleR, self.audioRes_numerator, self.audioRes_denominator, converter_type="sinc_fastest"
         )
 
         dcL = np.mean(preL)

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -16,7 +16,7 @@ from scipy.signal.signaltools import hilbert
 from noisereduce.spectralgate.nonstationary import SpectralGateNonStationary
 
 from lddecode.utils import unwrap_hilbert
-from vhsdecode.addons.FMdeemph import FMDeEmphasisC, gen_low_shelf, gen_high_shelf
+from vhsdecode.addons.FMdeemph import FMDeEmphasisC, gen_shelf
 from vhsdecode.addons.chromasep import samplerate_resample
 from vhsdecode.addons.gnuradioZMQ import ZMQSend, ZMQ_AVAILABLE
 from vhsdecode.utils import firdes_lowpass, firdes_highpass, FiltersClass, StackableMA
@@ -244,12 +244,12 @@ def build_shelf_filter(direction, t1_low, t2_high, db_per_octave, audio_rate):
     # using distances between the two frequencies, calculate the gain needed to fulfill the db/octave slope
     gain = log(t2_f/t1_f, 2) * db_per_octave
 
-    filter_function = gen_high_shelf if direction == "high" else gen_low_shelf
-    b, a = filter_function(
+    b, a = gen_shelf(
         center_f,
         gain,
-        0.707, # Q shouldn't cause much spiking beyond the desired gain
-        audio_rate
+        audio_rate,
+        direction,
+        qfactor=0.707 # Q shouldn't cause much spiking beyond the desired gain
     )
 
     # scale the filter such that the top of the shelf is at 0db gain

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -30,7 +30,7 @@ DEFAULT_EXPANDER_LOG_STRENGTH = 1.2
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT=0.4
 
-BLOCKS_PER_SECOND = 8
+BLOCKS_PER_SECOND = 2
 
 @dataclass
 class AFEParamsFront:
@@ -697,7 +697,7 @@ class HiFiDecode:
 
         preL = self.stereo_queue[0].result()
         preR = self.stereo_queue[1].result()
-        
+
         self.stereo_queue.clear()
 
         dcL = np.mean(preL)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -55,7 +55,7 @@ except ImportError as e:
     print(e)
     HIFI_UI = False
 
-DEFAULT_RESAMPLER_QUALITY = "medium"
+DEFAULT_RESAMPLER_QUALITY = "high"
 
 parser, _ = common_parser_cli(
     "Extracts audio from RAW HiFi FM RF captures",
@@ -101,7 +101,7 @@ parser.add_argument(
     dest="noise_reduction",
     type=str.lower,
     default="on",
-    help="Set noise reduction on/off",
+    help="Set noise reduction block (deemphasis and expansion) on/off",
 )
 
 parser.add_argument(
@@ -117,8 +117,8 @@ parser.add_argument(
     dest="NR_side_gain",
     type=float,
     default=DEFAULT_NR_ENVELOPE_GAIN,
-    help=f"Sets the noise reduction envelope tracking sidechain gain (default is {DEFAULT_NR_ENVELOPE_GAIN}). "
-    f"Range (20~100): 100 being a hard gate effect",
+    help=f"Sets the noise reduction expander sidechain gain (default is {DEFAULT_NR_ENVELOPE_GAIN}). "
+    f"Range (20~100): Higher values increase the effect of the expander",
 )
 
 parser.add_argument(


### PR DESCRIPTION
### Noise reduction / Re-sampling updates
* Add spectral noise reduction before deemphasis to remove FM noise
* Use sinc converter for resampling in audio chain to reduce resampling artifacts (controlled via options)

### Multi-processing updates
* Refactor thread pools into process pools for better multi threading. This helps to offset the extra processing time for the better resampling methods.

### Other Updates
* Fix hifi-decode deemphasis and weighting filters to use closer bandwidth to spec, vs. using q factor
* Add ability to specify bandwidth and slope to `vhsdecode/addons/FMdeemph.py` shelf filter
* Refactor post processing audio chain

### New Options
* Add `--NR_spectral_amount` option to control amount of spectral noise reduction.
  * 0 to disable
  * 1 for full spectral noise reduction
  * default: `0.4`
* Add `--resampler_quality` option to enable better quality resamplers. This reduces noise at the expense of processing time.
  * `low`, `medium`, `high`
  * default: `high`