### PR TITLE
hifi-decode: Add AFE and expander tunable parameters, update gui, update help menu

### DIFF
--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -22,8 +22,7 @@ try:
         QSpinBox,
         QFrame,
         QSizePolicy,
-        QGridLayout,
-        QToolButton
+        QGridLayout
     )
     from PyQt6 import QtGui, QtCore
 except ImportError:
@@ -46,8 +45,7 @@ except ImportError:
         QSpinBox,
         QFrame,
         QSizePolicy,
-        QGridLayout,
-        QToolButton
+        QGridLayout
     )
     from PyQt5 import QtGui, QtCore
 

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -94,6 +94,7 @@ class MainUIParameters:
         self.spectral_nr_amount = DEFAULT_SPECTRAL_NR_AMOUNT
         self.noise_reduction: bool = True
         self.automatic_fine_tuning: bool = True
+        self.bias_guess: bool = False
         self.grc = False
         self.audio_sample_rate: int = 48000
         self.standard: str = "NTSC"
@@ -128,6 +129,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.spectral_nr_amount = decode_options["spectral_nr_amount"]
     values.noise_reduction = decode_options["noise_reduction"]
     values.automatic_fine_tuning = decode_options["auto_fine_tune"]
+    values.bias_guess = decode_options["bias_guess"]
     values.audio_sample_rate = decode_options["audio_rate"]
     values.standard = "PAL" if decode_options["standard"] == "p" else "NTSC"
     values.format = "VHS" if decode_options["format"] == "vhs" else "Video8/Hi8"
@@ -150,6 +152,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "demod_type": values.demod_type.lower(),
         "noise_reduction": values.noise_reduction,
         "auto_fine_tune": values.automatic_fine_tuning,
+        "bias_guess": values.bias_guess,
         "nr_expander_gain": values.nr_expander_gain,
         "nr_expander_strength": values.nr_expander_strength,
         "nr_attack_tau": values.nr_attack_tau,
@@ -450,6 +453,16 @@ class HifiUi(QMainWindow):
         advanced_format_options_frame = LabeledFrame(self, "Advanced Format Options")
         layout.addLayout(advanced_format_options_frame)
 
+        # auto fine tune
+        self.automatic_fine_tuning_checkbox = QCheckBox("Automatic fine tuning")
+        self.automatic_fine_tuning_checkbox.setToolTip("Automatically adjust bias during decode. Not applicable to Quadrature demodulation.")
+        advanced_format_options_frame.inner_layout.addWidget(self.automatic_fine_tuning_checkbox)
+
+        # bias guess
+        self.bias_guess_checkbox = QCheckBox("Bias Guess")
+        self.bias_guess_checkbox.setToolTip("Attempt to guess the carrier frequencies")
+        advanced_format_options_frame.inner_layout.addWidget(self.bias_guess_checkbox)
+
         # left carrier adjustment
         afe_left_carrier_layout = QHBoxLayout()
         afe_left_carrier_spinbox_label = QLabel("Left Carrier (Hz)")
@@ -495,10 +508,6 @@ class HifiUi(QMainWindow):
 
         demodulation_options_frame = LabeledFrame(self, "Demodulation Options")
         layout.addLayout(demodulation_options_frame)
-
-        # auto fine tune
-        self.automatic_fine_tuning_checkbox = QCheckBox("Automatic fine tuning")
-        demodulation_options_frame.inner_layout.addWidget(self.automatic_fine_tuning_checkbox)
 
         # demodulation type option
         demod_type_layout = QHBoxLayout()
@@ -686,6 +695,7 @@ class HifiUi(QMainWindow):
             values.head_switching_interpolation
         )
         self.automatic_fine_tuning_checkbox.setChecked(values.automatic_fine_tuning)
+        self.bias_guess_checkbox.setChecked(values.bias_guess)
         self.sample_rate_combo.setCurrentText(str(values.audio_sample_rate))
         self.sample_rate_combo.setCurrentIndex(
             self.sample_rate_combo.findText(str(values.audio_sample_rate))
@@ -756,6 +766,7 @@ class HifiUi(QMainWindow):
             self.head_switching_interpolation_checkbox.isChecked()
         )
         values.automatic_fine_tuning = self.automatic_fine_tuning_checkbox.isChecked()
+        values.bias_guess = self.bias_guess_checkbox.isChecked()
         values.audio_sample_rate = int(self.sample_rate_combo.currentText())
         values.standard = self.standard_combo.currentText()
         values.format = self.format_combo.currentText()

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -44,6 +44,15 @@ except ImportError:
 
 from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_NR_EXPANDER_GAIN,
+    DEFAULT_NR_EXPANDER_LOG_STRENGTH,
+    DEFAULT_NR_EXPANDER_ATTACK_TAU,
+    DEFAULT_NR_EXPANDER_RELEASE_TAU,
+    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_NR_DEEMPHASIS_TAU_2,
+    DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEMOD_QUADRATURE,
@@ -63,6 +72,15 @@ class MainUIParameters:
         self.volume: float = 1.0
         self.normalize = False
         self.nr_expander_gain: float = DEFAULT_NR_EXPANDER_GAIN / 100.0
