### PR TITLE
hifi-decode: fixes after release issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Decoders & TBC Video Export has a mainly self-contained binary appimage package 
 
 
 <details closed>
-<summary>Direct installation of the development release on Linux (Ubuntu/Debian-based)</summary>
+<summary>Build from Source Linux (Ubuntu/Debian-based)</summary>
 <br>
 
 
@@ -433,6 +433,35 @@ Use <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the current process.
 
 You don't actually type `<` and `>` on your input & output files.
 
+
+</details>
+
+
+<details closed>
+<summary>Build from Source Windows</summary>
+<br>
+
+1. Install Python 3.13
+   * Download the [python installer](https://www.python.org/downloads/)
+   * **Make sure to check the box requesting Python be added to the PATH**
+1. Install Visual Studio Build Tools for 
+   * Download the [Visual Studio Installer](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+   * In the installer, select `Visual Studio Build Tools 2022`
+     * If there are multiple versions, select the latest year
+   * Click on the `Desktop Development with C++` and a list of default components will be selected
+   * Click `Install` to install them
+1. Install Rust
+   * Download the [Rust installer](https://www.rust-lang.org/tools/install) follow the wizard to install Rust
+1. Install extra python dependencies
+   * Open a terminal. If python installed successfully, `pip` should be an executable in your PATH.
+   * `pip install samplerate --prefer-binary`
+     * There is currently an issue with samplerate that prevents it from building on Windows, so this will install a prebuilt binary
+1. Build vhs-decode
+   * Clone the repo if you have not already done so
+   * `cd C:\path\to\vhs-decode`
+   * `pip install .[hifi_gui_qt6]`
+1. Now you will be able to run the decode suite from the source code.
+   * Example `python C:\path\to\vhs-decode\decode.py hifi --gui`
 
 </details>
 

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -355,7 +355,6 @@ class HifiUi(QMainWindow):
         self.resize_window()
         # sets default window icon
         self.setWindowIcon(QIcon.fromTheme("document-open"))
-        self.center_on_screen()
         self.setValues(params)
 
         # update this at the end so the window width is calculated with everything expanded
@@ -753,19 +752,6 @@ class HifiUi(QMainWindow):
         else:
             raise ValueError("Invalid transport state value")
         self._transport_state = value
-
-    def center_on_screen(self):
-        # Get the screen geometry
-        screen_geometry = self.screen().availableGeometry()
-
-        # Calculate the center of the screen
-        screen_center = screen_geometry.center()
-
-        # Set the window position to the center of the screen
-        self.move(
-            int(screen_center.x() - self.width() / 2),
-            int((screen_center.y() - self.height()) * 3 / 4),
-        )
 
     def setValues(self, values: MainUIParameters):
         self.volume_dial_control.setValue(values.volume)

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -1184,15 +1184,12 @@ class DialControl(QWidget):
 
 
 class CollapsableSection(QVBoxLayout):
-    def __init__(self, main_window, label_text, default_collapsed=False):
+    def __init__(self, main_window, label_text, default_collapsed=False, bg_color = "#333"):
         super(CollapsableSection, self).__init__()
 
         self.main_window = main_window
         self.main_window.collapsableSections.append(self)
         self.default_collapsed = default_collapsed
-
-        # Get the main widget background color from palette
-        bg_color = self.main_window.palette().color(QPalette.ColorRole.Window).name()
 
         # Create toggle button
         self.collapsed_arrow = QLabel()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -680,68 +680,83 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             "r",
         )
     elif "ldf" == extension:
-        if test_if_ld_ldf_reader_is_installed():
-            return UnseekableSoundFile(
-                LDFFileReader(pathR),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE",
+        try:
+            if test_if_ld_ldf_reader_is_installed():
+                return UnseekableSoundFile(
+                    LDFFileReader(pathR),
+                    "r",
+                    channels=1,
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                )
+            print(
+                "WARN: ld-ldf-reader is not installed. LDF file format may not decode correctly"
             )
-        print(
-            "WARN: ld-ldf-reader is not installed. LDF file format may not decode correctly"
-        )
+        except e:
+            print(
+                "WARN: Unexpected error opening ld-ldf-reader, LDF file format may not decode correctly", e
+            )
+        
+        try:    
+            if test_if_flac_is_installed():
+                return UnseekableSoundFile(
+                    FlacFileReader(pathR),
+                    "r",
+                    channels=1,
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                )
+            if test_if_ffmpeg_is_installed():
+                return UnseekableSoundFile(
+                    FFMpegFileReader(pathR),
+                    "r",
+                    channels=1,
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                )
+        except:
+            pass
 
-        if test_if_flac_is_installed():
-            return UnseekableSoundFile(
-                FlacFileReader(pathR),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE",
-            )
-        elif test_if_ffmpeg_is_installed():
-            return UnseekableSoundFile(
-                FFMpegFileReader(pathR),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE",
-            )
-        else:
-            return sf.SoundFile(
-                pathR,
-                "r",
-            )
-    elif "-" == path:
-        return UnseekableSoundFile(
-            BufferedInputStream(sys.stdin.buffer),
+        return sf.SoundFile(
+            pathR,
             "r",
-            channels=1,
-            samplerate=int(sample_rate),
-            format="RAW",
-            subtype="PCM_16",
-            endian="LITTLE",
         )
+    elif "-" == path:
+        try:
+            return UnseekableSoundFile(
+                BufferedInputStream(sys.stdin.buffer),
+                "r",
+                channels=1,
+                samplerate=int(sample_rate),
+                format="RAW",
+                subtype="PCM_16",
+                endian="LITTLE",
+            )
+        except e:
+            print("Failed to open standard in, unable to decode")
+            raise e
     else:
         print("WARN: Unknown file format.")
         print("WARN: Attempting to decode with ffmpeg")
-        if test_if_ffmpeg_is_installed():
-            return UnseekableSoundFile(
-                FFMpegFileReader(pathR),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE",
-            )
+        try:
+            if test_if_ffmpeg_is_installed():
+                return UnseekableSoundFile(
+                    FFMpegFileReader(pathR),
+                    "r",
+                    channels=1,
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                )
+        except:
+            pass
         print("WARN: Attempting to decode with SoundFile")
         return sf.SoundFile(pathR, "r")
 

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -694,7 +694,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             print(
                 "WARN: ld-ldf-reader is not installed. LDF file format may not decode correctly"
             )
-        except e:
+        except Exception as e:
             print(
                 "WARN: Unexpected error opening ld-ldf-reader, LDF file format may not decode correctly", e
             )
@@ -720,7 +720,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     subtype="PCM_16",
                     endian="LITTLE",
                 )
-        except:
+        except Exception as e:
             pass
 
         return sf.SoundFile(
@@ -738,7 +738,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                 subtype="PCM_16",
                 endian="LITTLE",
             )
-        except e:
+        except Exception as e:
             print("Failed to open standard in, unable to decode")
             raise e
     else:
@@ -755,7 +755,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     subtype="PCM_16",
                     endian="LITTLE",
                 )
-        except:
+        except Exception:
             pass
         print("WARN: Attempting to decode with SoundFile")
         return sf.SoundFile(pathR, "r")


### PR DESCRIPTION
* Use less memory for I/Q oscillators by just generating one full waveform and looping over it with modulus
* Reimplement numba for hilbert demod
* Fix Windows gui box background color
* Fix hifi gui improperly centering on screen
* Update readme.md with Windows build steps