### PR TITLE
hifi-decode: quadrature demodulation

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -431,7 +431,6 @@ class FMdemod:
         prev_unwrapped = prev_angle
 
         for i in range(1, len(in_rf) - order):
-            assert i >= 0
             #
             # mix in i/q
             #
@@ -582,9 +581,7 @@ class SpectralNoiseReduction:
             sig_stft_smooth_x, sig_stft_smooth_y = sig_stft_smooth.shape
 
             for x in range(sig_stft_smooth_x):
-                assert x >= 0
                 for y in range(sig_stft_smooth_y):
-                     assert y >= 0
                      sig_stft_smooth[x][y] = 1 / (1 + np.exp(-((abs_sig_stft[x][y] - sig_stft_smooth[x][y]) / sig_stft_smooth[x][y] + -thresh_n_mult_nonstationary) * sigmoid_slope_nonstationary))
         
         @staticmethod
@@ -603,9 +600,7 @@ class SpectralNoiseReduction:
             sig_mask_x, sig_mask_y = sig_mask.shape
 
             for x in range(sig_mask_x):
-                assert x >= 0
                 for y in range(sig_mask_y):
-                    assert y >= 0
                     sig_stft[x][y] = sig_stft[x][y] * (sig_mask[x][y] * prop_decrease + 1 * (1.0 - prop_decrease))
     
         def spectral_gating_nonstationary_single_channel(self, chunk):
@@ -704,7 +699,6 @@ class SpectralNoiseReduction:
             chunk_data = chunks[i]
 
             for j in range(len(chunk_data)):
-                assert j >= 0
                 chunk[j+chunk_offset] = chunk_data[j]
 
             chunk_offset += len(chunk_data)
@@ -712,7 +706,6 @@ class SpectralNoiseReduction:
         # add the input audio to the chunks
         audio_copy = np.empty_like(audio)
         for i in range(len(audio)):
-            assert i >= 0
             audio_copy[i] = audio[i]
             chunk[i+chunk_offset] = audio[i]
 
@@ -854,7 +847,6 @@ class NoiseReduction:
         levels = np.clip(rectified, 0.0, 1.0)
 
         for i in range(len(levels)):
-            assert i >= 0
             out[i] = levels[i] ** REAL_DTYPE(log_strength)
 
     @staticmethod
@@ -886,7 +878,6 @@ class NoiseReduction:
         #      Perhaps a limiter with slow attack and release would keep the signal within the expander's range.
         gate = np.clip(rsC * nr_env_gain, a_min=0.0, a_max=1.0)
         for i in range(len(audio)):
-            assert i >= 0
             audio_out[i] = audio[i] * gate[i]
 
     def rs_envelope(self, raw_data):
@@ -1276,7 +1267,6 @@ class HiFiDecode:
         two_pi_right = 2 * pi * carrier_right
 
         for i in range(size):
-            assert i >= 0
             t = i / sample_rate
 
             i_left[i] = cos(two_pi_left * t) #    In-phase
@@ -1565,7 +1555,6 @@ class HiFiDecode:
     def smooth(data_in: np.array, data_out: np.array, half_window: int):
         data_in_len = len(data_in)
         for i in range(data_in_len):
-            assert i >= 0
             start = max(0, i - half_window)
             end = min(data_in_len, i + half_window + 1)
             data_out[i] = np.mean(data_in[start:end])  # Apply moving average
@@ -1711,18 +1700,15 @@ class HiFiDecode:
     )
     def cancelDC_clip_trim(audio: np.array, clip: float, trim: int) -> float:
         for i in range(trim):
-            assert i >= 0
             audio[i] = 0
 
         for i in range(len(audio) - trim, len(audio)):
-            assert i >= 0
             audio[i] = 0
 
         # TODO: change this to roll off at a low frequency rather than just the mean
         dc = REAL_DTYPE(np.mean(audio))
 
         for i in range(trim, len(audio) - trim):
