### PR TITLE
hifi-decode: fix OSX shared memory length, make intel deps optional

### DIFF
--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -24,7 +24,7 @@ jobs:
           cp resources/appimage/decode/vhs-decode.desktop _build_appimage/
           cp resources/appimage/decode/vhs-decode.appdata.xml _build_appimage/
 
-          echo "${{ github.workspace }}[hifi_gui,hifi_gnuradio]" > _build_appimage/requirements.txt
+          echo "${{ github.workspace }}[intel,hifi_gui,hifi_gnuradio]" > _build_appimage/requirements.txt
 
           python-appimage build app -p 3.12 _build_appimage
 

--- a/.github/workflows/build_windows_decode.yml
+++ b/.github/workflows/build_windows_decode.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build Python module
         run: |
-          pip install ".[hifi_gui_qt6]" setuptools Cython pyinstaller pyinstaller-versionfile -r ./requirements.txt
+          pip install ".[intel,hifi_gui_qt6]" setuptools Cython pyinstaller pyinstaller-versionfile -r ./requirements.txt
           python setup.py build_ext --inplace
 
       - name: Build Windows binary

--- a/README.md
+++ b/README.md
@@ -328,9 +328,31 @@ Install VHS-Decode:
 
     cd vhs-decode
 
-Build and install vhs-decode via pipx
+Build and install vhs-decode via pipx, using **one** of the below scripts.
 
+* Base installation
+
+    ```
+    pipx install .
+    ```
+
+* With hifi-decode gui
+
+    ```
     pipx install .[hifi_gui_qt6]
+    ```
+
+* With Intel specific cpu optimizations
+
+    ```
+    pipx install .[intel]
+    ```
+
+* If reinstalling, you may need to add the `--force` flag to overwrite the previous installation.
+
+    ```
+    pipx install .[intel,hifi_gui_qt6] --force
+    ```
 
 Compile and Install ld-tools suite: (Required)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,13 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile>=0.13.1", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0", "rocket-fft>=0.2.5", "icc_rt"
+    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1","samplerate", "static-ffmpeg", "cython", "soundfile>=0.13.1", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0", "rocket-fft>=0.2.5"
 ]
 dynamic = ["version"]
 # version = "0.2.1dev0"
 
 [project.optional-dependencies]
+intel = [ "intel-cmplr-lib-rt", "icc_rt" ]
 hifi_gui = [ "PyQt5>=5.14.1" ]
 hifi_gui_qt6 = [ "PyQt6>=6.4.2" ]
 hifi_gnuradio = [ "pyzmq" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools>=61", "setuptools_scm>=6.2", "wheel", "Cython", "numpy"]
 name = "vhs_decode"
 description = "Software Decoder for raw rf captures of laserdisc, vhs and other analog video formats"
 readme = "README_pypi.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 keywords = ["laserdisc", "vhs", "video", "tape", "decoder"]
 license = {file = "LICENSE"}
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ soundfile>=0.13.1
 sounddevice
 noisereduce>=2.0.0
 rocket-fft>=0.2.5
-icc_rt

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -11,6 +11,8 @@ PyInstaller.__main__.run(
         "decode.py",
         "--collect-submodules",
         "application",
+        "--collect-all",
+        "rocket_fft",
         "--add-data",
         "vhsdecode/format_defs:vhsdecode/format_defs",
         "--icon",

--- a/vhsdecode/__init__.py
+++ b/vhsdecode/__init__.py
@@ -1,2 +1,34 @@
 #!/usr/bin/python3
 # Initialisation for the vhsdecode package.
+
+import sys
+import os
+
+from llvmlite.binding import load_library_permanently
+
+# load intel intrinsics library for numba
+ON_LINUX = sys.platform.startswith('linux')
+ON_DARWIN = sys.platform.startswith('darwin')
+ON_WINDOWS = sys.platform.startswith('win')
+
+os_lib_dir = os.path.join(
+    sys.prefix, *(["Library", "bin"] if ON_WINDOWS else ["lib"])
+)
+
+try:
+    if 32 << bool(sys.maxsize >> 32) == 64:
+        _nb_svml_dir = os.environ.get('NB_SVML_LIBS_DIR') or os_lib_dir
+        _nb_loader = lambda so: load_library_permanently(
+            os.path.join(_nb_svml_dir, so)
+        )
+    
+        if ON_LINUX:
+            _nb_loader("libintlc.so.5")
+            _nb_loader("libsvml.so")
+        elif ON_DARWIN:
+            _nb_loader("libintlc.dylib")
+            _nb_loader("libsvml.dylib")
+        elif ON_WINDOWS:
+            _nb_loader("svml_dispmd")
+except:
+    pass

--- a/vhsdecode/hifi/__init__.py
+++ b/vhsdecode/hifi/__init__.py
@@ -17,9 +17,6 @@ os_lib_dir = os.path.join(
 
 try:
     if 32 << bool(sys.maxsize >> 32) == 64:
-    
-        # `NB_SVML_LIBS_DIR` below is arbitrary: it may have been set manually beforehand.
-        # ... Otherwise, the default values are pretty robust for what I can tell.
         _nb_svml_dir = os.environ.get('NB_SVML_LIBS_DIR') or os_lib_dir
         _nb_loader = lambda so: load_library_permanently(
             os.path.join(_nb_svml_dir, so)


### PR DESCRIPTION
* Shorten shared memory names for OSX compatibility. See https://stackoverflow.com/a/38075686
* Add optional dependency group for Intel vector library
  * Example installation script `pipx install .[intel]`
* Add Intel vector library loading script to vhs-decode __init__.py. It fails silently and continues if the library isn't available.
* Temporarily pin max python version at 3.12. Can update to 3.13 once https://github.com/styfenschaer/rocket-fft/issues/15 is addressed.