### PR TITLE
hifi-decoder: Use SharedMemory for better multi processing, Fix 8mm, Fix Windows CTRL-C

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -2,6 +2,7 @@
 import argparse
 import sys
 from importlib import import_module
+from multiprocessing import freeze_support
 
 # from vhsdecode.main import main
 
@@ -43,4 +44,5 @@ def main(argv):
 
 
 if __name__ == "__main__":
+    freeze_support()
     main(sys.argv[1:])

--- a/decode.py
+++ b/decode.py
@@ -39,6 +39,7 @@ def main(argv):
         hifimain()
     else:
         print_options()
+        print(f"Instead got: {to_run}")
 
 
 if __name__ == "__main__":

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -985,11 +985,11 @@ class HiFiDecode:
         preL, preR = self.demodblock(data)
 
         # low pass filter to remove any remaining high frequency noise
-        preL = self.preAudioResampleL.lfilt(preL)
-        preR = self.preAudioResampleR.lfilt(preR)
-
-        preL = preL.astype(REAL_DTYPE, copy=False)
-        preR = preR.astype(REAL_DTYPE, copy=False)
+        # disabled since it interferes with head switching noise detection
+        # preL = self.preAudioResampleL.lfilt(preL)
+        # preR = self.preAudioResampleR.lfilt(preR)
+        # preL = preL.astype(REAL_DTYPE, copy=False)
+        # preR = preR.astype(REAL_DTYPE, copy=False)
 
         # remove peaks at edges of demodulated audio
         trim = self.if_rate_audio_ratio * self.pre_trim

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -567,6 +567,7 @@ class HiFiDecode:
                 self.afe_params = AFEParamsNTSCHi8()
                 self.standard = AFEParamsNTSCHi8()
 
+        self.headswitch_interpolation_enabled = self.options["head_switching_interpolation"]
         self.headswitch_passes = 2
         self.headswitch_signal_rate = self.audio_rate
         self.headswitch_hz = self.field_rate # frequency used to fit peaks to the expected headswitching interval
@@ -606,6 +607,7 @@ class HiFiDecode:
             "audioFinal_numerator": self.audioFinal_numerator,
             "audioFinal_denominator": self.audioFinal_denominator,
             "audio_final_resampler_converter": self.audio_final_resampler_converter,
+            "headswitch_interpolation_enabled": self.headswitch_interpolation_enabled,
             "headswitch_passes": self.headswitch_passes,
             "headswitch_signal_rate": self.headswitch_signal_rate,
             "headswitch_hz": self.headswitch_hz,
@@ -952,7 +954,9 @@ class HiFiDecode:
         audio = samplerate_resample(audio, audio_process_params["audioRes_numerator"], audio_process_params["audioRes_denominator"], audio_process_params["audio_resampler_converter"])
         audio, dc = HiFiDecode.cancelDC(audio)
         audio = HiFiDecode.clip(audio, AFEParamsVHS().VCODeviation)
-        audio = HiFiDecode.headswitch_remove_noise(audio, audio_process_params)
+
+        if audio_process_params["headswitch_interpolation_enabled"]:
+            audio = HiFiDecode.headswitch_remove_noise(audio, audio_process_params)
 
         if audio_process_params["audio_rate"] != audio_process_params["audio_final_rate"]:
             audio = samplerate_resample(audio, audio_process_params["audioFinal_numerator"], audio_process_params["audioFinal_denominator"], audio_process_params["audio_final_resampler_converter"])

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -65,6 +65,7 @@ class MainUIParameters:
         self.output_file: str = ""
         self.spectral_nr_amount = DEFAULT_SPECTRAL_NR_AMOUNT
         self.resampler_quality = DEFAULT_RESAMPLER_QUALITY
+        self.head_switching_interpolation = "on"
 
 
 def decode_options_to_ui_parameters(decode_options):
@@ -83,6 +84,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.output_file = decode_options["output_file"]
     values.spectral_nr_amount = decode_options["spectral_nr_amount"]
     values.resampler_quality = decode_options["resampler_quality"]
+    values.head_switching_interpolation = decode_options["head_switching_interpolation"]
     return values
 
 
@@ -103,6 +105,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "output_file": values.output_file,
         "spectral_nr_amount": values.spectral_nr_amount,
         "resampler_quality": values.resampler_quality,