-            assert i >= 0
             audio[i] = (audio[i] - dc) / REAL_DTYPE(clip)
 
         return dc
@@ -1835,7 +1821,6 @@ class HiFiDecode:
     )
     def adjust_gain(audio: np.array, gain: float) -> np.array:
         for i in range(len(audio)):
-            assert i >= 0
             audio[i] = audio[i] * gain
 
     @staticmethod

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -44,6 +44,9 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_NR_ENVELOPE_GAIN,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
+    DEMOD_QUADRATURE,
+    DEMOD_HILBERT,
+    DEFAULT_DEMOD,
 )
 
 
@@ -61,6 +64,7 @@ class MainUIParameters:
         self.standard: str = "PAL"
         self.format: str = "VHS"
         self.audio_mode: str = "Stereo"
+        self.demod_type: str = DEFAULT_DEMOD.capitalize()
         self.input_sample_rate: float = 40.0
         self.input_file: str = ""
         self.output_file: str = ""
@@ -82,6 +86,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.standard = "PAL" if decode_options["standard"] == "p" else "NTSC"
     values.format = "VHS" if decode_options["format"] == "vhs" else "Video8/Hi8"
     values.audio_mode = "Stereo"
+    values.demod_type = decode_options["demod_type"].capitalize()
     values.input_sample_rate = decode_options["input_rate"]
     values.input_file = decode_options["input_file"]
     values.output_file = decode_options["output_file"]
@@ -98,7 +103,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "standard": "p" if values.standard == "PAL" else "n",
         "format": "vhs" if values.format == "VHS" else "8mm",
         "preview": values.preview,
-        "original": False,
+        "demod_type": values.demod_type.lower(),
         "noise_reduction": values.noise_reduction,
         "auto_fine_tune": values.automatic_fine_tuning,
         "nr_side_gain": values.sidechain_gain * 100.0,
@@ -307,6 +312,14 @@ class HifiUi(QMainWindow):
         audio_mode_layout.addWidget(audio_mode_label)
         audio_mode_layout.addWidget(self.audio_mode_combo)
 
+        # Adds demodulation options
+        demod_type_layout = QHBoxLayout()
+        demod_type_label = QLabel("FM Demodulation Type:")
+        self.demod_type_combo = QComboBox(self)
+        self.demod_type_combo.addItems([DEMOD_QUADRATURE.capitalize(), DEMOD_HILBERT.capitalize()])
+        demod_type_layout.addWidget(demod_type_label)
+        demod_type_layout.addWidget(self.demod_type_combo)
+
         # adds input sample rate layout
         input_samplerate_layout = QHBoxLayout()
         input_samplerate_label = QLabel("Input Sample Rate MHz:")
@@ -343,6 +356,7 @@ class HifiUi(QMainWindow):
         middle_layout.addLayout(standard_layout)
         middle_layout.addLayout(format_layout)
         middle_layout.addLayout(audio_mode_layout)
+        middle_layout.addLayout(demod_type_layout)
         middle_layout.addLayout(samplerate_layout)
 
         # Bottom partition layout (horizontal)
@@ -474,6 +488,11 @@ class HifiUi(QMainWindow):
             self.audio_mode_combo.findText(values.audio_mode)
         )
 
+        self.demod_type_combo.setCurrentText(values.demod_type)
+        self.demod_type_combo.setCurrentIndex(
+            self.demod_type_combo.findText(values.demod_type)
+        )
+
         self.input_sample_rate = values.input_sample_rate / 1e6
         found_rate = False
         for i, rate in enumerate(self._input_combo_rates):
@@ -505,6 +524,7 @@ class HifiUi(QMainWindow):
         values.standard = self.standard_combo.currentText()
         values.format = self.format_combo.currentText()
         values.audio_mode = self.audio_mode_combo.currentText()
+        values.demod_type = self.demod_type_combo.currentText()
         values.input_sample_rate = self.input_sample_rate
         values.input_file = self.input_file
         values.output_file = self.output_file

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -375,6 +375,7 @@ class UnSigned16BitFileReader(io.RawIOBase):
     )
     def uint16_to_int16(uint16_in, int16_out):
         for i in range(len(uint16_in)):
