### PR TITLE
field order detection fixes / misc fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+import shutil
+import os
 import distutils.ccompiler
 from distutils.extension import Extension
 from Cython.Build import cythonize
@@ -12,6 +14,10 @@ import numpy
 compiler = distutils.ccompiler.new_compiler()
 
 if compiler.compiler_type == "unix":
+    if shutil.which("clang"):
+        os.environ["CC"] = "clang"
+        os.environ["CXX"] = "clang++"
+
     extra_compile_args=["-O3", "-flto"]
     extra_link_args=["-O3", "-flto"]
 else:

--- a/vhsdecode/cmdcommons.py
+++ b/vhsdecode/cmdcommons.py
@@ -141,7 +141,7 @@ def common_parser_gui(meta_title):
 
 
 def common_parser_cli(meta_title, default_threads=DEFAULT_THREADS + 1):
-    parser = argparse.ArgumentParser(description=meta_title)
+    parser = argparse.ArgumentParser(description=meta_title, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         "infile",
         metavar="infile",

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1242,6 +1242,7 @@ class FieldShared:
             prev_first_hsync_offset_lines,
             self.rf.prev_first_hsync_loc,
             self.rf.prev_first_hsync_diff,
+            self.rf.options.field_order_confidence,
             fallback_line0loc,
             fallback_is_first_field,
             fallback_is_first_field_confidence,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1195,6 +1195,11 @@ class FieldShared:
             else:
                 self.rf.prev_first_field = -1
 
+            if hasattr(self.prevfield, "isProgressiveField"):
+                self.rf.prev_progressive_field = 1 if self.prevfield.isProgressiveField else 0
+            else:
+                self.rf.prev_progressive_field = -1
+
         # calculate in terms of lines to prevent integer overflow when seeking ahead large amounts
         if self.rf.prev_first_hsync_readloc != -1:
             prev_first_hsync_offset_lines = (
@@ -1230,6 +1235,7 @@ class FieldShared:
             self.first_hsync_loc_line,
             self.vblank_next,
             self.isFirstField,
+            self.isProgressiveField,
             prev_hsync_diff,
             vblank_pulses,
         ) = sync.get_first_hsync_loc(
@@ -1255,6 +1261,7 @@ class FieldShared:
             self.rf.prev_first_hsync_diff = prev_hsync_diff
 
         self.rf.prev_first_field = self.isFirstField
+        self.rf.prev_progressive_field = self.isProgressiveField
 
         # self.getLine0(validpulses, meanlinelen)
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -18,6 +18,7 @@ from vhsdecode.chroma import (
     try_detect_track_betamax_pal,
 )
 
+from numba import njit
 from vhsdecode.debug_plot import plot_data_and_pulses
 
 NO_PULSES_FOUND = 1

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -2204,7 +2204,6 @@ class HiFiDecode:
             self.grc.send(filterL + filterR)
 
         if self.audio_process_params.decode_mode != 'r': 
-            print("processing left")
             preL, dcL, perf_measurements_l = HiFiDecode.demod_process_audio(
                 filterL, self.fmL, self.audio_process_params, self.audio_resampler_l, self.audio_final_resampler_l, measure_perf
             )
@@ -2213,7 +2212,6 @@ class HiFiDecode:
             dcL = 0
             perf_measurements_l = 0
         if self.audio_process_params.decode_mode != 'l': 
-            print("processing right")
             preR, dcR, perf_measurements_r = HiFiDecode.demod_process_audio(
                 filterR, self.fmR, self.audio_process_params, self.audio_resampler_r, self.audio_final_resampler_r, measure_perf
             )

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -1040,13 +1040,6 @@ class HiFiDecode:
         self.preAudioResampleL = FiltersClass(a_iirb, a_iira, dtype=np.float64)
         self.preAudioResampleR = FiltersClass(a_iirb, a_iira, dtype=np.float64)
 
-        self.dcCancelL = StackableMA(
-            min_watermark=0, window_average=self._blocks_per_second_ratio
-        )
-        self.dcCancelR = StackableMA(
-            min_watermark=0, window_average=self._blocks_per_second_ratio
-        )
-
         self.standard, self.field_rate = HiFiDecode.get_standard(
             options["format"],
             options["standard"],
@@ -1606,7 +1599,13 @@ class HiFiDecode:
         devL = (self.standard_original.LCarrierRef - self.standard.LCarrierRef) / 1e3
         devR = (self.standard_original.RCarrierRef - self.standard.RCarrierRef) / 1e3
 
-        print("Bias L %.02f kHz, R %.02f kHz" % (devL, devR), end=" ")
+        if self.audio_process_params.decode_mode == 'l':
+            print("Bias L %.02f kHz" % (devL), end=" ")
+        elif self.audio_process_params.decode_mode == 'r':
+            print("Bias R %.02f kHz" % (devR), end=" ")
+        else:
+            print("Bias L %.02f kHz, R %.02f kHz" % (devL, devR), end=" ")
+
         if abs(devL) < 9 and abs(devR) < 9:
             print("(good player/recorder calibration)")
         elif 9 <= abs(devL) < 10 or 9 <= abs(devR) < 10:
@@ -1646,25 +1645,27 @@ class HiFiDecode:
     def auto_fine_tune(
         self, dcL: float, dcR: float
     ) -> Tuple[AFEFilterable, AFEFilterable, FMdemod, FMdemod]:
-        left_carrier_dc_offset = (
-            self.standard.LCarrierRef - dcL * self.standard.VCODeviation
-        )
-        left_carrier_updated = self.standard.LCarrierRef - round(left_carrier_dc_offset)
-        self.standard.LCarrierRef = max(
-            min(left_carrier_updated, self.standard_original.LCarrierRef + 10e3),
-            self.standard_original.LCarrierRef - 10e3,
-        )
-
-        right_carrier_dc_offset = (
-            self.standard.RCarrierRef - dcR * self.standard.VCODeviation
-        )
-        right_carrier_updated = self.standard.RCarrierRef - round(
-            right_carrier_dc_offset
-        )
-        self.standard.RCarrierRef = max(
-            min(right_carrier_updated, self.standard_original.RCarrierRef + 10e3),
-            self.standard_original.RCarrierRef - 10e3,
-        )
+        if self.audio_process_params.decode_mode != 'r':
+            left_carrier_dc_offset = (
+                self.standard.LCarrierRef - dcL * self.standard.VCODeviation
+            )
+            left_carrier_updated = self.standard.LCarrierRef - round(left_carrier_dc_offset)
+            self.standard.LCarrierRef = max(
+                min(left_carrier_updated, self.standard_original.LCarrierRef + 10e3),
+                self.standard_original.LCarrierRef - 10e3,
+            )
+            
+        if self.audio_process_params.decode_mode != 'l':
+            right_carrier_dc_offset = (
+                self.standard.RCarrierRef - dcR * self.standard.VCODeviation
+            )
+            right_carrier_updated = self.standard.RCarrierRef - round(
+                right_carrier_dc_offset
+            )
+            self.standard.RCarrierRef = max(
+                min(right_carrier_updated, self.standard_original.RCarrierRef + 10e3),
+                self.standard_original.RCarrierRef - 10e3,
+            )
 
         # auto fine tune can't adjust quadrature demodulation since the i/q oscillators are generated once, disabling for now
         # use the --bg option to adjust for bias at the beginning of the decode
@@ -1960,7 +1961,7 @@ class HiFiDecode:
         cache=True,
         fastmath=True,
     )
-    def cancelDC_clip_trim(audio: np.array, trim: int) -> float:
+    def cancelDC_trim(audio: np.array, trim: int) -> float:
         for i in range(trim):
             audio[i] = 0
 
@@ -2094,8 +2095,8 @@ class HiFiDecode:
             "end_demod": 0,
             "start_audio_resample": 0,
             "end_audio_resample": 0,
-            "start_dc_clip_trim": 0,
-            "end_dc_clip_trim": 0,
+            "start_dc_trim": 0,
+            "end_dc_trim": 0,
             "start_headswitch": 0,
             "end_headswitch": 0,
             "start_audio_final_resample": 0,
@@ -2118,12 +2119,12 @@ class HiFiDecode:
         if measure_perf:
             perf_measurements["end_audio_resample"] = perf_counter()
 
-        # cancel dc based on mean, clip signal based on vco deviation, remove spikes at end of signal
+        # cancel dc based on mean, remove spikes at end of signal
         if measure_perf:
-            perf_measurements["start_dc_clip_trim"] = perf_counter()
-        dc = HiFiDecode.cancelDC_clip_trim(audio, audio_process_params.pre_trim)
+            perf_measurements["start_dc_trim"] = perf_counter()
+        dc = HiFiDecode.cancelDC_trim(audio, audio_process_params.pre_trim)
         if measure_perf:
-            perf_measurements["end_dc_clip_trim"] = perf_counter()
+            perf_measurements["end_dc_trim"] = perf_counter()
 
         # mute audio when carrier loss occurs
         if measure_perf:
@@ -2194,20 +2195,32 @@ class HiFiDecode:
 
         if measure_perf:
             start_carrier_filter = perf_counter()
-        filterL = self.afeL.work(rf_data_resampled)
-        filterR = self.afeR.work(rf_data_resampled)
+        if self.audio_process_params.decode_mode != 'r': filterL = self.afeL.work(rf_data_resampled)
+        if self.audio_process_params.decode_mode != 'l': filterR = self.afeR.work(rf_data_resampled)
         if measure_perf:
             end_carrier_filter = perf_counter()
 
         if self.options["grc"] and ZMQ_AVAILABLE:
             self.grc.send(filterL + filterR)
 
-        preL, dcL, perf_measurements_l = HiFiDecode.demod_process_audio(
-            filterL, self.fmL, self.audio_process_params, self.audio_resampler_l, self.audio_final_resampler_l, measure_perf
-        )
-        preR, dcR, perf_measurements_r = HiFiDecode.demod_process_audio(
-            filterR, self.fmR, self.audio_process_params, self.audio_resampler_r, self.audio_final_resampler_r, measure_perf
-        )
+        if self.audio_process_params.decode_mode != 'r': 
+            print("processing left")
+            preL, dcL, perf_measurements_l = HiFiDecode.demod_process_audio(
+                filterL, self.fmL, self.audio_process_params, self.audio_resampler_l, self.audio_final_resampler_l, measure_perf
+            )
+        else:
+            preL = None
+            dcL = 0
+            perf_measurements_l = 0
+        if self.audio_process_params.decode_mode != 'l': 
+            print("processing right")
+            preR, dcR, perf_measurements_r = HiFiDecode.demod_process_audio(
+                filterR, self.fmR, self.audio_process_params, self.audio_resampler_r, self.audio_final_resampler_r, measure_perf
+            )
+        else:
+            preR = None
+            dcR = 0
+            perf_measurements_r = 0
 
         # fine tune carrier frequency
         if measure_perf:
@@ -2254,9 +2267,9 @@ class HiFiDecode:
                 perf_measurements_l["end_audio_resample"]
                 - perf_measurements_l["start_audio_resample"]
             )
-            duration_dc_clip_trim_l = (
-                perf_measurements_l["end_dc_clip_trim"]
-                - perf_measurements_l["start_dc_clip_trim"]
+            duration_dc_trim_l = (
+                perf_measurements_l["end_dc_trim"]
+                - perf_measurements_l["start_dc_trim"]
             )
             duration_mute_l = (
                 perf_measurements_l["end_mute"] - perf_measurements_l["start_mute"]
@@ -2277,9 +2290,9 @@ class HiFiDecode:
                 perf_measurements_r["end_audio_resample"]
                 - perf_measurements_r["start_audio_resample"]
             )
-            duration_dc_clip_trim_r = (
-                perf_measurements_r["end_dc_clip_trim"]
-                - perf_measurements_r["start_dc_clip_trim"]
+            duration_dc_trim_r = (
+                perf_measurements_r["end_dc_trim"]
+                - perf_measurements_r["start_dc_trim"]
             )
             duration_mute_r = (
                 perf_measurements_r["end_mute"] - perf_measurements_r["start_mute"]
@@ -2302,13 +2315,13 @@ class HiFiDecode:
                 ("duration_carrier_filter", duration_carrier_filter),
                 ("duration_demod_l", duration_demod_l),
                 ("duration_audio_resample_l", duration_audio_resample_l),
-                ("duration_dc_clip_trim_l", duration_dc_clip_trim_l),
+                ("duration_dc_trim_l", duration_dc_trim_l),
                 ("duration_mute_l", duration_mute_l),
                 ("duration_headswitch_l", duration_headswitch_l),
                 ("duration_audio_final_resample_l", duration_audio_final_resample_l),
                 ("duration_demod_r", duration_demod_r),
                 ("duration_audio_resample_r", duration_audio_resample_r),
-                ("duration_dc_clip_trim_r", duration_dc_clip_trim_r),
+                ("duration_dc_trim_r", duration_dc_trim_r),
                 ("duration_mute_r", duration_mute_r),
                 ("duration_headswitch_r", duration_headswitch_r),
                 ("duration_audio_final_resample_r", duration_audio_final_resample_r),

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1665,7 +1665,7 @@ async def decode_parallel(
             block = buffer.get_block()
             overlap_start = len(previous_overlap) + frames_read
             overlap_end = overlap_start + decoder_state.block_overlap
-            for i in range(overlap_start, overlap_end):
+            for i in range(overlap_start, min(overlap_end, len(block))):
                 block[i] = block[i-decoder_state.block_overlap]
         else:
             # copy the the current overlap to use in the next iteration

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -307,14 +307,13 @@ def main(args=None, use_gui=False):
     debug_group.add_argument(
         "--field_order_action",
         dest="field_order_action",
-        default="alternate",
+        default="detect",
         metavar="value",
-        type=lambda x: x if x in ["alternate", "duplicate", "drop"] else parser.error('--field_order_action must be one of ["alternate", "duplicate", "drop"]'),
+        type=lambda x: x if x in ["detect", "duplicate", "drop"] else parser.error('--field_order_action must be one of ["detect", "duplicate", "drop"]'),
         help=(
             "Decides how to handle field order discontinuities,\n"
             "  When the field order cadence is broken such that there are two Top or two Bottom fields.\n"
-            "  * `alternate`: (default) alternate between duplicate and drop.\n"
-            "                 This option should allow the video to stay synced with the audio when there are multiple duplicate fields\n"
+            "  * `detect`:    (default) use the distance between the dropped field to determine whether to drop or duplicate.\n"
             "  * `duplicate`: always duplicate the last valid field\n"
             "  * `drop`:      always drop the last valid field\n"
         ),

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -305,6 +305,21 @@ def main(args=None, use_gui=False):
         ),
     )
     debug_group.add_argument(
+        "--field_order_action",
+        dest="field_order_action",
+        default="alternate",
+        metavar="value",
+        type=lambda x: x if x in ["alternate", "duplicate", "drop"] else parser.error('--field_order_action must be one of ["alternate", "duplicate", "drop"]'),
+        help=(
+            "Decides how to handle field order discontinuities,\n"
+            "  When the field order cadence is broken such that there are two Top or two Bottom fields.\n"
+            "  * `alternate`: (default) alternate between duplicate and drop.\n"
+            "                 This option should allow the video to stay synced with the audio when there are multiple duplicate fields\n"
+            "  * `duplicate`: always duplicate the last valid field\n"
+            "  * `drop`:      always drop the last valid field\n"
+        ),
+    )
+    debug_group.add_argument(
         "--use_saved_levels",
         dest="saved_levels",
         action="store_true",
@@ -504,6 +519,7 @@ def main(args=None, use_gui=False):
         rf_options=rf_options,
         extra_options=extra_options,
         debug_plot=debug_plot,
+        field_order_action=args.field_order_action
     )
 
     if check_debug():

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -309,13 +309,14 @@ def main(args=None, use_gui=False):
         dest="field_order_action",
         default="detect",
         metavar="value",
-        type=lambda x: x if x in ["detect", "duplicate", "drop"] else parser.error('--field_order_action must be one of ["detect", "duplicate", "drop"]'),
+        type=lambda x: x if x in ["detect", "duplicate", "drop", "none"] else parser.error('--field_order_action must be one of ["detect", "duplicate", "drop", "none"]'),
         help=(
             "Decides how to handle field order discontinuities,\n"
             "  When the field order cadence is broken such that there are two Top or two Bottom fields.\n"
             "  * `detect`:    (default) use the distance between the dropped field to determine whether to drop or duplicate.\n"
             "  * `duplicate`: always duplicate the last valid field\n"
             "  * `drop`:      always drop the last valid field\n"
+            "  * `none`:      do nothing, (field order will be out of sync causing issues for interlaced video)\n"
         ),
     )
     debug_group.add_argument(

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -256,7 +256,13 @@ class VHSDecode(ldd.LDdecode):
                 else:
                     self.duplicate_prev_field = not self.duplicate_prev_field
 
-                if self.duplicate_prev_field:
+                if self.field_order_action == "none":
+                    ldd.logger.error(
+                        "Possibly skipped field (Two fields with same isFirstField in a row)"
+                    )
+                    fi["decodeFaults"] |= 4
+                    fi["syncConf"] = 0
+                elif self.duplicate_prev_field:
                     ldd.logger.error(
                         "Possibly skipped field (Two fields with same isFirstField in a row), duplicating the last field to compensate..."
                     )

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -511,7 +511,8 @@ class VHSDecode(ldd.LDdecode):
 
             fi, duplicateField, writeField = self.buildmetadata(f)
 
-            self.lastvalidfield[f.isFirstField] = (f, fi, picture, audio, efm)
+            if writeField:
+                self.lastvalidfield[f.isFirstField] = (f, fi, picture, audio, efm)
 
             if duplicateField:
                 if self.lastvalidfield[not f.isFirstField] is not None:

--- a/vhsdecode/sync.pyx
+++ b/vhsdecode/sync.pyx
@@ -446,12 +446,12 @@ def get_first_hsync_loc(
             if progressive_field_confidence == field_order_lengths_len:
                 progressive_field = True
 
-    # overrides previous first field, if fallback has high confidence
-    if fallback_is_first_field_confidence > 70:
-        if fallback_is_first_field == 1:
-            first_field = True
-        else:
-            first_field = False
+    # overrides previous first field, if fallback has more confidence
+    if (
+        fallback_is_first_field_confidence > first_field_confidence
+        and fallback_is_first_field_confidence > second_field_confidence
+    ):
+        first_field = fallback_is_first_field == 1
 
     # ***********************************************************
     # calculate the expected line locations for each vblank pulse

--- a/vhsdecode/utils.py
+++ b/vhsdecode/utils.py
@@ -240,7 +240,7 @@ class StackableMA:
         return mean / len(self.stack)
 
     def pull(self):
-        if np.size(self.stack) > 0:
+        if len(self.stack) > 0:
             if len(self.stack) >= self.window_average:
                 self.stack = self.stack[-self.window_average:]
         


### PR DESCRIPTION
## Features

* Adds `field_order_confidence` option that allows for less strict field order detection. The default is the same as the existing behavior. The confidence value can be decreased to allow for faster field order changes, which can be useful for home recordings that duplicate fields.
```
  --field_order_confidence value
                        Allow field order cadence to change after n percent of field order pulses detected.
                          Reduce this number if you experience field order issues when decoding sources with multiple recordings, such as home recordings
                          Increase this number if there is damage to the v-sync area to prevent incorrect field order detection
                          Range 0-100; Sane Values 50-100
                            100, (default) all field order pulses must match to change field cadence
                             50, half of field order pulses must match to change field cadence
                              0, any field order pulse can match to change field cadence
```
* Adds `field_order_action` option to control over what action to take when a duplicate field order is detected. Downstream tooling needs to have alternating Top and Bottom fields, otherwise the interlaced video is not encodable. This option determines how to handle duplicate field orders to compensate for this. The default is to `detect` between `duplicate` and `drop` based on distance between the duplicate field.
```
  --field_order_action value
                        Decides how to handle field order discontinuities,
                          When the field order cadence is broken such that there are two Top or two Bottom fields.
                          * `detect`:    (default) use the distance between the dropped field to determine whether to drop or duplicate.
                          * `duplicate`: always duplicate the last valid field
                          * `drop`:      always drop the last valid field
                          * `none`:      do nothing, (field order will be out of sync causing issues for interlaced video)"
```
* Add new fields to metadata json for frame order information.
```js
{
   // Set to `true` when the vsync pulses indicated a first field, otherwise `false`
   "detectedFirstField": true | false,
   // Set to `true` when the field is a copy of the previous, otherwise `false`
   "isDuplicateField": true | false,
   // Set to `true` when the field should be treated as the first field regardless of detected value, otherwise `false`.
   // This is an existing field, but it is added here for context.
   "isFirstField": true | false, 
   ...existingFields
}
```
* Update progressive field order logic
  * Replace simple distance check with more resilient check for sequence of three repeated field orders
  * The distance check was incorrectly flipping the field order for interlaced video
  * Progressive video should still be decoded with `--fallback_vsync`
* RF and System parameters are printed to the `.log` file when `--debug` is specified.

## Refactors
* `decodeframe` is threaded for slightly more efficiency.
* Thread eq pulse detection
* Numba optimize various vsync serration code blocks
* Default to compiler to use `clang` over `gcc` for cython code since it is faster
* Skip processing for opposite channel in hifi-decode if in left or right only (mono) mode

## Fixes
* add boundary check for last block logic in hifi-decode