### PR TITLE
hifi-decode: Do FFT in power of 2

### DIFF
--- a/vhsdecode/addons/chromasep.py
+++ b/vhsdecode/addons/chromasep.py
@@ -37,7 +37,7 @@ def signal_resample(data, n, d, converter_type="linear"):
 # The converter params are the same as in libsamplerate:
 # In ascending quality/complexity order:
 #   zero_order_hold, linear, sinc_fastest, sinc_best
-def samplerate_resample(data, n, d, converter_type="linear"):
+def samplerate_resample(data, n, d, converter_type="sinc_fastest"):
     ratio = n / d
     return resample(data, ratio=ratio, converter_type=converter_type)
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -798,7 +798,12 @@ class HiFiDecode:
             self.block_size,
             self.block_audio_final_size
         ])
-        block_audio_overlap_divisor = int(self.block_audio_size / block_size_gcd)
+
+        if block_size_gcd > 5:
+            block_audio_overlap_divisor = int(self.block_audio_size / block_size_gcd)
+        else:
+            print(f"WARNING: The input sample rate is not evenly divisible by the output sample rate. Audio sync issues may occur. Input Rate: {self.input_rate}, Output Rate: {self.audio_final_rate}.")
+            block_audio_overlap_divisor = 1
 
         # start and end samples to zero to remove spikes at edges of demodulated audio
         self.pre_trim = 50
@@ -813,6 +818,7 @@ class HiFiDecode:
         overlap_seconds = self.block_audio_final_overlap / self.audio_final_rate
 
         self.block_overlap = round(self.input_rate * overlap_seconds)
+        self.block_audio_overlap = ceil(self.input_rate * overlap_seconds)
         self.block_read_overlap = self.block_overlap * 2
         self.block_audio_final_overlap = round(self.audio_final_rate * overlap_seconds)
 
@@ -1086,6 +1092,10 @@ class HiFiDecode:
     @property
     def blockAudioSize(self) -> int:
         return self.block_audio_size
+    
+    @property
+    def blockAudioOverlap(self) -> int:
+        return self.block_audio_overlap
         
     # size of the audio decoded audio after resampling
     @property

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -551,15 +551,13 @@ class NoiseReduction:
 class HiFiAudioParams:
     pre_trim: int
     gain: int
-    block_final_audio_size: int
-    block_overlap_audio_final: int
+    block_audio_final_size: int
     decode_mode: str
     preview: bool
     original: bool
     auto_fine_tune: bool
     format: str
     if_rate: int
-    if_rate_audio_ratio: float
     input_rate: int
     audio_rate: int
     ifresample_numerator: int
@@ -601,13 +599,11 @@ class HiFiDecode:
         self.gain = options["gain"]
 
         self.input_rate: int = int(options["input_rate"])
+        self.if_rate: int = 2 ** 23 # needs to be a power of 2 for fft
         self.audio_rate: int = 192000
         self.audio_final_rate: int = int(options["audio_rate"])
+
         self.rfBandPassParams = AFEParamsFront()
-        # downsamples the if signal to fit within the nyquist cutoff within an integer ratio of the audio rate
-        min_if_rate = (self.rfBandPassParams.cutoff + self.rfBandPassParams.transition_width) * 2
-        self.if_rate_audio_ratio = ceil(min_if_rate / self.audio_rate)
-        self.if_rate: int = int(self.if_rate_audio_ratio * self.audio_rate)
         (
             self.ifresample_numerator,
             self.ifresample_denominator,
@@ -618,6 +614,10 @@ class HiFiDecode:
         ) = self.getResamplingRatios()
 
         self.set_block_sizes()