+        self.nr_expander_strength: float = DEFAULT_NR_EXPANDER_LOG_STRENGTH
+        self.nr_attack_tau: float = DEFAULT_NR_EXPANDER_ATTACK_TAU
+        self.nr_release_tau: float = DEFAULT_NR_EXPANDER_RELEASE_TAU
+        self.nr_weighting_shelf_low_tau: float = DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1
+        self.nr_weighting_shelf_high_tau: float = DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2
+        self.nr_weighting_db_per_octave: float = DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE
+        self.nr_deemphasis_low_tau: float = DEFAULT_NR_DEEMPHASIS_TAU_1
+        self.nr_deemphasis_high_tau: float = DEFAULT_NR_DEEMPHASIS_TAU_2
+        self.nr_deemphasis_db_per_octave: float = DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE
         self.afe_vco_deviation = 0
         self.afe_left_carrier = 0
         self.afe_right_carrier = 0
@@ -88,6 +106,15 @@ def decode_options_to_ui_parameters(decode_options):
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
     values.nr_expander_gain = decode_options["nr_expander_gain"] / 100.0
+    values.nr_expander_strength = decode_options["nr_expander_strength"]
+    values.nr_attack_tau = decode_options["nr_attack_tau"]
+    values.nr_release_tau = decode_options["nr_release_tau"]
+    values.nr_weighting_shelf_low_tau = decode_options["nr_weighting_shelf_low_tau"]
+    values.nr_weighting_shelf_high_tau = decode_options["nr_weighting_shelf_high_tau"]
+    values.nr_weighting_db_per_octave = decode_options["nr_weighting_db_per_octave"]
+    values.nr_deemphasis_low_tau = decode_options["nr_deemphasis_low_tau"]
+    values.nr_deemphasis_high_tau = decode_options["nr_deemphasis_high_tau"]
+    values.nr_deemphasis_db_per_octave = decode_options["nr_deemphasis_db_per_octave"]
     values.afe_vco_deviation = decode_options["afe_vco_deviation"]
     values.afe_left_carrier = decode_options["afe_left_carrier"]
     values.afe_right_carrier = decode_options["afe_right_carrier"]
@@ -117,6 +144,15 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "noise_reduction": values.noise_reduction,
         "auto_fine_tune": values.automatic_fine_tuning,
         "nr_expander_gain": values.nr_expander_gain * 100.0,
+        "nr_expander_strength": values.nr_expander_strength,
+        "nr_attack_tau": values.nr_attack_tau,
+        "nr_release_tau": values.nr_release_tau,
+        "nr_weighting_shelf_low_tau": values.nr_weighting_shelf_low_tau,
+        "nr_weighting_shelf_high_tau": values.nr_weighting_shelf_high_tau,
+        "nr_weighting_db_per_octave": values.nr_weighting_db_per_octave,
+        "nr_deemphasis_low_tau": values.nr_deemphasis_low_tau,
+        "nr_deemphasis_high_tau": values.nr_deemphasis_high_tau,
+        "nr_deemphasis_db_per_octave": values.nr_deemphasis_db_per_octave,
         "afe_vco_deviation": values.afe_vco_deviation,
         "afe_left_carrier": values.afe_left_carrier,
         "afe_right_carrier": values.afe_right_carrier,

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -74,7 +74,6 @@ STOP_STATE = 0
 PLAY_STATE = 1
 PAUSE_STATE = 2
 PREVIEW_STATE = 3
-IMMEDIATE_STOP = "IMMEDIATE_STOP"
 
 class MainUIParameters:
     def __init__(self):

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -43,7 +43,7 @@ except ImportError:
     from PyQt5 import QtGui, QtCore
 
 from vhsdecode.hifi.HiFiDecode import (
-    DEFAULT_NR_ENVELOPE_GAIN,
+    DEFAULT_NR_EXPANDER_GAIN,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEMOD_QUADRATURE,
@@ -62,7 +62,7 @@ class MainUIParameters:
     def __init__(self):
         self.volume: float = 1.0
         self.normalize = False
-        self.nr_envelope_gain: float = DEFAULT_NR_ENVELOPE_GAIN / 100.0
+        self.nr_expander_gain: float = DEFAULT_NR_EXPANDER_GAIN / 100.0
         self.afe_vco_deviation = 0
         self.afe_left_carrier = 0
         self.afe_right_carrier = 0
@@ -87,7 +87,7 @@ def decode_options_to_ui_parameters(decode_options):
     values = MainUIParameters()
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
-    values.nr_envelope_gain = decode_options["nr_side_gain"] / 100.0
+    values.nr_expander_gain = decode_options["nr_expander_gain"] / 100.0
     values.afe_vco_deviation = decode_options["afe_vco_deviation"]
     values.afe_left_carrier = decode_options["afe_left_carrier"]
     values.afe_right_carrier = decode_options["afe_right_carrier"]
@@ -116,7 +116,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "demod_type": values.demod_type.lower(),
         "noise_reduction": values.noise_reduction,
         "auto_fine_tune": values.automatic_fine_tuning,
-        "nr_side_gain": values.nr_envelope_gain * 100.0,
+        "nr_expander_gain": values.nr_expander_gain * 100.0,
         "afe_vco_deviation": values.afe_vco_deviation,
         "afe_left_carrier": values.afe_left_carrier,
         "afe_right_carrier": values.afe_right_carrier,
@@ -247,15 +247,15 @@ class HifiUi(QMainWindow):
             5
         )  # Set a reasonable maximum length for display
 
