### PR TITLE
ld-ldf-reader Windows support

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,8 +3,16 @@
 	"name": "vhs-decode",
 	"license": "GPL-3.0+",
 	"dependencies": [
-	"qwt",
-	"fftw3",
-	"getopt"
+		"qwt",
+		"fftw3",
+		"getopt",
+		{
+			"name": "ffmpeg",
+			"default-features": false,
+			"features": [
+				"avcodec",
+				"avformat"
+			]
+		}
 	]
 }


### PR DESCRIPTION
* Add ffmpeg dependencies for ld-ldf-reader Windows build
* This should be merged before pull in changes from happycube/ld-decode#926