+
+        print("rates", self.input_rate, self.if_rate, self.audio_rate, self.audio_final_rate)
+        print("rates gcd", np.gcd.reduce([self.input_rate, self.if_rate, self.audio_rate, self.audio_final_rate]))
+        print("min overlap", self.pre_trim + self.resampler_overlap)
 
         self.bandpassRF = AFEBandPass(self.rfBandPassParams, self.input_rate)
         a_iirb, a_iira = firdes_lowpass(
@@ -716,15 +716,13 @@ class HiFiDecode:
         self.audio_process_params = HiFiAudioParams(
             pre_trim = self.pre_trim,
             gain = self.gain,
-            block_final_audio_size = self.block_final_audio_size,
-            block_overlap_audio_final = self.block_overlap_audio_final,
+            block_audio_final_size = self.block_audio_final_size,
             decode_mode = self.decode_mode,
             preview = options["preview"],
             original = options["original"],
             auto_fine_tune = options["auto_fine_tune"],
             format = options["format"],
             if_rate = self.if_rate,
-            if_rate_audio_ratio = self.if_rate_audio_ratio,
             input_rate = self.input_rate,
             audio_rate = self.audio_rate,
             ifresample_numerator = self.ifresample_numerator,
@@ -758,6 +756,10 @@ class HiFiDecode:
             muting_fft_end = self.muting_fft_end,
         )
 
+    # TODO: Subtrack overlap from block size rather than adding it
+    #       Required that the processing size of each block is exactly 0.5 seconds, so the demode can be a power of 2
+    #       Any overlap will represented inside the blocks, not appended
+
     def set_block_sizes(self, block_size=None, is_last_block=False):
         # block overlap and edge discard
         self.blocks_second: float = 1 / BLOCKS_PER_SECOND
@@ -770,31 +772,58 @@ class HiFiDecode:
 
         self.block_resampled_size: int = ceil(self.if_rate * self.blocks_second)
         self.block_audio_size: int = ceil(self.audio_rate * self.blocks_second)
-        self.block_final_audio_size: int = ceil(self.audio_final_rate * self.blocks_second)
+        self.block_audio_final_size: int = ceil(self.audio_final_rate * self.blocks_second)
 
         # trim off peaks at edges of if
         self.pre_trim = 50
         self.resampler_overlap = 1e2
         # use the greatest common divisor to calculate the overlap samples so it is always an integer
-        block_size_gcd = np.gcd.reduce([self.block_size, self.block_resampled_size, self.block_audio_size, self.block_final_audio_size])
-        overlap_divisor = int(self.audio_rate / block_size_gcd)
+        block_size_gcd = np.gcd.reduce([
+            self.block_size,
+            #self.block_resampled_size,
+            #self.block_audio_size,
+            self.block_audio_final_size
+        ])
+        block_audio_overlap_divisor = int(self.block_audio_size / block_size_gcd)
 
         if not is_last_block:
-            self.block_overlap_audio = ceil((self.resampler_overlap + self.pre_trim * 2) / overlap_divisor) * overlap_divisor
+            # TODO: What is this when it is the last block?????
+            self.block_audio_overlap = ceil((self.resampler_overlap + self.pre_trim * 2) / block_audio_overlap_divisor) * block_audio_overlap_divisor
 
-        overlap_seconds = self.block_overlap_audio / self.audio_rate
+        overlap_seconds = self.block_audio_overlap / self.audio_rate
 
         self.block_overlap = round(self.input_rate * overlap_seconds)
-        self.block_overlap_resampled = round(self.if_rate * overlap_seconds)
-        self.block_overlap_audio_final = round(self.audio_final_rate * overlap_seconds)
+        self.block_resampled_overlap = round(self.if_rate * overlap_seconds)
+        self.block_audio_overlap = round(self.audio_rate * overlap_seconds)
+        self.block_audio_final_overlap = round(self.audio_final_rate * overlap_seconds)
+
+        print("block sizes",
+            self.block_size,
+            self.block_resampled_size,
+            self.block_audio_size,
+            self.block_audio_final_size,
+            "overlap",
+            block_size_gcd,
+            self.block_overlap,
+            self.block_resampled_overlap,
+            self.block_audio_overlap
+        )
 
         return {
-            "block_len": self.block_size,
+            "block_size": self.block_size,
             "block_overlap": self.block_overlap,
-            "block_resampled_len": self.block_resampled_size + self.block_overlap_resampled,
-            "block_audio_len": self.block_audio_size + self.block_overlap_audio,
-            "block_audio_final_len": self.block_final_audio_size,
-            "block_audio_final_overlap": self.block_overlap_audio_final,
+            "block_audio_size": self.block_audio_size,
+            "block_audio_final_size": self.block_audio_final_size,
+            "block_audio_final_overlap": self.block_audio_final_overlap
+        }
+    
+    def get_block_sizes(self):
+        return {
+            "block_size": self.block_size,
+            "block_overlap": self.block_overlap,
+            "block_audio_size": self.block_audio_size,
+            "block_audio_final_size": self.block_audio_final_size,
+            "block_audio_final_overlap": self.block_audio_final_overlap
         }
 
     def getResamplingRatios(self):
@@ -1064,7 +1093,7 @@ class HiFiDecode:
     # size of the audio decoded audio after resampling
     @property
     def blockFinalAudioSize(self) -> int:
-        return self.block_final_audio_size
+        return self.block_audio_final_size
 
     @property
     def readOverlap(self) -> int:
@@ -1072,7 +1101,7 @@ class HiFiDecode:
 
     @property
     def audioDiscard(self) -> int:
-        return self.block_overlap_audio
+        return self.block_audio_overlap
 
     @property
     def sourceRate(self) -> int:
@@ -1287,20 +1316,21 @@ class HiFiDecode:
 
     def block_decode(
         self,
-        raw_data: np.array,
-        final_block_len: int,
+        rf_data: np.array,
+        block_audio_final_size: int,
+        block_audio_final_overlap: int,
         measure_perf: bool = False
     ) -> Tuple[int, np.array, np.array]:
         # Do a bandpass filter to remove any the video components from the signal.
         if measure_perf: start_bandpassRF = perf_counter()
-        raw_data = self.bandpassRF.work(raw_data)
+        rf_data = self.bandpassRF.work(rf_data)
         if measure_perf: end_bandpassRF = perf_counter()
-        raw_data = raw_data.astype(REAL_DTYPE, copy=False)
+        rf_data = rf_data.astype(REAL_DTYPE, copy=False)
 
         # resample from input sample rate to if sample rate
         if measure_perf: start_if_resampler = perf_counter()
-        data = samplerate_resample(
-            raw_data, self.ifresample_numerator, self.ifresample_denominator, converter_type=self.if_resampler_converter
+        rf_data_resampled = samplerate_resample(
+            rf_data, self.ifresample_numerator, self.ifresample_denominator, converter_type=self.if_resampler_converter
         )
         if measure_perf: end_if_resampler = perf_counter()
 
@@ -1318,7 +1348,7 @@ class HiFiDecode:
         #     preR, dcR = audioR_future.result()
         
         if measure_perf: start_carrier_filter = perf_counter()
-        filterL, filterR = self.filterCarriers(data)
+        filterL, filterR = self.filterCarriers(rf_data_resampled)
         if measure_perf: end_carrier_filter = perf_counter()
 
         if self.options["grc"] and ZMQ_AVAILABLE:
@@ -1341,9 +1371,12 @@ class HiFiDecode:
 
         # trim off the block overlap
         audio_len = len(preL)
-        overlap_to_trim = int((audio_len - final_block_len) / 2)
+        expected_len =  block_audio_final_size - block_audio_final_overlap * 2
+        overlap_to_trim = round((audio_len - expected_len) / 2)
         preL = preL[overlap_to_trim:-overlap_to_trim]
         preR = preR[overlap_to_trim:-overlap_to_trim]
+
+        print("overlap to trim", len(rf_data), len(rf_data_resampled), overlap_to_trim, audio_len)
 
         if measure_perf: start_adjust_gain = perf_counter()
         if self.audio_process_params.gain != 1:
@@ -1427,11 +1460,7 @@ class HiFiDecode:
             buffer = DecoderSharedMemory(decoder_state)
             raw_data = buffer.get_block()
         
-            audioL, audioR = decoder.block_decode(raw_data, decoder_state.post_audio_len, measure_perf)
-        
-            # create a new buffer with the trimmed offsets
-            decoder_state.pre_audio_trimmed = len(audioL)
-            buffer = DecoderSharedMemory(decoder_state)
+            audioL, audioR = decoder.block_decode(raw_data, decoder_state.block_audio_final_size, decoder_state.block_audio_final_overlap, measure_perf)
         
             if measure_perf: start_final_audio_copy = perf_counter()
             # copy the audio data into the shared buffer

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -196,11 +196,11 @@ class DecoderSharedMemory():
         self.block_end_overlap_bytes = self.block_end_overlap_len * self.block_dtype_item_size
 
     @staticmethod
-    def get_shared_memory(block_size, block_audio_size, name, block_dtype=np.int16, audio_dtype=REAL_DTYPE):
+    def get_shared_memory(block_size, block_audio_size, block_audio_overlap, name, block_dtype=np.int16, audio_dtype=REAL_DTYPE):
         max_audio_size = (block_audio_size * np.dtype(audio_dtype).itemsize) * 6
         block_size_with_audio = (
             to_aligned_offset(block_size * np.dtype(block_dtype).itemsize) +
-            to_aligned_offset(block_audio_size * np.dtype(audio_dtype).itemsize) * 2
+            to_aligned_offset(((block_audio_overlap * 4) + block_audio_size) * np.dtype(audio_dtype).itemsize) * 2
         )
 
         byte_size = max(max_audio_size, block_size_with_audio) + ALIGNMENT * 16

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -19,42 +19,43 @@ NumbaBlockArray = numba.types.Array(numba.types.int16, 1, "C", aligned=True)
 
 @dataclass
 class DecoderState:
-    def __init__(self, decoder, buffer_name, block_len, block_num, is_last_block):
-        block_sizes = decoder.set_block_sizes(block_len, is_last_block)
+    def __init__(self, decoder, buffer_name, block_size, block_num, is_last_block):
+        block_sizes = decoder.set_block_sizes(block_size, is_last_block)
 
         self.name = buffer_name
         self.block_num = block_num
         self.is_last_block = is_last_block
-        self.pre_audio_len = block_sizes["block_audio_len"]
-        self.pre_audio_trimmed = block_sizes["block_audio_len"]
-        self.post_audio_len = block_sizes["block_audio_final_len"]
-        self.post_audio_trimmed = block_sizes["block_audio_final_len"]
-        self.stereo_audio_len = block_sizes["block_audio_final_len"] * 2
-        self.stereo_audio_trimmed = block_sizes["block_audio_final_len"] * 2
-        self.block_len = block_sizes["block_len"]
-        self.block_overlap = block_sizes["block_overlap"]
-        self.block_resampled_len = block_sizes["block_resampled_len"]
-        self.block_resampled_trimmed = block_sizes["block_resampled_len"]
-        self.block_audio_final_overlap = block_sizes["block_audio_final_overlap"]
+
+        # block data for input rf 
         self.block_dtype = np.int16
+        self.block_size = block_sizes["block_size"]
+        self.block_overlap = block_sizes["block_overlap"]
+
+        # block data for demodulated audio @ 192000Hz
         self.audio_dtype = REAL_DTYPE
+        self.block_audio_size = block_sizes["block_audio_size"]
+
+        # block data for resampled audio @ user set audio rate
+        self.block_audio_final_size = block_sizes["block_audio_final_size"]
+        self.block_audio_final_overlap = block_sizes["block_audio_final_overlap"]
+        self.block_audio_final_len = self.block_audio_final_size - self.block_audio_final_overlap * 2
+        self.stereo_audio_len = self.block_audio_final_len * 2
 
     name: str
     block_num: int
     is_last_block: bool
-    pre_audio_len: int
-    pre_audio_trimmed: int
-    post_audio_len: int
-    post_audio_trimmed: int
-    stereo_audio_len: int
-    stereo_audio_trimmed: int
-    block_len: int
-    block_overlap: int
-    block_resampled_len: int
-    block_resampled_trimmed: int
-    block_audio_final_overlap: int
+
     block_dtype: np.dtype
+    block_size: int
+    block_overlap: int
+
     audio_dtype: np.dtype
+    block_audio_size: int
+
+    block_audio_final_size: int
+    block_audio_final_overlap: int
+    block_audio_final_len: int
+    stereo_audio_len: int
 
 def to_aligned_offset(size):
     alignment = ALIGNMENT
@@ -81,7 +82,7 @@ class PostProcessorSharedMemory():
         self.unlink = self.shared_memory.unlink
 
         self.audio_dtype = decoder_state.audio_dtype
-        self.channel_len = decoder_state.post_audio_len
+        self.channel_len = decoder_state.block_audio_final_len
         self.audio_dtype_item_size = np.dtype(self.audio_dtype).itemsize
 
         ### Post Processing Memory
@@ -164,10 +165,7 @@ class DecoderSharedMemory():
         self.audio_dtype = decoder_state.audio_dtype
         self.audio_dtype_item_size = np.dtype(self.audio_dtype).itemsize
 
-        self.block_resampled_trimmed = decoder_state.block_resampled_trimmed
-        self.pre_audio_trimmed = decoder_state.pre_audio_trimmed
-        self.post_audio_trimmed = decoder_state.post_audio_trimmed
-        self.stereo_audio_trimmed = decoder_state.stereo_audio_trimmed
+        self.block_audio_len = decoder_state.block_audio_size
 
         ### Decoder Memory
         # |--pre_left--|--pre_right--|-------------------------------raw_data-------------------------------|
@@ -175,11 +173,11 @@ class DecoderSharedMemory():
 
         # pre left
         self.l_pre_offset = 0
-        self.l_pre_len = decoder_state.pre_audio_len
+        self.l_pre_len = decoder_state.block_audio_size
         self.l_pre_bytes = self.l_pre_len * self.audio_dtype_item_size
         # pre right
         self.r_pre_offset = to_aligned_offset(self.l_pre_offset + self.l_pre_bytes)
-        self.r_pre_len = decoder_state.pre_audio_len
+        self.r_pre_len = decoder_state.block_audio_size
         self.r_pre_bytes = self.r_pre_len * self.audio_dtype_item_size
 
         ## raw data in
@@ -189,7 +187,7 @@ class DecoderSharedMemory():
         self.block_start_overlap_bytes = self.block_start_overlap_len * self.block_dtype_item_size
         # block data
         self.block_offset = self.block_start_overlap_offset + self.block_start_overlap_bytes
-        self.block_len = decoder_state.block_len - decoder_state.block_overlap
+        self.block_len = decoder_state.block_size - (decoder_state.block_overlap * 2)
         self.block_bytes = self.block_len * self.block_dtype_item_size
         # second overlap
         self.block_end_overlap_offset = self.block_offset + self.block_bytes
@@ -197,19 +195,14 @@ class DecoderSharedMemory():
         self.block_end_overlap_bytes = self.block_end_overlap_len * self.block_dtype_item_size
 
     @staticmethod
-    def get_shared_memory(block_len, block_overlap, block_resampled_len, pre_audio_len, name, block_dtype=np.int16, audio_dtype=REAL_DTYPE):
-        max_audio_size = (pre_audio_len * np.dtype(audio_dtype).itemsize) * 6
+    def get_shared_memory(block_size, block_audio_size, name, block_dtype=np.int16, audio_dtype=REAL_DTYPE):
+        max_audio_size = (block_audio_size * np.dtype(audio_dtype).itemsize) * 6
         block_size_with_audio = (
-            to_aligned_offset(block_len * np.dtype(block_dtype).itemsize) + 
-            to_aligned_offset(block_overlap * np.dtype(block_dtype).itemsize) * 2 + 
-            to_aligned_offset(pre_audio_len * np.dtype(audio_dtype).itemsize) * 2
-        )
-        resampled_size_with_audio = (
-            to_aligned_offset(block_resampled_len * np.dtype(audio_dtype).itemsize) + 
-            to_aligned_offset(pre_audio_len * np.dtype(audio_dtype).itemsize) * 2
+            to_aligned_offset(block_size * np.dtype(block_dtype).itemsize) +
+            to_aligned_offset(block_audio_size * np.dtype(audio_dtype).itemsize) * 2
         )
 
-        byte_size = max(max_audio_size, block_size_with_audio, resampled_size_with_audio) + ALIGNMENT * 16
+        byte_size = max(max_audio_size, block_size_with_audio) + ALIGNMENT * 16
 
         # allow more than one instance to run at a time
         system_random = SystemRandom()
@@ -249,10 +242,10 @@ class DecoderSharedMemory():
         return np.ndarray(self.block_end_overlap_len, dtype=self.block_dtype, offset=self.block_end_overlap_offset, buffer=self.buf)
     
     def get_pre_left(self) -> np.array:
-        return np.ndarray(self.pre_audio_trimmed, dtype=self.audio_dtype, offset=self.l_pre_offset, buffer=self.buf)
+        return np.ndarray(self.block_audio_len, dtype=self.audio_dtype, offset=self.l_pre_offset, buffer=self.buf)
     
     def get_pre_right(self) -> np.array:
-        return np.ndarray(self.pre_audio_trimmed, dtype=self.audio_dtype, offset=self.r_pre_offset, buffer=self.buf)
+        return np.ndarray(self.block_audio_len, dtype=self.audio_dtype, offset=self.r_pre_offset, buffer=self.buf)
     
     @staticmethod
     @njit(numba.types.void(NumbaAudioArray, NumbaAudioArray, numba.types.int64), cache=True, fastmath=True, nogil=True)


### PR DESCRIPTION
### Fixes
* Disable integer division for overlap when input sample rate is not dividable by the output sample rate, i.e. `--cxadc`
* Tune block overlap logic to be a bit more accurate.
* Calculate peak gain only for audio that is written to the output file.

### Enhancements
* Update intermediate frequency audio sample rate so FFT operations operate on data chunks sized in a power of 2 for efficiency.

### Benchmark

```bash
$ ffmpeg -i test.rf.flac -f s16le -acodec pcm_s16le - | \
~/git/vhs-decode/hifi-decode -n -t 32 -f 20 --overwrite --auto_fine_tune off --normalize - test.hifi.flac
```

<details> 
<summary>Computer Specs</summary>

```bash
$ lscpu
CPU(s):                   192
  On-line CPU(s) list:    0-191
Vendor ID:                GenuineIntel
  Model name:             Intel(R) Xeon(R) CPU E7-8890 v4 @ 2.20GHz
    CPU family:           6
    Model:                79
    Thread(s) per core:   2
    Core(s) per socket:   24
    Socket(s):            4
    Stepping:             1
```

</details>

#### Before Changes
```
- Decoding speed: 61733 kFrames/s (1.54x), 0 blocks enqueued
- Input position: 0:29:28.403
- Audio position: 0:29:28.403
- Audio buffer  : 0:00:00.000
- Wall time     : 0:19:05.831

Peak gain is 72.92%. Adjusting by 137.04%, please wait...
Progress [########################################] 100.00%

Decode finished, seconds elapsed: 1164
Decode finished successfully
```

#### After Changes
```
- Decoding speed: 76518 kFrames/s (1.91x), 0 blocks enqueued
- Input position: 0:29:28.403
- Audio position: 0:29:28.403
- Audio buffer  : 0:00:00.000
- Wall time     : 0:15:24.437

Peak gain is 71.56%. Adjusting by 139.65%, please wait...
Progress [########################################] 100.00%

Decode finished, seconds elapsed: 945
Decode finished successfully
```