-        # NR Envelope gain dial and numeric textbox
-        nr_envelope_label = QLabel("Expander Gain:")
-        self.nr_envelope_dial = QDial(self)
-        self.nr_envelope_dial.setRange(0, 100)
-        self.nr_envelope_textbox = QLineEdit(self)
-        self.nr_envelope_textbox.setValidator(
+        # NR Expander gain dial and numeric textbox
+        nr_expander_label = QLabel("Expander Gain:")
+        self.nr_expander_dial = QDial(self)
+        self.nr_expander_dial.setRange(0, 100)
+        self.nr_expander_textbox = QLineEdit(self)
+        self.nr_expander_textbox.setValidator(
             QtGui.QDoubleValidator()
         )  # Only allow float input
-        self.nr_envelope_textbox.setMaxLength(
+        self.nr_expander_textbox.setMaxLength(
             5
         )  # Set a reasonable maximum length for display
 
@@ -277,9 +277,9 @@ class HifiUi(QMainWindow):
         upper_layout.addWidget(volume_label)
         upper_layout.addWidget(self.volume_dial)
         upper_layout.addWidget(self.volume_textbox)
-        upper_layout.addWidget(nr_envelope_label)
-        upper_layout.addWidget(self.nr_envelope_dial)
-        upper_layout.addWidget(self.nr_envelope_textbox)
+        upper_layout.addWidget(nr_expander_label)
+        upper_layout.addWidget(self.nr_expander_dial)
+        upper_layout.addWidget(self.nr_expander_textbox)
         upper_layout.addWidget(spectral_nr_amount_label)
         upper_layout.addWidget(self.spectral_nr_amount_dial)
         upper_layout.addWidget(self.spectral_nr_amount_textbox)
@@ -450,9 +450,9 @@ class HifiUi(QMainWindow):
         # Connect events to functions
         self.volume_dial.valueChanged.connect(self.on_volume_changed)
         self.volume_textbox.editingFinished.connect(self.on_volume_textbox_changed)
-        self.nr_envelope_dial.valueChanged.connect(self.on_nr_envelope_gain_changed)
-        self.nr_envelope_textbox.editingFinished.connect(
-            self.on_nr_envelope_textbox_changed
+        self.nr_expander_dial.valueChanged.connect(self.on_nr_expander_gain_changed)
+        self.nr_expander_textbox.editingFinished.connect(
+            self.on_nr_expander_textbox_changed
         )
         self.spectral_nr_amount_dial.valueChanged.connect(self.on_spectral_nr_amount_changed)
         self.spectral_nr_amount_textbox.editingFinished.connect(
@@ -541,8 +541,8 @@ class HifiUi(QMainWindow):
     def setValues(self, values: MainUIParameters):
         self.volume_dial.setValue(int(values.volume * 100 / 2))
         self.volume_textbox.setText(str(values.volume))
-        self.nr_envelope_dial.setValue(int(values.nr_envelope_gain * 100))
-        self.nr_envelope_textbox.setText(str(values.nr_envelope_gain))
+        self.nr_expander_dial.setValue(int(values.nr_expander_gain * 100))
+        self.nr_expander_textbox.setText(str(values.nr_expander_gain))
         self.spectral_nr_amount_dial.setValue(int(values.spectral_nr_amount * 100))
         self.spectral_nr_amount_textbox.setText(str(values.spectral_nr_amount))
         self.normalize_checkbox.setChecked(values.normalize)
@@ -601,7 +601,7 @@ class HifiUi(QMainWindow):
     def getValues(self) -> MainUIParameters:
         values = MainUIParameters()
         values.volume = float(self.volume_textbox.text())
-        values.nr_envelope_gain = float(self.nr_envelope_textbox.text())
+        values.nr_expander_gain = float(self.nr_expander_textbox.text())
         values.afe_vco_deviation = self.afe_vco_deviation_spinbox.value()
         values.afe_left_carrier = self.afe_left_carrier_spinbox.value()
         values.afe_right_carrier = self.afe_right_carrier_spinbox.value()
@@ -647,11 +647,11 @@ class HifiUi(QMainWindow):
         except ValueError:
             pass
 
-    def on_nr_envelope_gain_changed(self, value):
-        self.nr_envelope_textbox.setText(str(value / 100.0))
+    def on_nr_expander_gain_changed(self, value):
+        self.nr_expander_textbox.setText(str(value / 100.0))
 
-    def on_nr_envelope_textbox_changed(self):
-        text = self.nr_envelope_textbox.text()
+    def on_nr_expander_textbox_changed(self):
+        text = self.nr_expander_textbox.text()
         try:
             value = float(text)
             self.spectral_nr_amount_dial.setValue(int(value * 100))

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -74,11 +74,11 @@ class MainUIParameters:
         self.standard: str = "NTSC"
         self.format: str = "VHS"
         self.audio_mode: str = "Stereo"
+        self.resampler_quality = DEFAULT_RESAMPLER_QUALITY
         self.demod_type: str = DEFAULT_DEMOD.capitalize()
         self.input_sample_rate: float = 40.0
         self.input_file: str = ""
         self.output_file: str = ""
-        self.resampler_quality = DEFAULT_RESAMPLER_QUALITY
         self.head_switching_interpolation = "on"
         self.muting = "on"
 
@@ -98,11 +98,11 @@ def decode_options_to_ui_parameters(decode_options):
     values.standard = "PAL" if decode_options["standard"] == "p" else "NTSC"
     values.format = "VHS" if decode_options["format"] == "vhs" else "Video8/Hi8"
     values.audio_mode = "Stereo"
+    values.resampler_quality = decode_options["resampler_quality"]
     values.demod_type = decode_options["demod_type"].capitalize()
     values.input_sample_rate = decode_options["input_rate"]
     values.input_file = decode_options["input_file"]
     values.output_file = decode_options["output_file"]
-    values.resampler_quality = decode_options["resampler_quality"]
     values.head_switching_interpolation = decode_options["head_switching_interpolation"]
     values.muting = decode_options["muting"]
     return values
@@ -263,7 +263,9 @@ class HifiUi(QMainWindow):
         spectral_nr_amount_label = QLabel("Spectral NR:")
         self.spectral_nr_amount_dial = QDial(self)
         self.spectral_nr_amount_dial.setRange(0, 100)
+        self.spectral_nr_amount_dial.setToolTip("Uses \"0\" in Preview Mode")
         self.spectral_nr_amount_textbox = QLineEdit(self)
+        self.spectral_nr_amount_textbox.setToolTip("Uses \"0\" in Preview Mode")
         self.spectral_nr_amount_textbox.setValidator(
             QtGui.QDoubleValidator()
         )  # Only allow float input
@@ -336,6 +338,7 @@ class HifiUi(QMainWindow):
         sample_rate_label = QLabel("Audio Sample Rate Hz:")
         self.sample_rate_combo = QComboBox(self)
         self.sample_rate_combo.addItems(["44100", "48000", "96000", "192000"])
+        self.sample_rate_combo.setToolTip("Uses \"44100\" in Preview Mode")
         samplerate_layout.addWidget(sample_rate_label)
         samplerate_layout.addWidget(self.sample_rate_combo)
 
@@ -362,6 +365,15 @@ class HifiUi(QMainWindow):
         self.audio_mode_combo.addItems(["Stereo", "L", "R", "Stereo MPX", "Sum"])
         audio_mode_layout.addWidget(audio_mode_label)
         audio_mode_layout.addWidget(self.audio_mode_combo)
+
+        # Adds resampler quality layout
+        resampler_quality_layout = QHBoxLayout()
+        resampler_quality_label = QLabel("Audio Resampler Quality:")
+        self.resampler_quality_combo = QComboBox(self)
+        self.resampler_quality_combo.addItems(["High", "Medium", "Low"])
+        self.resampler_quality_combo.setToolTip("Uses \"Low\" in Preview Mode")
+        resampler_quality_layout.addWidget(resampler_quality_label)
+        resampler_quality_layout.addWidget(self.resampler_quality_combo)
 
         # Adds demodulation options
         demod_type_layout = QHBoxLayout()
@@ -407,6 +419,7 @@ class HifiUi(QMainWindow):
         middle_layout.addLayout(standard_layout)
         middle_layout.addLayout(format_layout)
         middle_layout.addLayout(audio_mode_layout)
+        middle_layout.addLayout(resampler_quality_layout)
         middle_layout.addLayout(demod_type_layout)
         middle_layout.addLayout(samplerate_layout)
 
@@ -553,6 +566,10 @@ class HifiUi(QMainWindow):
         self.audio_mode_combo.setCurrentIndex(
             self.audio_mode_combo.findText(values.audio_mode)
         )
+        self.resampler_quality_combo.setCurrentText(values.resampler_quality.title())
+        self.resampler_quality_combo.setCurrentIndex(
+            self.resampler_quality_combo.findText(values.resampler_quality.title())
+        )
 
         self.demod_type_combo.setCurrentText(values.demod_type)
         self.demod_type_combo.setCurrentIndex(
@@ -600,6 +617,7 @@ class HifiUi(QMainWindow):
         values.standard = self.standard_combo.currentText()
         values.format = self.format_combo.currentText()
         values.audio_mode = self.audio_mode_combo.currentText()
+        values.resampler_quality = self.resampler_quality_combo.currentText().lower()
         values.demod_type = self.demod_type_combo.currentText()
         values.input_sample_rate = self.input_sample_rate
         values.input_file = self.input_file

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -48,6 +48,15 @@ from vhsdecode.hifi.HiFiDecode import (
     SpectralNoiseReduction,
     NoiseReduction,
     DEFAULT_NR_EXPANDER_GAIN,
+    DEFAULT_NR_EXPANDER_LOG_STRENGTH,
+    DEFAULT_NR_EXPANDER_ATTACK_TAU,
+    DEFAULT_NR_EXPANDER_RELEASE_TAU,
+    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_NR_DEEMPHASIS_TAU_2,
+    DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
@@ -282,27 +291,95 @@ noise_reduction_options_group.add_argument(
     help=f'Mutes the audio when there is no hifi carrier. (defaults to "on").',
 )
 noise_reduction_options_group.add_argument(
-    "--noise_reduction",
-    dest="noise_reduction",
-    type=str.lower,
-    default="on",
-    help="Set noise reduction block (deemphasis and expansion) on/off",
-)
-noise_reduction_options_group.add_argument(
-    "--NR_expander_gain",
-    dest="NR_expander_gain",
-    type=float,
-    default=DEFAULT_NR_EXPANDER_GAIN,
-    help=f"Sets the noise reduction expander gain (default is {DEFAULT_NR_EXPANDER_GAIN}). "
-    f"Range (20~100): Higher values increase the effect of the expander",
-)
-noise_reduction_options_group.add_argument(
     "--NR_spectral_amount",
     dest="spectral_nr_amount",
     type=float,
     default=DEFAULT_SPECTRAL_NR_AMOUNT,
     help=f"Sets the amount of broadband spectral noise reduction to apply. (default is {DEFAULT_SPECTRAL_NR_AMOUNT}). "
     f"Range (0~1): 0 being off, 1 being full spectral noise reduction",
+)
+noise_reduction_options_group.add_argument(
+    "--noise_reduction",
+    dest="noise_reduction",
+    type=str.lower,
+    default="on",
+    help="Set noise reduction block (deemphasis and expansion) on/off",
+)
+
+expander_options_group = parser.add_argument_group("Expander tuning options (advanced)")
+expander_options_group.add_argument(
+    "--NR_expander_gain",
+    dest="nr_expander_gain",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_GAIN,
+    help=f"Sets the expander gain (default is {DEFAULT_NR_EXPANDER_GAIN}). "
+    f"Range (20~100): Higher values increase the effect of the expander",
+)
+expander_options_group.add_argument(
+    "--NR_expander_strength",
+    dest="nr_expander_strength",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_LOG_STRENGTH,
+    help=f"Sets the expander logarithmic strength (default is {DEFAULT_NR_EXPANDER_LOG_STRENGTH}). "
+    f"Range (1~2): Higher values increase the logarithmic slope of the expander",
+)
+expander_options_group.add_argument(
+    "--NR_attack_tau",
+    dest="nr_attack_tau",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_ATTACK_TAU,
+    help=f"Sets the expander attack speed in tau (default is {DEFAULT_NR_EXPANDER_ATTACK_TAU})."
+)
+expander_options_group.add_argument(
+    "--NR_release_tau",
+    dest="nr_release_tau",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_RELEASE_TAU,
+    help=f"Sets the expander release speed in tau (default is {DEFAULT_NR_EXPANDER_RELEASE_TAU})."
+)
+expander_options_group.add_argument(
+    "--NR_weighting_shelf_low_tau",
+    dest="nr_weighting_shelf_low_tau",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
+    help=f"Sets the expander sidechain high-pass shelf filter low point in tau (default is {DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1})."
+)
+expander_options_group.add_argument(
+    "--NR_weighting_shelf_high_tau",
+    dest="nr_weighting_shelf_high_tau",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
+    help=f"Sets the expander sidechain high-pass shelf filter high point in tau (default is {DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2})."
+)
+expander_options_group.add_argument(
+    "--NR_weighting_db_per_octave",
+    dest="nr_weighting_db_per_octave",
+    type=float,
+    default=DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    help=f"Sets the expander sidechain high-pass shelf filter cutoff rate (default is {DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE})."
+)
+
+deemphasis_options_group = parser.add_argument_group("Deemphasis tuning options (advanced)")
+deemphasis_options_group.add_argument(
+    "--NR_deemphasis_low_tau",
+    dest="nr_deemphasis_low_tau",
+    type=float,
+    default=DEFAULT_NR_DEEMPHASIS_TAU_1,
+    help=f"Sets the deemphasis low-pass shelf filter low point in tau (default is {DEFAULT_NR_DEEMPHASIS_TAU_1})."
+)
+deemphasis_options_group.add_argument(
+    "--NR_deemphasis_high_tau",
+    dest="nr_deemphasis_high_tau",
+    type=float,
+    default=DEFAULT_NR_DEEMPHASIS_TAU_2,
+    help=f"Sets the deemphasis low-pass shelf filter high point in tau (default is {DEFAULT_NR_DEEMPHASIS_TAU_2})."
+)
+deemphasis_options_group.add_argument(
+    "--NR_deemphasis_db_per_octave",
+    dest="nr_deemphasis_db_per_octave",
+    type=float,
+    default=DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
+    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (default is {DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE})."
 )
 
 def test_if_ld_ldf_reader_is_installed():
@@ -722,7 +799,6 @@ class PostProcessor:
         self.final_audio_rate = decode_options["audio_rate"]
         self.use_noise_reduction = decode_options["noise_reduction"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
-        self.nr_expander_gain = decode_options["nr_expander_gain"]
         self.peak_gain = peak_gain
 
         # create processes and wire up queues
@@ -806,8 +882,17 @@ class PostProcessor:
                 spectral_nr_worker_l_output,
                 nr_worker_l_out_input,
                 self.use_noise_reduction,
-                self.nr_expander_gain,
                 self.final_audio_rate,
+                decode_options["nr_expander_gain"],
+                decode_options["nr_expander_strength"],
+                decode_options["nr_attack_tau"],
+                decode_options["nr_release_tau"],
+                decode_options["nr_weighting_shelf_low_tau"],
+                decode_options["nr_weighting_shelf_high_tau"],
+                decode_options["nr_weighting_db_per_octave"],
+                decode_options["nr_deemphasis_low_tau"],
+                decode_options["nr_deemphasis_high_tau"],
+                decode_options["nr_deemphasis_db_per_octave"],
             ),
         )
         self.nr_worker_l.start()
@@ -821,8 +906,17 @@ class PostProcessor:
                 spectral_nr_worker_r_output,
                 nr_worker_r_out_input,
                 self.use_noise_reduction,
-                self.nr_expander_gain,
                 self.final_audio_rate,
+                decode_options["nr_expander_gain"],
+                decode_options["nr_expander_strength"],
+                decode_options["nr_attack_tau"],
+                decode_options["nr_release_tau"],
+                decode_options["nr_weighting_shelf_low_tau"],
+                decode_options["nr_weighting_shelf_high_tau"],
+                decode_options["nr_weighting_db_per_octave"],
+                decode_options["nr_deemphasis_low_tau"],
+                decode_options["nr_deemphasis_high_tau"],
+                decode_options["nr_deemphasis_db_per_octave"],
             ),
         )
         self.nr_worker_r.start()
@@ -900,11 +994,32 @@ class PostProcessor:
         in_conn,
         out_conn,
         use_noise_reduction,
-        nr_expander_gain,
         final_audio_rate,
+        nr_expander_gain,
+        nr_expander_strength,
+        nr_attack_tau,
+        nr_release_tau,
+        nr_weighting_shelf_low_tau,
+        nr_weighting_shelf_high_tau,
+        nr_weighting_db_per_octave,
+        nr_deemphasis_low_tau,
+        nr_deemphasis_high_tau,
+        nr_deemphasis_db_per_octave,
     ):
         setproctitle(current_process().name)
-        noise_reduction = NoiseReduction(nr_expander_gain, audio_rate=final_audio_rate)
+        noise_reduction = NoiseReduction(
+            final_audio_rate,
+            nr_expander_gain,
+            nr_expander_strength,
+            nr_attack_tau,
+            nr_release_tau,
+            nr_weighting_shelf_low_tau,
+            nr_weighting_shelf_high_tau,
+            nr_weighting_db_per_octave,
+            nr_deemphasis_low_tau,
+            nr_deemphasis_high_tau,
+            nr_deemphasis_db_per_octave,
+        )
 
         while True:
             while True:
@@ -1738,7 +1853,16 @@ def main() -> int:
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "normalize": args.normalize,
-        "nr_expander_gain": args.NR_expander_gain,
+        "nr_expander_gain": args.nr_expander_gain,
+        "nr_expander_strength": args.nr_expander_strength,
+        "nr_attack_tau": args.nr_attack_tau,
+        "nr_release_tau": args.nr_release_tau,
+        "nr_weighting_shelf_low_tau": args.nr_weighting_shelf_low_tau,
+        "nr_weighting_shelf_high_tau": args.nr_weighting_shelf_high_tau,
+        "nr_weighting_db_per_octave": args.nr_weighting_db_per_octave,
+        "nr_deemphasis_low_tau": args.nr_deemphasis_low_tau,
+        "nr_deemphasis_high_tau": args.nr_deemphasis_high_tau,
+        "nr_deemphasis_db_per_octave": args.nr_deemphasis_db_per_octave,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,
         "gain": args.gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -47,7 +47,7 @@ from vhsdecode.hifi.HiFiDecode import (
     HiFiDecode,
     SpectralNoiseReduction,
     NoiseReduction,
-    DEFAULT_NR_ENVELOPE_GAIN,
+    DEFAULT_NR_EXPANDER_GAIN,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
@@ -289,11 +289,11 @@ noise_reduction_options_group.add_argument(
     help="Set noise reduction block (deemphasis and expansion) on/off",
 )
 noise_reduction_options_group.add_argument(
-    "--NR_sidechain_gain",
-    dest="NR_side_gain",
+    "--NR_expander_gain",
+    dest="NR_expander_gain",
     type=float,
-    default=DEFAULT_NR_ENVELOPE_GAIN,
-    help=f"Sets the noise reduction expander sidechain gain (default is {DEFAULT_NR_ENVELOPE_GAIN}). "
+    default=DEFAULT_NR_EXPANDER_GAIN,
+    help=f"Sets the noise reduction expander gain (default is {DEFAULT_NR_EXPANDER_GAIN}). "
     f"Range (20~100): Higher values increase the effect of the expander",
 )
 noise_reduction_options_group.add_argument(
@@ -722,7 +722,7 @@ class PostProcessor:
         self.final_audio_rate = decode_options["audio_rate"]
         self.use_noise_reduction = decode_options["noise_reduction"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
-        self.nr_side_gain = decode_options["nr_side_gain"]
+        self.nr_expander_gain = decode_options["nr_expander_gain"]
         self.peak_gain = peak_gain
 
         # create processes and wire up queues
@@ -806,7 +806,7 @@ class PostProcessor:
                 spectral_nr_worker_l_output,
                 nr_worker_l_out_input,
                 self.use_noise_reduction,
-                self.nr_side_gain,
+                self.nr_expander_gain,
                 self.final_audio_rate,
             ),
         )
@@ -821,7 +821,7 @@ class PostProcessor:
                 spectral_nr_worker_r_output,
                 nr_worker_r_out_input,
                 self.use_noise_reduction,
-                self.nr_side_gain,
+                self.nr_expander_gain,
                 self.final_audio_rate,
             ),
         )
@@ -900,11 +900,11 @@ class PostProcessor:
         in_conn,
         out_conn,
         use_noise_reduction,
-        nr_side_gain,
+        nr_expander_gain,
         final_audio_rate,
     ):
         setproctitle(current_process().name)
