### PR TITLE
GnuRadio RF AFE Playground

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ soundfile>=0.13.1
 sounddevice
 noisereduce>=2.0.0
 rocket-fft>=0.2.5
+pyzmq

--- a/tools/zmq_afe/ZMQ_AFE.grc
+++ b/tools/zmq_afe/ZMQ_AFE.grc
@@ -1,0 +1,173 @@
+options:
+  parameters:
+    author: ''
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: ZMQ_AFE
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ZMQ AFE Playground
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 40e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: qtgui_freq_sink_x_0
+  id: qtgui_freq_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'True'
+    average: '0.2'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '"blue"'
+    color10: '"dark blue"'
+    color2: '"red"'
+    color3: '"green"'
+    color4: '"black"'
+    color5: '"cyan"'
+    color6: '"magenta"'
+    color7: '"yellow"'
+    color8: '"dark red"'
+    color9: '"dark green"'
+    comment: ''
+    ctrlpanel: 'True'
+    fc: '0'
+    fftsize: '4096'
+    freqhalf: 'False'
+    grid: 'True'
+    gui_hint: ''
+    label: Relative Gain
+    label1: ''
+    label10: ''''''
+    label2: ''''''
+    label3: ''''''
+    label4: ''''''
+    label5: ''''''
+    label6: ''''''
+    label7: ''''''
+    label8: ''''''
+    label9: ''''''
+    legend: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: RF input spectra
+    nconnections: '1'
+    showports: 'False'
+    tr_chan: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_tag: '""'
+    type: float
+    units: dB
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    wintype: firdes.WIN_HAMMING
+    ymax: '10'
+    ymin: '-140'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [568, 172.0]
+    rotation: 0
+    state: true
+- name: zeromq_rep_sink_0
+  id: zeromq_rep_sink
+  parameters:
+    address: tcp://*:5556
+    affinity: ''
+    alias: ''
+    comment: ''
+    hwm: '-1'
+    pass_tags: 'False'
+    timeout: '100'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [576, 308.0]
+    rotation: 0
+    state: true
+- name: zeromq_req_source_0
+  id: zeromq_req_source
+  parameters:
+    address: tcp://localhost:5555
+    affinity: ''
+    alias: ''
+    comment: ''
+    hwm: '-1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    pass_tags: 'False'
+    timeout: '100'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [232, 308.0]
+    rotation: 0
+    state: true
+
+connections:
+- [zeromq_req_source_0, '0', qtgui_freq_sink_x_0, '0']
+- [zeromq_req_source_0, '0', zeromq_rep_sink_0, '0']
+
+metadata:
+  file_format: 1

--- a/vhsdecode/demodcache.py
+++ b/vhsdecode/demodcache.py
@@ -1,10 +1,20 @@
 import time
 from lddecode.core import DemodCache
+from vhsdecode.addons.gnuradioZMQ import ZMQSend, ZMQReceive
 
 
 class DemodCacheTape(DemodCache):
     def __init__(self, *args, **kwargs):
         super(DemodCacheTape, self).__init__(*args, **kwargs)
+        self.rf_options = args[0].options
+        if self.rf_options.gnrc_afe:
+            self.zmqsend = ZMQSend()
+            self.zmqreceive = ZMQReceive()
+            print("Open GNURadio with ZMQ REQ source set at tcp://localhost:%d and ZMQ REP sink set at tcp://*:%d" % (self.zmqsend.port, self.zmqreceive.port))
+            print("The data stream will be of the float type at 40MSPS (40Mhz sample rate)")
+            print("It will send the raw RF for further processing prior to demodulation (useful for RF EQ discovery "
+                  "and group delay compensation)")
+            print("You might want to do this in single threaded decode mode (-t 1 parameter)")
 
     def worker(self, return_on_empty=False):
         """Override to skip mtf stuff since that's laserdisc specific."""
@@ -24,6 +34,12 @@ class DemodCacheTape(DemodCache):
 
             if item[0] == "DEMOD":
                 blocknum, block, _, request = item[1:]