+            assert i >= 0
             int16_out[i] = uint16_in[i] - 2**15
 
     def readable(self):
@@ -679,6 +680,7 @@ class PostProcessor:
     )
     def normalize(gain, _, audio):
         for i in range(len(audio)):
+            assert i >= 0
             audio[i] = audio[i] * gain
 
     @staticmethod
@@ -834,11 +836,13 @@ class PostProcessor:
             trim_samples = int(0.0015 * sample_rate)
             start_sample = trim_samples
             for i in range(trim_samples):
+                assert i >= 0
                 stereo[(i * 2)] = 0
                 stereo[(i * 2) + 1] = 0
 
         channel_length = len(audioL)
         for i in range(start_sample, channel_length):
+            assert i >= 0
             audioLSample = audioL[i]
             stereo[(i * 2)] = audioLSample
             gain = abs(audioLSample)
@@ -1013,6 +1017,7 @@ class SoundDeviceProcess:
     )
     def build_stereo(interleaved: np.array, stacked) -> np.array:
         for i in range(0, len(stacked)):
+            assert i >= 0
             stacked[i][0] = interleaved[i * 2] * 2**15
             stacked[i][1] = interleaved[i * 2 + 1] * 2**15
 

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -52,6 +52,9 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
     REAL_DTYPE,
+    DEMOD_QUADRATURE,
+    DEMOD_HILBERT,
+    DEFAULT_DEMOD,
 )
 from vhsdecode.hifi.TimeProgressBar import TimeProgressBar
 import io
@@ -111,15 +114,15 @@ parser.add_argument(
     dest="preview",
     action="store_true",
     default=False,
-    help="Use preview quality (faster and noisier)",
+    help="Preview the audio through your speakers as it decodes. Uses preview quality (faster and noisier)",
 )
 
 parser.add_argument(
-    "--original",
-    dest="original",
-    action="store_true",
-    default=False,
-    help="Use the same FM demod as vhs-decode",
+    "--demod",
+    dest="demod_type",
+    type=str.lower,
+    default=DEFAULT_DEMOD,
+    help=f"Set the FM demodulation type (default: {DEFAULT_DEMOD}) ({DEMOD_QUADRATURE}, {DEMOD_HILBERT})",
 )
 
 parser.add_argument(
@@ -1538,7 +1541,7 @@ def main() -> int:
         "format": "vhs" if not args.format_8mm else "8mm",
         "preview": args.preview,
         "preview_available": SOUNDDEVICE_AVAILABLE,
-        "original": args.original,
+        "demod_type": args.demod_type,
         "resampler_quality": resampler_quality if not args.preview else "low",
         "spectral_nr_amount": args.spectral_nr_amount if not args.preview else 0,
         "head_switching_interpolation": args.head_switching_interpolation == "on",

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1124,7 +1124,7 @@ async def decode_parallel(
     threads: int = 8,
     ui_t: Optional[AppWindow] = None,
 ):
-    decoder = HiFiDecode(options=decode_options)
+    decoder = HiFiDecode(options=decode_options, is_main_process=True)
     # TODO: reprocess data read in this step
     if bias_guess:
         LCRef, RCRef = guess_bias(

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -325,7 +325,6 @@ class DecoderSharedMemory:
     def copy_data_float32(src: np.array, dst: np.array, length: int):
         # ctypes.memmove(dst.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), src.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), length)
         for i in range(length):
-            assert i >= 0
             dst[i] = src[i]
 
     @staticmethod
@@ -341,7 +340,6 @@ class DecoderSharedMemory:
     )
     def copy_data_int16(src: np.array, dst: np.array, length: int):
         for i in range(length):
-            assert i >= 0
             dst[i] = src[i]
 
     @staticmethod
@@ -360,7 +358,6 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, dst_offset: int, length: int
     ):
         for i in range(length):