-        noise_reduction = NoiseReduction(nr_side_gain, audio_rate=final_audio_rate)
+        noise_reduction = NoiseReduction(nr_expander_gain, audio_rate=final_audio_rate)
 
         while True:
             while True:
@@ -1738,7 +1738,7 @@ def main() -> int:
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "normalize": args.normalize,
-        "nr_side_gain": args.NR_side_gain,
+        "nr_expander_gain": args.NR_expander_gain,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,
         "gain": args.gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -198,7 +198,7 @@ demod_options.add_argument(
 demod_options.add_argument(
     "--bias_guess",
     "--bg",
-    dest="BG",
+    dest="bias_guess",
     action="store_true",
     default=False,
     help="Do carrier bias guess",
@@ -1408,13 +1408,12 @@ def write_soundfile_process_worker(
 
 async def decode_parallel(
     decode_options: dict,
-    bias_guess,
     threads: int = 8,
     ui_t: Optional[AppWindow] = None,
 ):
     decoder = HiFiDecode(options=decode_options, is_main_process=True)
     # TODO: reprocess data read in this step
-    if bias_guess:
+    if decode_options["bias_guess"]:
         LCRef, RCRef = guess_bias(
             decoder, decode_options["input_file"], int(decode_options["input_rate"])
         )
@@ -1786,7 +1785,7 @@ def run_decoder(args, decode_options, ui_t: Optional[AppWindow] = None):
             loop.set_default_executor(async_executor)
             loop.run_until_complete(
                 decode_parallel(
-                    decode_options, args.BG, threads=args.threads, ui_t=ui_t
+                    decode_options, threads=args.threads, ui_t=ui_t
                 )
             )
         print("Decode finished successfully")
@@ -1852,6 +1851,7 @@ def main() -> int:
         "muting": args.muting == "on",
         "noise_reduction": args.noise_reduction == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
+        "bias_guess": args.bias_guess,
         "normalize": args.normalize,
         "nr_expander_gain": args.nr_expander_gain,
         "nr_expander_strength": args.nr_expander_strength,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -66,7 +66,6 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_DEMOD,
 )
 from vhsdecode.hifi.TimeProgressBar import TimeProgressBar
-from vhsdecode.hifi.HifiUi import STOP_STATE, PLAY_STATE, PAUSE_STATE, PREVIEW_STATE
 import io
 
 try:
@@ -93,6 +92,11 @@ try:
 except ImportError as e:
     print(e)
     HIFI_UI = False
+
+STOP_STATE = 0
+PLAY_STATE = 1
+PAUSE_STATE = 2
+PREVIEW_STATE = 3
 
 STOP_NOT_REQUESTED = 0
 STOP_REQUESTED = 1


### PR DESCRIPTION
## Features
* Add AFE adjustment parameters
* Add expander adjustment parameters
* Organized the help menu and removed the vhs-decode options that don't apply to hifi-decode
* Various GUI updates
  * Add "Preview" button that will play the decoded audio through sound, replacing the checkbox.
  * Add all remaining cli options to gui (except for threads, which will default to the number of cpu cores)
  * Rearrange widgets so they are appropriately grouped in collapsible sections 
  * Add section labels to widget groups

## Fixes
* Avoid potential overflow by moving vco deviation division step into demodulation, so it can use float64.
* Use `filtfilt` when running the bandpass filters to avoid phase changes. This was causing occasional clicks on high amplitude / high deviation signals
* Remove expander `np.clip` to avoid potential dynamic range issues
* Fix "Other" sample rate selection bug in gui
* Fix responsiveness in gui while decoding or previewing

Updated GUI (default visible options):
![image](https://github.com/user-attachments/assets/bd786adf-534a-4fd7-84d3-41f2db195f7b)

Updated GUI (all options visible):
![image](https://github.com/user-attachments/assets/7062e85e-c534-43f0-9083-9197e2c236b4)

Updated usage printout:
```
usage: hifi-decode [-h] [--frequency FREQ] [--overwrite] [--threads threads] [--gui] [--gnuradio] [--preview] [--pal] [--ntsc] [--8mm] [--demod DEMOD_TYPE] [--bias_guess] [--auto_fine_tune AUTO_FINE_TUNE]
                   [--AFE_vco_deviation AFE_VCO_DEVIATION] [--AFE_left_carrier AFE_LEFT_CARRIER] [--AFE_right_carrier AFE_RIGHT_CARRIER] [--audio_rate RATE] [--audio_mode MODE] [--resampler_quality RESAMPLER_QUALITY]
                   [--normalize] [--gain GAIN] [--head_switching_interpolation HEAD_SWITCHING_INTERPOLATION] [--muting MUTING] [--NR_spectral_amount SPECTRAL_NR_AMOUNT] [--noise_reduction NOISE_REDUCTION]
                   [--NR_expander_gain NR_EXPANDER_GAIN] [--NR_expander_strength NR_EXPANDER_STRENGTH] [--NR_attack_tau NR_ATTACK_TAU] [--NR_release_tau NR_RELEASE_TAU]
                   [--NR_weighting_shelf_low_tau NR_WEIGHTING_SHELF_LOW_TAU] [--NR_weighting_shelf_high_tau NR_WEIGHTING_SHELF_HIGH_TAU] [--NR_weighting_db_per_octave NR_WEIGHTING_DB_PER_OCTAVE]
                   [--NR_deemphasis_low_tau NR_DEEMPHASIS_LOW_TAU] [--NR_deemphasis_high_tau NR_DEEMPHASIS_HIGH_TAU] [--NR_deemphasis_db_per_octave NR_DEEMPHASIS_DB_PER_OCTAVE]
                   [infile] [outfile]

Extracts audio from RAW HiFi FM RF captures

positional arguments:
  infile                source file
  outfile               base name for destination files

options:
  -h, --help            show this help message and exit
  --frequency FREQ, -f FREQ
                        RF sampling frequency in source file (default is 40MHz)
  --overwrite           Overwrite existing decode files.
  --threads threads, -t threads
                        number of CPU threads to use
  --gui                 Opens hifi-decode GUI graphical user interface
  --gnuradio            Opens ZMQ REP pipe to gnuradio at port 5555
  --preview             Preview the audio through your speakers as it decodes. Uses preview quality (faster and noisier)

System options:
  --pal, -p             source is in PAL format
  --ntsc, -n            source is in NTSC format
  --8mm                 Use settings for Video8 and Hi8 tape formats.

Demodulation options:
  --demod DEMOD_TYPE    Set the FM demodulation type (default: quadrature) (quadrature, hilbert)
  --bias_guess, --bg    Do carrier bias guess
  --auto_fine_tune AUTO_FINE_TUNE
                        Set auto tuning of the analog front end on/off
  --AFE_vco_deviation AFE_VCO_DEVIATION
                        Overrides the VCO maximum deviation. This represents the maximum frequency offset + or - from the center frequency.
  --AFE_left_carrier AFE_LEFT_CARRIER
                        Overrides the left carrier center frequency.
  --AFE_right_carrier AFE_RIGHT_CARRIER
                        Overrides the right carrier center frequency.

Audio processing options:
  --audio_rate RATE, --ar RATE
                        Output sample rate in Hz (default 48000)
  --audio_mode MODE     Audio mode (s: stereo, mpx: stereo with mpx, l: left channel, r: right channel, sum: mono sum) - defaults to s other than on 8mm which defaults to mpx. 8mm mono is not auto detected currently so
                        has to be manually specified as l.
  --resampler_quality RESAMPLER_QUALITY
                        Sets quality of resampling to use in the audio chain. (default is high). Range (low, medium, high): low being faster, and high having best quality
  --normalize           Automatically amplifies the audio to the peak gain of the decode. This will create a temporary file ending in "tmp_normalize.raw" that is deleted after the amplification step is complete.
  --gain GAIN           Manually adjust the gain/volume of the output audio (default is 1.0).

Noise reduction options:
  --head_switching_interpolation HEAD_SWITCHING_INTERPOLATION
                        Enables head switching noise interpolation. (defaults to "on").
  --muting MUTING       Mutes the audio when there is no hifi carrier. (defaults to "on").
  --NR_spectral_amount SPECTRAL_NR_AMOUNT
                        Sets the amount of broadband spectral noise reduction to apply. (default is 0.4). Range (0~1): 0 being off, 1 being full spectral noise reduction
  --noise_reduction NOISE_REDUCTION
                        Set noise reduction block (deemphasis and expansion) on/off

Expander tuning options (advanced):
  --NR_expander_gain NR_EXPANDER_GAIN
                        Sets the expander gain (default is 22). Range (20~100): Higher values increase the effect of the expander
  --NR_expander_strength NR_EXPANDER_STRENGTH
                        Sets the expander logarithmic strength (default is 1.2). Range (1~2): Higher values increase the logarithmic slope of the expander
  --NR_attack_tau NR_ATTACK_TAU
                        Sets the expander attack speed in tau (default is 0.003).
  --NR_release_tau NR_RELEASE_TAU
                        Sets the expander release speed in tau (default is 0.07).
  --NR_weighting_shelf_low_tau NR_WEIGHTING_SHELF_LOW_TAU
                        Sets the expander sidechain high-pass shelf filter low point in tau (default is 0.00024).
  --NR_weighting_shelf_high_tau NR_WEIGHTING_SHELF_HIGH_TAU
                        Sets the expander sidechain high-pass shelf filter high point in tau (default is 2.4e-05).
  --NR_weighting_db_per_octave NR_WEIGHTING_DB_PER_OCTAVE
                        Sets the expander sidechain high-pass shelf filter cutoff rate (default is 2.1).

Deemphasis tuning options (advanced):
  --NR_deemphasis_low_tau NR_DEEMPHASIS_LOW_TAU
                        Sets the deemphasis low-pass shelf filter low point in tau (default is 0.00024).
  --NR_deemphasis_high_tau NR_DEEMPHASIS_HIGH_TAU
                        Sets the deemphasis low-pass shelf filter high point in tau (default is 5.6e-05).
  --NR_deemphasis_db_per_octave NR_DEEMPHASIS_DB_PER_OCTAVE
                        Sets the deemphasis low-pass shelf filter cutoff rate (default is 6.6).

```

