### PR TITLE
samplerate -> soxr

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,10 +452,6 @@ You don't actually type `<` and `>` on your input & output files.
    * Click `Install` to install them
 1. Install Rust
    * Download the [Rust installer](https://www.rust-lang.org/tools/install) follow the wizard to install Rust
-1. Install extra python dependencies
-   * Open a terminal. If python installed successfully, `pip` should be an executable in your PATH.
-   * `pip install samplerate --prefer-binary`
-     * There is currently an issue with samplerate that prevents it from building on Windows, so this will install a prebuilt binary
 1. Build vhs-decode
    * Clone the repo if you have not already done so
    * `cd C:\path\to\vhs-decode`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1",'samplerate==0.1; platform_system == "Linux"', 'samplerate; platform_system != "Linux"', "static-ffmpeg", "cython", "soundfile>=0.13.1", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0", "setproctitle"
+    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1", "soxr", "static-ffmpeg", "cython", "soundfile>=0.13.1", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0", "setproctitle"
 ]
 dynamic = ["version"]
 # version = "0.2.1dev0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ Cython
 matplotlib
 numba>=0.58.1
 numpy>=1.22
-samplerate==0.1; platform_system == "Linux"
-samplerate; platform_system != "Linux"
+soxr
 scipy >=1.10
 soundfile>=0.13.1
 sounddevice

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1488,13 +1488,10 @@ async def decode_parallel(
     threads: int = 8,
     ui_t: Optional[AppWindow] = None,
 ):
-    decoder = HiFiDecode(options=decode_options, is_main_process=True)
+    decoder = HiFiDecode(options=decode_options, is_main_process=True, bias_guess=decode_options["bias_guess"])
     # TODO: reprocess data read in this step
     if decode_options["bias_guess"]:
-        LCRef, RCRef = guess_bias(
-            decoder, decode_options["input_file"], int(decode_options["input_rate"])
-        )
-        decoder.updateAFE(LCRef, RCRef)
+        guess_bias(decoder, decode_options["input_file"], int(decode_options["input_rate"]))
 
     input_file = decode_options["input_file"]
     output_file = decode_options["output_file"]
@@ -1858,9 +1855,8 @@ def guess_bias(decoder, input_file, block_size, blocks_limits=10):
             f.buffer_read_into(block_buffer, "int16")
             blocks.append(block_buffer)
 
-    LCRef, RCRef = decoder.guessBiases(blocks)
+    decoder.guessBiases(blocks)
     print("\ndone!")
-    return LCRef, RCRef
 
 
 def run_decoder(args, decode_options, ui_t: Optional[AppWindow] = None):


### PR DESCRIPTION
* Remove `samplerate` and replace with `soxr`
  * Roughly doubles performance of hifi-decode
  * Resampling is defaulted to the highest quality setting, not possible with `samplerate` since it was too slow.
* Fix I/Q oscillator discontinuities