### PR TITLE
hifi-decode: Head Switching Filtering, IF to Audio resampling improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Test samples & signals can be digitally generated using [HackTV](https://github.
 # [HiFi-Decode](https://github.com/oyvindln/vhs-decode/wiki/003-Audio#hifi-decode-hifi-rf-into-audio-installation-and-usage) & [RTL-SDR Decode](https://github.com/oyvindln/vhs-decode/wiki/RTLSDR)
 
 
-Thanks to VideoMem's work on [Superheterodyne Decoding Tools](https://github.com/VideoMem/Superheterodyne-decoding-tools) we now have a working [HiFi Audio Decoder](https://github.com/oyvindln/vhs-decode/wiki/003-Audio) which provides basic decoding support for VHS & Video8/Hi8 HiFi FM tracks which takes uncompressed or FLAC compressed RF captures of HiFi FM signals and outputs standard 24-bit 44.1-192kHz FLAC stereo audio files. The decoding quality is not yet up to the standard of the output from the conventional vcr decoding circuitry.
+Thanks to VideoMem's work on [Superheterodyne Decoding Tools](https://github.com/VideoMem/Superheterodyne-decoding-tools) we now have a working [HiFi Audio Decoder](https://github.com/oyvindln/vhs-decode/wiki/003-Audio) which provides decoding support for VHS & Video8/Hi8 HiFi FM tracks which takes uncompressed or FLAC compressed RF captures of HiFi FM signals and outputs standard 24-bit 44.1-192kHz FLAC stereo audio files. The decoded quality is close to and better in some cases than the hardware output from a VCR.
 
 [RTLSDR capture & decoding](https://github.com/oyvindln/vhs-decode/wiki/RTLSDR) (cross plafrom as its 100% GNURadio based) can run in realtime on most systems (1~3 sec delay) and provide live playback, Alongside 8msps RF files and a 48kHz 24-bit FLAC file of the decoded audio.
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -26,11 +26,11 @@ from vhsdecode.utils import firdes_lowpass, firdes_highpass, FiltersClass, Stack
 import matplotlib.pyplot as plt
 
 # lower increases expander strength and decreases overall gain
-DEFAULT_NR_ENVELOPE_GAIN = 24
+DEFAULT_NR_ENVELOPE_GAIN = 22
 # increase gain to compensate for deemphasis gain loss
-DEFAULT_NR_DEEMPHASIS_GAIN = 1.1
+DEFAULT_NR_DEEMPHASIS_GAIN = 1
 # sets logarithmic slope for the 1:2 expander
-DEFAULT_EXPANDER_LOG_STRENGTH = 1.3
+DEFAULT_EXPANDER_LOG_STRENGTH = 1.2
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
 
@@ -386,7 +386,7 @@ class NoiseReduction:
         # deemphasis filter for output audio
         self.NR_deemphasis_T1 = 240e-6
         self.NR_deemphasis_T2 = 56e-6
-        self.NR_deemphasis_db_per_octave = 6.5
+        self.NR_deemphasis_db_per_octave = 6.6
 
         deemph_b, deemph_a = build_shelf_filter(
             "low", 
@@ -474,7 +474,7 @@ class NoiseReduction:
 
         audio_with_deemphasis = self.nrDeemphasisLowpass.lfilt(de_noise)
 
-        make_up_gain = (DEFAULT_NR_DEEMPHASIS_GAIN + self.spectral_nr_amount * 1.1)
+        make_up_gain = (DEFAULT_NR_DEEMPHASIS_GAIN + self.spectral_nr_amount * 1.3)
         audio_with_gain = np.clip(audio_with_deemphasis * make_up_gain, a_min=-1.0, a_max=1.0)
 
         # applies noise reduction

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -666,7 +666,7 @@ class HiFiDecode:
         interpolator_in = interpolator_in[np.logical_not(np.isnan(interpolator_in))]
 
         # interpolate the gap where the peak was removed
-        interpolator = interp1d(time, interpolator_in, kind="linear", copy=False, assume_sorted=True)
+        interpolator = interp1d(time, interpolator_in, kind="linear", copy=False, assume_sorted=True, fill_value="extrapolate")
 
         for (start, end) in boundaries:
             # sample and hold inteerpolation if boundaries are beyond this chunk

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -28,9 +28,9 @@ import matplotlib.pyplot as plt
 # lower increases expander strength and decreases overall gain
 DEFAULT_NR_ENVELOPE_GAIN = 24
 # increase gain to compensate for deemphasis gain loss
-DEFAULT_NR_DEEMPHASIS_GAIN = 1
+DEFAULT_NR_DEEMPHASIS_GAIN = 1.1
 # sets logarithmic slope for the 1:2 expander
-DEFAULT_EXPANDER_LOG_STRENGTH = 1.2
+DEFAULT_EXPANDER_LOG_STRENGTH = 1.3
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -936,7 +936,7 @@ class HiFiDecode:
             self.updateStandard(self.devL, self.devR)
             self.updateDemod()
 
-        return block_count, preL, preR
+        return preL, preR
     
     @staticmethod
     def debug_peak_interpolation(audio, filtered_signal, filtered_signal_abs, peaks, interpolation_boundaries, interpolated, headswitch_signal_rate):

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -647,8 +647,11 @@ class HiFiDecode:
 
         return afeL, afeR, fmL, fmR
 
-
-    def interpolate_boundaries(self, audio, boundaries):
+    def interpolate_boundaries(
+        self,
+        audio: np.array,
+        boundaries: list[Tuple[int, int]]
+    ) -> np.array:
         interpolated_signal = np.copy(audio)
 
         # setup interpolator input by copying and removing any samples that are peaks
@@ -695,8 +698,11 @@ class HiFiDecode:
         
         return peaks
     
-    def calc_headswitch_boundaries(self, peaks):
-        peak_boundaries = []
+    def calc_headswitch_boundaries(
+        self,
+        peaks: list[Tuple[int, int, float]]
+    ) -> list[Tuple[int, int]]:
+        peak_boundaries = list()
 
         # scale the peak width depending on how much the peak stands out from the base signal
         # use light scaling for headswtich peaks since they are usually very brief
@@ -711,7 +717,7 @@ class HiFiDecode:
 
         # merge overlapping or duplicate boundaries
         peak_boundaries.sort(key=lambda x: x[0])
-        merged = []
+        merged = list()
         
         for boundary in peak_boundaries:
             if not merged or merged[-1][1] < boundary[0]:

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -500,7 +500,7 @@ class HiFiDecode:
 
         # trim off peaks at edges of if
         self.pre_trim = 50
-        self.block_overlap_audio: int = int(self.audio_rate / (1e2 + self.pre_trim * 2))
+        self.block_overlap_audio: int = int(self.audio_rate / (4e2 + self.pre_trim * 2))
         audio_final_rate = (self.options["audio_rate"] / self.audio_rate) * (
             self.audioRes_numerator / self.audioRes_denominator
         )

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -896,13 +896,13 @@ class HiFiDecode:
     @staticmethod
     @njit(cache=True, fastmath=True, nogil=True)
     def cancelDC(audio: np.array) -> Tuple[np.array, float]:
-        dc = np.mean(audio)
+        dc = REAL_DTYPE(np.mean(audio))
         return audio - dc, dc
     
     @staticmethod
     @njit(cache=True, fastmath=True, nogil=True)
     def clip(audio: np.array, clip: float) -> np.array:
-        return audio / clip
+        return audio / REAL_DTYPE(clip)
     
     @staticmethod
     def headswitch_remove_noise(audio: np.array, audio_process_params: dict) -> np.array:
@@ -996,8 +996,8 @@ class HiFiDecode:
             self.updateStandard(self.devL, self.devR)
             self.updateDemod()
 
-        assert preL.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format"
-        assert preR.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format"
+        assert preL.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format, instead got {preL.dtype}"
+        assert preR.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format, instead got {preR.dtype}"
 
         return preL, preR
     

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -30,6 +30,8 @@ DEFAULT_EXPANDER_LOG_STRENGTH = 1.2
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
 
+DEFAULT_RESAMPLER_QUALITY = "high"
+
 BLOCKS_PER_SECOND = 2
 
 @dataclass
@@ -519,15 +521,13 @@ class HiFiDecode:
         self.preAudioResampleL = FiltersClass(a_iirb, a_iira, self.if_rate)
         self.preAudioResampleR = FiltersClass(a_iirb, a_iira, self.if_rate)
 
-        if self.options["resampler_quality"] == "medium":
-            self.if_resampler_converter = "linear"
-            self.audio_resampler_converter = "sinc_fastest"
-
-        elif self.options["resampler_quality"] == "high":
+        if self.options["resampler_quality"] == "high":
             self.if_resampler_converter = "linear"
             self.audio_resampler_converter = "sinc_medium"
-
-        else:
+        elif self.options["resampler_quality"] == "medium":
+            self.if_resampler_converter = "linear"
+            self.audio_resampler_converter = "sinc_fastest"
+        else: # low
             self.if_resampler_converter = "linear"
             self.audio_resampler_converter = "linear"
 

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -40,13 +40,17 @@ except ImportError:
     )
     from PyQt5 import QtGui, QtCore
 
-from vhsdecode.hifi.HiFiDecode import DEFAULT_NR_ENVELOPE_GAIN as DEFAULT_NR_GAIN_, DEFAULT_SPECTRAL_NR_AMOUNT
+from vhsdecode.hifi.HiFiDecode import (
+    DEFAULT_NR_ENVELOPE_GAIN,
+    DEFAULT_SPECTRAL_NR_AMOUNT,
+    DEFAULT_RESAMPLER_QUALITY
+)
 
 
 class MainUIParameters:
     def __init__(self):
         self.volume: float = 1.0
-        self.sidechain_gain: float = DEFAULT_NR_GAIN_ / 100.0
+        self.sidechain_gain: float = DEFAULT_NR_ENVELOPE_GAIN / 100.0
         self.noise_reduction: bool = True
         self.automatic_fine_tuning: bool = True
         self.grc = False
@@ -60,7 +64,7 @@ class MainUIParameters:
         self.input_file: str = ""
         self.output_file: str = ""
         self.spectral_nr_amount = DEFAULT_SPECTRAL_NR_AMOUNT
-        self.resampler_quality = None
+        self.resampler_quality = DEFAULT_RESAMPLER_QUALITY
 
 
 def decode_options_to_ui_parameters(decode_options):

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -197,13 +197,12 @@ def signal_handler(sig, frame):
     is_main_thread = main_pid == os.getpid()
     if signal_count >= 1:
         if is_main_thread:
-            print("")
-            print("Ctrl-C was pressed again, stopping immediately...")
+            # prevent reentrant calls https://stackoverflow.com/a/75368797
+            os.write(sys.stdout.fileno(), b"\nCtrl-C was pressed again, stopping immediately...\n")
         sys.exit(1)
     if signal_count == 0:
         if is_main_thread:
-            print("")
-            print("Ctrl-C was pressed, stopping decode...")
+            os.write(sys.stdout.fileno(), b"\nCtrl-C was pressed, stopping decode...\n")
     signal_count += 1
 
 signal.signal(signal.SIGINT, signal_handler)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -764,7 +764,7 @@ def decode(decoder, decode_options, ui_t: Optional[AppWindow] = None):
                         if decode_options["auto_fine_tune"]:
                             log_bias(decoder)
         
-                        post_processor.submit(l, r, current_block)
+                        post_processor.submit(l, r)
 
                         current_block += 1
                         for stereo in post_processor.read():

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -370,7 +370,8 @@ class UnSigned16BitFileReader(io.RawIOBase):
 # The samplerate here could be anything
 def as_soundfile(pathR, sample_rate=48000):
     path = pathR.lower()
-    if ".raw" in path or ".s16" in path:
+    extension = pathR.lower().split(".")[-1]
+    if "raw" == extension or "s16" == extension:
         return sf.SoundFile(
             pathR,
             "r",
@@ -380,7 +381,7 @@ def as_soundfile(pathR, sample_rate=48000):
             subtype="PCM_16",
             endian="LITTLE",
         )
-    elif ".u8" in path or ".r8" in path:
+    elif "u8" == extension or "r8" == extension:
         return sf.SoundFile(
             pathR,
             "r",
@@ -390,7 +391,7 @@ def as_soundfile(pathR, sample_rate=48000):
             subtype="PCM_U8",
             endian="LITTLE",
         )
-    elif ".s8" in path:
+    elif "s8" == extension:
         return sf.SoundFile(
             pathR,
             "r",
@@ -400,7 +401,7 @@ def as_soundfile(pathR, sample_rate=48000):
             subtype="PCM_S8",
             endian="LITTLE",
         )
-    elif ".u16" in path or ".r16" in path:
+    elif "u16" == extension or "r16" == extension:
         return sf.SoundFile(
             UnSigned16BitFileReader(pathR),
             "r",
@@ -410,7 +411,7 @@ def as_soundfile(pathR, sample_rate=48000):
             subtype="PCM_16",
             endian="LITTLE",
         )
-    elif ".flac" in path or ".ldf" in path or ".hifi" in path:
+    elif "flac" == extension or "ldf" == extension or "hifi" == extension:
         return sf.SoundFile(
             pathR,
             "r",

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -26,7 +26,8 @@ from vhsdecode.hifi.HiFiDecode import (
     SpectralNoiseReduction,
     NoiseReduction,
     DEFAULT_NR_ENVELOPE_GAIN,
-    DEFAULT_SPECTRAL_NR_AMOUNT
+    DEFAULT_SPECTRAL_NR_AMOUNT,
+    DEFAULT_RESAMPLER_QUALITY
 )
 from vhsdecode.hifi.TimeProgressBar import TimeProgressBar
 import io
@@ -56,7 +57,6 @@ except ImportError as e:
     print(e)
     HIFI_UI = False
 
-DEFAULT_RESAMPLER_QUALITY = "high"
 
 parser, _ = common_parser_cli(
     "Extracts audio from RAW HiFi FM RF captures",
@@ -510,12 +510,12 @@ class PostProcessor:
             audio_rate=decode_options["audio_rate"]
         )
 
-        if decode_options["resampler_quality"] == "medium":
-            self.resampler_converter_type = "sinc_medium"
-        elif decode_options["resampler_quality"] == "low":
-            self.resampler_converter_type = "sinc_fastest"
-        else:
+        if decode_options["resampler_quality"] == "high":
             self.resampler_converter_type = "sinc_best"
+        elif decode_options["resampler_quality"] == "medium":
+            self.resampler_converter_type = "sinc_medium"
+        else: # low
+            self.resampler_converter_type = "sinc_fastest"
 
         common_params = {
             "resample_audio_rate": decode_options["audio_rate"],

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -700,7 +700,7 @@ class PostProcessor:
                 overlap_start, overlap_end = PostProcessor.get_overlap(len(l), is_last_block, audio_rate, decoder_audio_rate, decoder_audio_block_size, decoder_audio_discard_size)
                 stereo = PostProcessor.stereo_interleave(l, r, overlap_start, overlap_end)
                 
-                assert stereo.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format"
+                assert stereo.dtype == REAL_DTYPE, f"Audio data must be in {REAL_DTYPE} format, instead got {stereo.dtype}"
 
                 executor.submit(out_conn.send_bytes, stereo)
 
@@ -758,7 +758,7 @@ class PostProcessor:
 
         l_block_num, l = self.nr_worker_l_out.get()
         r_block_num, r = self.nr_worker_r_out.get()
-        assert l_block_num == r_block_num, "Noise reduction processes are out of sync!"
+        assert l_block_num == r_block_num, "Noise reduction processes are out of sync! Channels will be out od sync."
 
         self.discard_merge_worker_in.put_nowait((l, r, is_last_block))
         stereo = self.discard_merge_worker_out_parent.recv_bytes()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -857,22 +857,23 @@ def decode(decoder, decode_options, ui_t: Optional[AppWindow] = None):
                                             decode_options["audio_rate"],
                                             blocking=False,
                                         )
-                                        stereo_play_buffer = list()
-                                    stereo_play_buffer += stereo
+                                        stereo_play_buffer = []
+                                    stereo_play_buffer = np.concatenate((stereo_play_buffer, np.frombuffer(stereo, dtype=np.float32)))
                                 else:
                                     print(
                                         "Import of sounddevice failed, preview is not available!"
                                     )
                         except ValueError:
                             pass
-                        if ui_t is not None:
-                            ui_t.app.processEvents()
-                            if ui_t.window.transport_state == 0:
-                                break
-                            elif ui_t.window.transport_state == 2:
-                                while ui_t.window.transport_state == 2:
-                                    ui_t.app.processEvents()
-                                    time.sleep(0.01)
+
+                    if ui_t is not None:
+                        ui_t.app.processEvents()
+                        if ui_t.window.transport_state == 0:
+                            break
+                        elif ui_t.window.transport_state == 2:
+                            while ui_t.window.transport_state == 2:
+                                ui_t.app.processEvents()
+                                time.sleep(0.01)
 
                     if is_last_block:
                         break
@@ -999,8 +1000,8 @@ async def decode_parallel(
                                         decode_options["audio_rate"],
                                         blocking=False,
                                     )
-                                    stereo_play_buffer = list()
-                                stereo_play_buffer += stereo
+                                    stereo_play_buffer = []
+                                stereo_play_buffer = np.concatenate((stereo_play_buffer, np.frombuffer(stereo, dtype=np.float32)))
                             else:
                                 print(
                                     "Import of sounddevice failed, preview is not available!"
@@ -1008,14 +1009,15 @@ async def decode_parallel(
                     except ValueError:
                         pass
 
-                    if ui_t is not None:
-                        ui_t.app.processEvents()
-                        if ui_t.window.transport_state == 0:
-                            break
-                        elif ui_t.window.transport_state == 2:
-                            while ui_t.window.transport_state == 2:
-                                ui_t.app.processEvents()
-                                time.sleep(0.01)
+                if ui_t is not None:
+                    ui_t.app.processEvents()
+                    if ui_t.window.transport_state == 0:
+                        break
+                    elif ui_t.window.transport_state == 2:
+                        while ui_t.window.transport_state == 2:
+                            ui_t.app.processEvents()
+                            time.sleep(0.01)
+
                 progressB.print(f.tell())
                   
                 if is_last_block:

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -615,9 +615,9 @@ class PostProcessor:
         overlap_start = total_overlap - round(total_overlap / 20)
         overlap_end = overlap_start - total_overlap + len(audio)
         
-        if block_num == 0:
-            # don't trim the start when at the first block
-            overlap_start = 0
+        #if block_num == 0:
+        #    # don't trim the start when at the first block
+        #    overlap_start = 0
         if is_last_block:
             # don't trim the end when at the last block
             overlap_end = len(audio)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -339,6 +339,7 @@ class UnseekableSoundFile(sf.SoundFile):
 
         # offset array copying logic implemented without numpy seems a bit faster
         out_int16_len = np.size(out_int16)
+        overlap_size = min(overlap_size, out_int16_len)
         new_overlap = np.empty(overlap_size, dtype=np.int16)
         result = np.empty(overlap_size + out_int16_len, dtype=np.float64)
         


### PR DESCRIPTION
* De-noise head switching pulses
  * The audio is high pass filtered to remove audible sound and sent to `scipy.signal.find_peaks` to detect the peaks that fit closely to the video system field rate.
  * Peaks are then smoothed using linear interpolation.
* IF to audio resampling now uses  `sinc-fastest`, `sinc-medium` for resampling quality `medium` and `high` options respectfully. This also removes the IF to audio low-pass filter, which is not needed with `sinc` resampling.
  * The better resampling method removes artifacts and noise that was audible in some cases.
  * On my machine, the decode is actually faster since the low-pass filter was removed.
  * It also helps with the head switching detection to have a tighter impulse response on the pulses so they are more easily detected and interpolated
* Overlap blocks in the beginning to avoid periodic clicks when each block is appended to the audio.
* Improve multi-threading by offloading soundfile encoding to it's own process and various audio processing tasks to the process pool.
* Fix file extension handling.

#### Head Switching Noise Reduction example:
* Top: Without head switching noise reduction
* Bottom: With head switching noise reduction
![image](https://github.com/user-attachments/assets/55e86e27-f465-4b89-a92f-d6a88efa8aac)

#### Head Switching peak detection debugging graph
![head switch detection](https://github.com/user-attachments/assets/eccb8094-32ec-4149-9f97-143598f3b34c)
