### PR TITLE
Build on older distro

### DIFF
--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: oraclelinux:8
-      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw
+      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw --security-opt apparmor:unconfined --privileged
 
     steps:
       - name: Setup environment

--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -6,9 +6,16 @@ on:
 jobs:
   build-decode:
     name: Build vhs-decode (x86_64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: oraclelinux:8
+      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw
 
     steps:
+      - name: Setup environment
+        run: |
+          dnf install --assumeyes git python3.12-pip gcc-c++ file
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -31,7 +31,7 @@ jobs:
           cp resources/appimage/decode/vhs-decode.desktop _build_appimage/
           cp resources/appimage/decode/vhs-decode.appdata.xml _build_appimage/
 
-          echo "${{ github.workspace }}[hifi_gui,hifi_gnuradio]" > _build_appimage/requirements.txt
+          echo "$(pwd)[hifi_gui,hifi_gnuradio]" > _build_appimage/requirements.txt
 
           python-appimage build app -p 3.12 _build_appimage
 

--- a/.github/workflows/build_linux_tools.yml
+++ b/.github/workflows/build_linux_tools.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: oraclelinux:8
-      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw
+      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw --security-opt apparmor:unconfined --privileged
 
     steps:
       - name: Set up DNF download cache

--- a/.github/workflows/build_linux_tools.yml
+++ b/.github/workflows/build_linux_tools.yml
@@ -35,7 +35,7 @@ jobs:
           dnf install --assumeyes --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
           dnf install --assumeyes --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm
           FORCE_DNF=1 /usr/bin/crb enable
-          dnf --assumeyes install git file qt5-qtbase-devel qwt-qt5-devel fftw-devel ffmpeg-devel ffmpeg pkgconf-pkg-config make cmake sox python3-pip gcc-c++ python3-devel
+          dnf --assumeyes install git file xz qt5-qtbase-devel qwt-qt5-devel fftw-devel ffmpeg-devel ffmpeg pkgconf-pkg-config make cmake sox python3-pip gcc-c++ python3-devel
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_linux_tools.yml
+++ b/.github/workflows/build_linux_tools.yml
@@ -17,22 +17,30 @@ env:
 jobs:
   build-tbc-tools:
     name: Build tbc-tools (x86_64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: oraclelinux:8
+      options: --cap-add SYS_ADMIN --cap-add MKNOD --device /dev/fuse:mrw
 
     steps:
+      - name: Set up DNF download cache
+        id: dnf-cache
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: dnfcache
+          
+      - name: Setup environment
+        run: |
+          dnf install --assumeyes --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm
+          dnf install --assumeyes --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm
+          FORCE_DNF=1 /usr/bin/crb enable
+          dnf --assumeyes install git file qt5-qtbase-devel qwt-qt5-devel fftw-devel ffmpeg-devel ffmpeg pkgconf-pkg-config make cmake sox python3-pip gcc-c++ python3-devel
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Setup environment
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: >-
-            git make cmake pkg-config openssl
-            qt5-qmake qtbase5-dev libqwt-qt5-dev libfftw3-dev
-            ffmpeg libavformat-dev libavcodec-dev libavutil-dev
-          version: 1.0
 
       - name: Create release directory
         run: mkdir release/
@@ -55,8 +63,9 @@ jobs:
 
           chmod +x ${{ env.APPIMAGE_FILE }} ${{ env.APPIMAGE_PLUGIN_FILE }} ${{ env.APPIMAGE_QT_FILE }}
 
+          EXTRA_QT_MODULES="core;gui;opengl;svg;widgets" ./${{ env.APPIMAGE_QT_FILE }} --appdir AppDir
+
           ./${{ env.APPIMAGE_FILE }} \
-          --plugin qt \
           --desktop-file resources/appimage/tools/tbc-tools.desktop \
           --icon-file assets/icons/vhs-decode.png \
           --appdir AppDir/ \


### PR DESCRIPTION
The upgrade to Ubuntu 22.04's glibc 2.35 cuts off quite some distros, including popular ones that still have support:

- Debian 11 (supported by Debian LTS)
- Every version of Enterprise Linux, as even EL9 runs on glibc 2.34
- Amazon Linux 2023 (latest release, default on AWS)