-            assert i >= 0
             dst[i + dst_offset] = src[i]
 
     @staticmethod
@@ -379,7 +376,6 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, dst_offset: int, length: int
     ):
         for i in range(length):
-            assert i >= 0
             dst[i + dst_offset] = src[i]
 
     @staticmethod
@@ -395,7 +391,6 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, src_offset: int, length: int
     ):
         for i in range(length):
-            assert i >= 0
             dst[i] = src[i + src_offset]
 
 

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -363,6 +363,24 @@ class DecoderSharedMemory:
     @staticmethod
     @njit(
         numba.types.void(
+            NumbaAudioArray,
+            NumbaAudioArray,
+            numba.types.int64,
+            numba.types.int64,
+        ),
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def copy_data_dst_offset_float32(
+        src: np.array, dst: np.array, dst_offset: int, length: int
+    ):
+        for i in range(length):
+            dst[i + dst_offset] = src[i]
+
+    @staticmethod
+    @njit(
+        numba.types.void(
             NumbaAudioArray, NumbaAudioArray, numba.types.int64, numba.types.int64
         ),
         cache=True,

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -325,6 +325,7 @@ class DecoderSharedMemory:
     def copy_data_float32(src: np.array, dst: np.array, length: int):
         # ctypes.memmove(dst.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), src.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), length)
         for i in range(length):
+            assert i >= 0
             dst[i] = src[i]
 
     @staticmethod
@@ -340,6 +341,7 @@ class DecoderSharedMemory:
     )
     def copy_data_int16(src: np.array, dst: np.array, length: int):
         for i in range(length):
+            assert i >= 0
             dst[i] = src[i]
 
     @staticmethod
@@ -358,6 +360,7 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, dst_offset: int, length: int
     ):
         for i in range(length):
+            assert i >= 0
             dst[i + dst_offset] = src[i]
 
     @staticmethod
@@ -376,6 +379,7 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, dst_offset: int, length: int
     ):
         for i in range(length):
+            assert i >= 0
             dst[i + dst_offset] = src[i]
 
     @staticmethod
@@ -391,6 +395,7 @@ class DecoderSharedMemory:
         src: np.array, dst: np.array, src_offset: int, length: int
     ):
         for i in range(length):
+            assert i >= 0
             dst[i] = src[i + src_offset]
 
 


### PR DESCRIPTION
* Add quadrature FM demodulation.
  * It seems to be faster and sounds better than the hilbert version. Since the quality is better, it's defaulted in this PR. Users can switch back to the existing hilbert version by supplying `--demod hilbert` if they have issues.
  * I was also able to remove the RF resampling when using the quadrature method since there is no FFT step requiring a chunk size at a power of 2. This may improve quality to demodulate at the native capture rate. Speed is about the same for each thread: there is no longer time spent on resampling, but there is now more time spent on demodulating.
  * Quadrature demodulation uses `float64` in the demodulation logic with limited performance impact. This helps to eliminate a very low, but measurable noise floor that was introduced with `float32` precision.
  * Multi-processing is significantly faster with quadrature demodulation, and performance scales up the more cpu cores that are added. The bottleneck in the pipeline is no longer the demodulation workers, but is the spectral noise reduction.
    * (189 threads on 192 core machine)
     ```
     - Decoding speed: 209441 kFrames/s (5.24x), 0 blocks enqueued
     - Input position: 1:39:59.899
     - Audio position: 1:39:59.899
     - Audio buffer  : 0:00:00.000
     - Wall time     : 0:19:05.887

     Peak gain is 62.41%. Adjusting by 160.14%, please wait...
     Progress [########################################] 100.00%

     Decode finished, seconds elapsed: 1194
     Decode finished successfully
     ```
* Replace `--original` option with `--demod` which allows selection of the two different demodulation methods `quadrature` (currently defaulted) and `hilbert`, the existing method.
* Optimize spectral noise reduction code.
* Use a bit less memory when allocating shared memory.