+
+                if self.rf_options.gnrc_afe:
+                    raw_input = block["rawinput"]
+                    raw_size = raw_input.size
+                    self.zmqsend.send(raw_input)
+                    block["rawinput"] = self.zmqreceive.receive(raw_size)
 
                 output = {}
 

--- a/vhsdecode/demodcache.py
+++ b/vhsdecode/demodcache.py
@@ -11,7 +11,7 @@ class DemodCacheTape(DemodCache):
             self.zmqsend = ZMQSend()
             self.zmqreceive = ZMQReceive()
             print("Open GNURadio with ZMQ REQ source set at tcp://localhost:%d and ZMQ REP sink set at tcp://*:%d" % (self.zmqsend.port, self.zmqreceive.port))
-            print("The data stream will be of the float type at 40MSPS (40Mhz sample rate)")
+            print("The data stream will be of the float type at 40MSPS (40MHz sample rate)")
             print("It will send the raw RF for further processing prior to demodulation (useful for RF EQ discovery "
                   "and group delay compensation)")
             print("You might want to do this in single threaded decode mode (-t 1 parameter)")

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -314,6 +314,14 @@ def main(args=None, use_gui=False):
         default=f.DEFAULT_HYSTERESIS,
         help="Dropout detection hysteresis, the rf level needs to go above the dropout threshold multiplied by this for a dropout to end.",
     )
+    dodgroup.add_argument(
+        "--gnrc",
+        "--gnuradio_rf_afe",
+        dest="gnrc_afe",
+        action="store_true",
+        default=False,
+        help="Open a ZMQ pipe back and forth to GNU Radio for RF AFE/EQ/Group delay measurements. (WIP)\nYou might want to use this with -t 1",
+    )
 
     args = parser.parse_args(args)
 
@@ -401,6 +409,7 @@ def main(args=None, use_gui=False):
     rf_options["export_raw_tbc"] = args.export_raw_tbc
     rf_options["tape_speed"] = args.tape_speed
     rf_options["ire0_adjust"] = args.ire0_adjust
+    rf_options["gnrc_afe"] = args.gnrc_afe
 
     extra_options = get_extra_options(args, not use_gui)
     extra_options["params_file"] = args.params_file

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -604,6 +604,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "fm_audio_notch",
                 "chroma_offset",
                 "ire0_adjust",
+                "gnrc_afe",
             ],
         )(
             self.iretohz(100) * 2,
@@ -634,6 +635,7 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("fm_audio_notch", 0),
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
             ire0_adjust,
+            rf_options.get("gnrc_afe", False),
         )
 
         # As agc can alter these sysParams values, store a copy to then


### PR DESCRIPTION
Added a ZMQ REQ / REP for back and forth communication from vhs-decode and gnuradio.

Using the --gnrc switch flag in vhs-decode, it sends the uncompressed 40MSPS RAW RF float data and receives it back prior to demodulation (FM decoding, TBC and chroma processing).

It is intended to use with gnuradio-companion as a playground to find the best RF EQ, with hopes of troubleshooting the decoding ringing.

The use is very simple.

Decode adding -t1 and --gnrc flag on you decode command line.

It will print a message like this:

```text
Initializing ZMQSend (REP) at pid 64926, port 5555
Initializing ZMQReceive (REQ) at pid 64926, port 5556
Open GNURadio with ZMQ REQ source set at tcp://localhost:5555 and ZMQ REP sink set at tcp://*:5556
The data stream will be of the float type at 40MSPS (40MHz sample rate)
It will send the raw RF for further processing prior to demodulation (useful for RF EQ discovery and group delay compensation)
You might want to do this in single threaded decode mode (-t 1 parameter)
```

Then open the graph located on tools/zmq_afe/ZMQ_AFE.grc

![image](https://github.com/user-attachments/assets/e16842e6-e03e-417e-9b96-4841a945c79c)

It comes with a builtin frequency spectrum
![image](https://github.com/user-attachments/assets/997521a5-37b6-493a-905d-43ac77a6dec9)

Whatever you transform the signal between the ZMQ REQ source and the ZMQ REP sink it will be decoded back by vhs-decode.
Currently no transforms are applied



