### PR TITLE
open flac files directly

### DIFF
--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -410,6 +410,11 @@ def as_soundfile(pathR, sample_rate=48000):
             subtype="PCM_16",
             endian="LITTLE",
         )
+    elif ".flac" in path:
+        return sf.SoundFile(
+            pathR,
+            "r",
+        )
     elif "-" == path:
         return UnseekableSoundFile(
             BufferedInputStream(sys.stdin.buffer),


### PR DESCRIPTION
Open FLAC files directly with the soundfile module instead of the detour over ffmpeg. This should also prevent the hangups mentioned in issue #156