### PR TITLE
hifi-decode: fix block size at end of file

### DIFF
--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -41,9 +41,6 @@ class DecoderState:
         # block data for resampled audio @ user set audio rate
         self.block_audio_final_size = block_sizes["block_audio_final_size"]
         self.block_audio_final_overlap = block_overlap["block_audio_final_overlap"]
-        self.block_audio_final_len = (
-            self.block_audio_final_size - self.block_audio_final_overlap * 2
-        )
 
     name: str
     block_num: int
@@ -59,7 +56,12 @@ class DecoderState:
 
     block_audio_final_size: int
     block_audio_final_overlap: int
-    block_audio_final_len: int
+
+    @property
+    def block_audio_final_len(self):
+        # don't allow 0 or negative length audio, even if there's more overlap than actual audio
+        return max(50, self.block_audio_final_size - self.block_audio_final_overlap * 2)
+
 
 
 def to_aligned_offset(size):


### PR DESCRIPTION
* The last block was being resized causing some issues with the input data offsets. The fix is to just keep the blocksize the same, and just cut the audio at the end. This is much simpler too.
* Added a couple boundary conditions just in case the last block is smaller than the overlap.