+        "head_switching_interpolation": values.head_switching_interpolation,
         "mode": (
             "s"
             if values.audio_mode == "Stereo"
@@ -251,10 +254,12 @@ class HifiUi(QMainWindow):
 
         # Checkboxes
         self.noise_reduction_checkbox = QCheckBox("Noise reduction")
+        self.head_switching_interpolation_checkbox = QCheckBox("Head Switching Interpolation")
         self.automatic_fine_tuning_checkbox = QCheckBox("Automatic fine tuning")
         self.preview_checkbox = QCheckBox("Preview")
         self.preview_checkbox.setCheckable(params.preview_available)
         middle_layout.addWidget(self.noise_reduction_checkbox)
+        middle_layout.addWidget(self.head_switching_interpolation_checkbox)
         middle_layout.addWidget(self.automatic_fine_tuning_checkbox)
         middle_layout.addWidget(self.preview_checkbox)
 
@@ -436,6 +441,7 @@ class HifiUi(QMainWindow):
         self.sidechain_dial.setValue(int(values.sidechain_gain * 100))
         self.sidechain_textbox.setText(str(values.sidechain_gain))
         self.noise_reduction_checkbox.setChecked(values.noise_reduction)
+        self.head_switching_interpolation_checkbox.setChecked(values.head_switching_interpolation)
         self.automatic_fine_tuning_checkbox.setChecked(values.automatic_fine_tuning)
         self.sample_rate_combo.setCurrentText(str(values.audio_sample_rate))
         self.sample_rate_combo.setCurrentIndex(
@@ -473,6 +479,7 @@ class HifiUi(QMainWindow):
         values.volume = float(self.volume_textbox.text())
         values.sidechain_gain = float(self.sidechain_textbox.text())
         values.noise_reduction = self.noise_reduction_checkbox.isChecked()
+        values.head_switching_interpolation = self.head_switching_interpolation_checkbox.isChecked()
         values.automatic_fine_tuning = self.automatic_fine_tuning_checkbox.isChecked()
         values.audio_sample_rate = int(self.sample_rate_combo.currentText())
         values.standard = self.standard_combo.currentText()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -144,7 +144,8 @@ parser.add_argument(
     "--head_switching_interpolation",
     dest="head_switching_interpolation",
     type=str.lower,
-    help=f"Enables head switching noise interpolation. (defaults to \"on\" for VHS, \"off\" for Video8 and Hi8)."
+    default="on",
+    help=f"Enables head switching noise interpolation. (defaults to \"on\")."
 )
 
 parser.add_argument(
@@ -1420,13 +1421,6 @@ def main() -> int:
 
     real_mode = default_mode if not args.mode else args.mode
 
-    default_head_switching_interpolation = "on" if not args.format_8mm else "off"
-    head_switching_interpolation = (
-        default_head_switching_interpolation
-        if not args.head_switching_interpolation else
-        args.head_switching_interpolation
-    )
-
     if (
         args.resampler_quality == "low" or 
         args.resampler_quality == "medium" or 
@@ -1445,7 +1439,7 @@ def main() -> int:
         "original": args.original,
         "resampler_quality": resampler_quality if not args.preview else "low",
         "spectral_nr_amount": args.spectral_nr_amount if not args.preview else 0,
-        "head_switching_interpolation": head_switching_interpolation == "on",
+        "head_switching_interpolation": args.head_switching_interpolation == "on",
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "nr_side_gain": args.NR_side_gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -139,6 +139,13 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--head_switching_interpolation",
+    dest="head_switching_interpolation",
+    type=str.lower,
+    help=f"Enables head switching noise interpolation. (defaults to \"on\" for VHS, \"off\" for Video8 and Hi8)."
+)
+
+parser.add_argument(
     "--resampler_quality",
     dest="resampler_quality",
     type=str,
@@ -1403,6 +1410,13 @@ def main() -> int:
 
     real_mode = default_mode if not args.mode else args.mode
 
+    default_head_switching_interpolation = "on" if not args.format_8mm else "off"
+    head_switching_interpolation = (
+        default_head_switching_interpolation
+        if not args.head_switching_interpolation else
+        args.head_switching_interpolation
+    )
+
     if (
         args.resampler_quality == "low" or 
         args.resampler_quality == "medium" or 
@@ -1421,6 +1435,7 @@ def main() -> int:
         "original": args.original,
         "resampler_quality": resampler_quality if not args.preview else "low",
         "spectral_nr_amount": args.spectral_nr_amount if not args.preview else 0,
+        "head_switching_interpolation": head_switching_interpolation == "on",
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "nr_side_gain": args.NR_side_gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1365,9 +1365,9 @@ def run_decoder(args, decode_options, ui_t: Optional[AppWindow] = None):
                 decoders.append(HiFiDecode(decode_options))
                 decoders[i].updateAFE(LCRef, RCRef)
 
-            #set_start_method("spawn")
+            # set_start_method("spawn")
             # one thread to continuously read in the blocks, one thread for processing what was read
-            with ThreadPoolExecutor(int(args.threads/2)) as async_executor:
+            with ThreadPoolExecutor(1) as async_executor:
                 loop = asyncio.get_event_loop()
                 loop.set_default_executor(async_executor)
                 loop.run_until_complete(decode_parallel(decoders, decode_options, threads=args.threads, ui_t=ui_t))


### PR DESCRIPTION
* Move all data transfers between processes to shared memory. Results in huge speed ups on multi core machines.
* Stream audio data in `--preview` mode to prevent skips for a good real-time rf monitoring experience.
* Add `--head_switching_interpolation [on/off]` option to turn this noise reduction feature on or off.
* Fix 8mm decoding by putting the RF low-pass filter back in. It's needed to filter out the video signals from 8mm capture data.
  * This is also re-enabled for VHS. In some cases this can help filter out noise for a minor performance impact.
* Fix Windows issue with CTRL-C causing an `InterruptedException` rather than cleaning up gracefully.

### Benchmarks
#### Piping in from `flac`
`flac -d -c --force-raw-format --endian little --sign signed hifi_rf.flac - | ~/git/vhs-decode/hifi-decode -t 16 -n -f 20MHz --auto_fine_tune off --audio_rate 48000 - hifi_decoded.flac`

* Dell Laptop with 16 cores circa 2021, running 16 threads (Linux)
  * 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz
```
- Decoding speed: 48988 kFrames/s (1.22x), 16 running processes
- Input position: 0:03:48.780
- Audio position: 0:03:40.416
- Wall time     : 0:03:06.805
```

* Dell Laptop with 16 cores circa 2021, running 16 threads (Windows 11)
  * 11th Gen Intel(R) Core(TM) i9-11980HK @ 2.60GHz
```
Decoding speed: 31265 kFrames/s (0.78x), 15 running processes
- Input position: 0:08:22.332
- Audio position: 0:08:14.460
- Wall time     : 0:10:42.668
```

* AMD Desktop circa 2015, running 4 threads
  * AMD A10-7860K Radeon R7, 12 Compute Cores 4C+8G
```
Decoding speed: 8362 kFrames/s (0.21x), 4 running processes
- Input position: 0:00:49.692
- Audio position: 0:00:46.248
- Wall time     : 0:03:57.707
```

* Old i7 sandybridge laptop circa 2010, running 8 threads
  * Intel(R) Core(TM) i7-2960XM CPU @ 2.70GHz
```
Decoding speed: 10053 kFrames/s (0.25x), 8 running processes
- Input position: 0:00:23.616
- Audio position: 0:00:18.696
- Wall time     : 0:01:33.961
```

* Core2 Duo machine circa ~2008, running 2 threads:
  * Intel(R) Core(TM)2 Extreme CPU X9000  @ 2.80GHz
```
Decoding speed: 1405 kFrames/s (0.04x), 2 running processes
- Input position: 0:00:14.760
- Audio position: 0:00:12.792
- Wall time     : 0:07:00.142
```

#### Piping in from `ffmpeg`
`ffmpeg -i hifi_rf.flac -f s16le -acodec pcm_s16le - | ~/git/vhs-decode/hifi-decode -t 64 -n -f 20MHz --auto_fine_tune off --audio_rate 48000 - hifi_decoded.flac`
* Large server with 192 cores circa 2018, running 64 threads:
  * Dell Poweredge R930 Server, 4x Intel(R) Xeon(R) CPU E7-8890 v4 @ 2.20GHz
```
- Decoding speed: 102333 kFrames/s (2.56x), 52 running processes
- Input position: 0:29:28.402
- Audio position: 0:29:28.740
- Wall time     : 0:11:31.233
```
![Screenshot from 2025-02-08 21-36-41](https://github.com/user-attachments/assets/2cb2389c-46a8-471a-b4c4-87c55dd03831)