### PR TITLE
hifi-decode: Normalize option, fix Hifi GUI

### DIFF
--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -50,6 +50,7 @@ from vhsdecode.hifi.HiFiDecode import (
 class MainUIParameters:
     def __init__(self):
         self.volume: float = 1.0
+        self.normalize = False
         self.sidechain_gain: float = DEFAULT_NR_ENVELOPE_GAIN / 100.0
         self.noise_reduction: bool = True
         self.automatic_fine_tuning: bool = True
@@ -71,6 +72,7 @@ class MainUIParameters:
 def decode_options_to_ui_parameters(decode_options):
     values = MainUIParameters()
     values.volume = decode_options["gain"]
+    values.normalize = decode_options["normalize"]
     values.sidechain_gain = decode_options["nr_side_gain"] / 100.0
     values.noise_reduction = decode_options["noise_reduction"]
     values.automatic_fine_tuning = decode_options["auto_fine_tune"]
@@ -101,6 +103,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "grc": values.grc,
         "audio_rate": values.audio_sample_rate,
         "gain": values.volume,
+        "normalize": values.normalize,
         "input_file": values.input_file,
         "output_file": values.output_file,
         "spectral_nr_amount": values.spectral_nr_amount,
@@ -253,11 +256,13 @@ class HifiUi(QMainWindow):
         self.main_layout.addLayout(middle_layout)
 
         # Checkboxes
+        self.normalize_checkbox = QCheckBox("Normalize")
         self.noise_reduction_checkbox = QCheckBox("Noise reduction")
         self.head_switching_interpolation_checkbox = QCheckBox("Head Switching Interpolation")
         self.automatic_fine_tuning_checkbox = QCheckBox("Automatic fine tuning")
         self.preview_checkbox = QCheckBox("Preview")
         self.preview_checkbox.setCheckable(params.preview_available)
+        middle_layout.addWidget(self.normalize_checkbox)
         middle_layout.addWidget(self.noise_reduction_checkbox)
         middle_layout.addWidget(self.head_switching_interpolation_checkbox)
         middle_layout.addWidget(self.automatic_fine_tuning_checkbox)
@@ -440,6 +445,7 @@ class HifiUi(QMainWindow):
         self.volume_textbox.setText(str(values.volume))
         self.sidechain_dial.setValue(int(values.sidechain_gain * 100))
         self.sidechain_textbox.setText(str(values.sidechain_gain))
+        self.normalize_checkbox.setChecked(values.normalize)
         self.noise_reduction_checkbox.setChecked(values.noise_reduction)
         self.head_switching_interpolation_checkbox.setChecked(values.head_switching_interpolation)
         self.automatic_fine_tuning_checkbox.setChecked(values.automatic_fine_tuning)
@@ -478,6 +484,7 @@ class HifiUi(QMainWindow):
         values = MainUIParameters()
         values.volume = float(self.volume_textbox.text())
         values.sidechain_gain = float(self.sidechain_textbox.text())
+        values.normalize = self.normalize_checkbox.isChecked()
         values.noise_reduction = self.noise_reduction_checkbox.isChecked()
         values.head_switching_interpolation = self.head_switching_interpolation_checkbox.isChecked()
         values.automatic_fine_tuning = self.automatic_fine_tuning_checkbox.isChecked()

--- a/vhsdecode/hifi/TimeProgressBar.py
+++ b/vhsdecode/hifi/TimeProgressBar.py
@@ -8,11 +8,15 @@ class TimeProgressBar:
         self.label = label
         self.time = time
 
-    def print(self, v):
+    def print(self, v, new_line=True):
         if self.max > 0:
             sys.stdout.write(self.label + " [")
             c = round(v * self.w / self.max)
             d = self.w - c
             sys.stdout.write("#" * c)
             sys.stdout.write(" " * d)
-            sys.stdout.write("] %.02f%%\n" % (v * 100.0 / self.max))
+            sys.stdout.write("] %.02f%%" % (v * 100.0 / self.max))
+            if new_line:
+                sys.stdout.write("\n")
+            else:
+                sys.stdout.write("\r")

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -64,6 +64,7 @@ except ImportError as e:
     print(e)
     HIFI_UI = False
 
+NORMALIZE_FILE_SUFFIX = "_tmp_normalize.wav"
 
 parser, _ = common_parser_cli(
     "Extracts audio from RAW HiFi FM RF captures",
@@ -156,11 +157,20 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--normalize",
+    dest="normalize",
+    action="store_true",
+    default=False,
+    help=F"Automatically amplifies the audio to the peak gain of the decode. "
+    f"This will create a temporary file ending in \"{NORMALIZE_FILE_SUFFIX}\" that is deleted after the amplification step is complete."
+)
+
+parser.add_argument(
     "--gain",
     dest="gain",
     type=float,
     default=1.0,
-    help="Sets the gain/volume of the output audio (default is 1.0)",
+    help="Manually adjust the gain/volume of the output audio (default is 1.0)",
 )
 
 parser.add_argument(
@@ -408,8 +418,17 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         return sf.SoundFile(pathR, "r")
 
 
-def as_outputfile(path, sample_rate):
-    if ".wav" in path.lower():
+def as_outputfile(path, sample_rate, normalize):
+    if normalize:
+        return sf.SoundFile(
+            path + NORMALIZE_FILE_SUFFIX,
+            "w",
+            channels=2,
+            samplerate=int(sample_rate),
+            format="WAV", # TODO: update to FLAC 32 bit when supported by soundfile
+            subtype="FLOAT",
+        )
+    elif ".wav" in path.lower():
         return sf.SoundFile(
             path,
             "w",
@@ -426,7 +445,7 @@ def as_outputfile(path, sample_rate):
             samplerate=int(sample_rate),
             format="FLAC",
             subtype="PCM_24",
-            #compression_level=0.0
+            compression_level=1.0
         )
 
 
@@ -472,11 +491,13 @@ class PostProcessor:
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
         out_conn,
+        peak_gain,
     ):
         self.final_audio_rate = decode_options["audio_rate"]
         self.use_noise_reduction = decode_options["noise_reduction"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
         self.nr_side_gain = decode_options["nr_side_gain"]
+        self.peak_gain = peak_gain
 
         # create processes and wire up queues
         #
@@ -528,9 +549,15 @@ class PostProcessor:
         self.nr_worker_r.start()
         atexit.register(self.nr_worker_r.terminate)
         
-        self.mix_to_stereo_worker_process = Process(target=PostProcessor.mix_to_stereo_worker, name="hifi_stereo_mrg", args=(nr_worker_l_out_output, nr_worker_r_out_output, self.mix_to_stereo_worker_output, self.final_audio_rate))
+        self.mix_to_stereo_worker_process = Process(target=PostProcessor.mix_to_stereo_worker, name="hifi_stereo_mrg", args=(nr_worker_l_out_output, nr_worker_r_out_output, self.mix_to_stereo_worker_output, self.peak_gain, self.final_audio_rate))
         self.mix_to_stereo_worker_process.start()
         atexit.register(self.mix_to_stereo_worker_process.terminate)
+
+    @staticmethod
+    @guvectorize([(numba.types.float32, NumbaAudioArray, NumbaAudioArray)], '(),(n)->(n)', cache=True, fastmath=True, nopython=True)
+    def normalize(gain, _, audio):
+        for i in range(len(audio)):
+            audio[i] = audio[i] * gain
 
     @staticmethod
     def spectral_noise_reduction_worker(
@@ -607,7 +634,7 @@ class PostProcessor:
             out_conn.send(decoder_state)
 
     @staticmethod
-    def mix_to_stereo_worker(nr_l_in_conn, nr_r_in_conn, out_conn, sample_rate):
+    def mix_to_stereo_worker(nr_l_in_conn, nr_r_in_conn, out_conn, peak_gain, sample_rate):
         while True:
             while True:
                 try:
@@ -630,16 +657,20 @@ class PostProcessor:
             l = buffer.get_nr_left()
             r = buffer.get_nr_right()
             stereo = buffer.get_stereo()
+            
+            max_gain = PostProcessor.stereo_interleave(l, r, stereo, decoder_state.post_audio_trimmed, sample_rate, decoder_state.block_num == 0)
 
-            stereo_len = PostProcessor.stereo_interleave(l, r, stereo, decoder_state.post_audio_trimmed, sample_rate, decoder_state.block_num == 0)
+            if peak_gain.value < max_gain:
+                with peak_gain.get_lock():
+                    peak_gain.value = max_gain
 
-            decoder_state.stereo_audio_trimmed = stereo_len
+            decoder_state.stereo_audio_trimmed = decoder_state.post_audio_trimmed * 2
             buffer.close()
             out_conn.send(decoder_state)
             
 
     @staticmethod
-    @njit(numba.types.int32(NumbaAudioArray, NumbaAudioArray, NumbaAudioArray, numba.types.int32, numba.types.int32, numba.types.bool_), cache=True, fastmath=True, nogil=True)
+    @njit(numba.types.float32(NumbaAudioArray, NumbaAudioArray, NumbaAudioArray, numba.types.int32, numba.types.int32, numba.types.bool_), cache=True, fastmath=True, nogil=True)
     def stereo_interleave(
         audioL: np.array,
         audioR: np.array,
@@ -648,19 +679,29 @@ class PostProcessor:
         sample_rate: int,
         is_first_block: bool
     ) -> int:
-        for i in range(channel_length):
-            stereo[(i * 2)] = audioL[i]
-            stereo[(i * 2) + 1] = audioR[i]
+        max_gain = 0
+        start_sample = 0
 
         # mute the spike that occurs during noise reduction
         if is_first_block:
             trim_samples = int(0.0015 * sample_rate)
+            start_sample = trim_samples
             for i in range(trim_samples):
                 stereo[(i * 2)] = 0
                 stereo[(i * 2) + 1] = 0
-            
-        stereo_len = channel_length * 2
-        return stereo_len
+
+        for i in range(start_sample, channel_length):
+            audioLSample = audioL[i]
+            stereo[(i * 2)] = audioLSample
+            if abs(audioLSample) > max_gain:
+                max_gain = abs(audioLSample)
+
+            audioRSample = audioR[i]
+            stereo[(i * 2) + 1] = audioRSample
+            if abs(audioRSample) > max_gain:
+                max_gain = abs(audioRSample)
+
+        return max_gain
 
     @staticmethod
     def block_sorter_worker(
@@ -836,9 +877,10 @@ def write_soundfile_process_worker(
     audio_rate = decode_options["audio_rate"]
     input_rate = decode_options["input_rate"]
     preview_mode = decode_options["preview"]
+    normalize = decode_options["normalize"]
 
     with SoundDeviceProcess(audio_rate) as player:
-        with as_outputfile(output_file, audio_rate) as w:
+        with as_outputfile(output_file, audio_rate, normalize) as w:
             done = False
             while not done:
                 while True:
@@ -897,6 +939,7 @@ async def decode_parallel(
     blocks_enqueued = Value("d", 0)
     input_position = Value('d', 0)
     total_samples_decoded = Value('d', 0)
+    peak_gain = Value('d', 0)
     start_time = datetime.now()
     
     # HiFiDecode data flow diagram
@@ -949,7 +992,8 @@ async def decode_parallel(
         post_processor_shared_memory_idle_queue,
         shared_memory_idle_queue,
         blocks_enqueued,
-        post_processor_out_input_conn
+        post_processor_out_input_conn,
+        peak_gain,
     )
     atexit.register(post_processor.close)
 
@@ -963,7 +1007,7 @@ async def decode_parallel(
             post_processor_shared_memory_idle_queue,
             start_time, 
             input_position, 
-            total_samples_decoded, 
+            total_samples_decoded,
             decode_options, 
             output_file, 
             decode_done
@@ -1089,6 +1133,41 @@ async def decode_parallel(
         atexit.unregister(shared_memory.close)
         atexit.unregister(shared_memory.unlink)
     
+    print(f"\nPeak gain is {(peak_gain.value * 100):.2f}%.", end="")
+
+    if decode_options["normalize"]:
+        gain_adjust = 1 / peak_gain.value - np.finfo(np.float16).eps # subtract epsilon error to prevent appearance of "clipping" in editing tools
+        print(f" Adjusting by {(gain_adjust * 100):.2f}%, please wait...")
+
+        input_file_post_gain = output_file + NORMALIZE_FILE_SUFFIX
+        output_file = decode_options["output_file"]
+        audio_rate = decode_options["audio_rate"]
+    
+        try:
+            total_frames_read = 0
+            buffer = np.empty(block_audio_size, dtype=np.float32)
+            
+            with sf.SoundFile(input_file_post_gain, "r") as f:
+                progressB = TimeProgressBar(f.frames, f.frames)
+                with as_outputfile(output_file, audio_rate, False) as w:
+                    done = False
+                    while not done:
+                        frames_read = f.buffer_read_into(buffer, dtype="float32")
+                        samples_read = frames_read * 2
+                        
+                        if samples_read < len(buffer):
+                            buffer = buffer[0:samples_read]
+                            done = True
+    
+                        PostProcessor.normalize(gain_adjust, buffer, buffer)
+                        w.buffer_write(buffer, "float32")
+                        
+                        total_frames_read += frames_read
+                        progressB.print(total_frames_read, False)
+            print("")
+        finally:
+            os.remove(input_file_post_gain)
+    
     elapsed_time = datetime.now() - start_time
     dt_string = elapsed_time.total_seconds()
     print(f"\nDecode finished, seconds elapsed: {round(dt_string)}")
@@ -1173,6 +1252,7 @@ def main() -> int:
         "head_switching_interpolation": args.head_switching_interpolation == "on",
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
+        "normalize": args.normalize,
         "nr_side_gain": args.NR_side_gain,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,


### PR DESCRIPTION
* Add `--normalize` option to adjust the gain of the decoded output up to the peak gain.
  * This creates a temporary file that stores the float32 samples of the decoded audio. After the decode is completed, the temporary file is read again, each sample multiplied by `1/peak_gain` and saved to the final output file.
* Fix: prevent the hifi-gui from locking up during a decode.