### PR TITLE
Hifi Decode: Expander Fixes, Rename Noise Reduction parameters

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -65,7 +65,7 @@ DEFAULT_DEEMPHASIS_TAU_1 = 240e-6
 # high end of shelf curve
 DEFAULT_DEEMPHASIS_TAU_2 = 56e-6
 # slope of the filter
-DEFAULT_DEEMPHASIS_DB_PER_OCTAVE = 7
+DEFAULT_DEEMPHASIS_DB_PER_OCTAVE = 6.6
 
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -936,19 +936,23 @@ class NoiseReduction:
         nogil=True,
     )
     def apply_gate(
-        nr_env_gain: float, rsC: np.array, audio: np.array, audio_out: np.array
+        nr_env_gain: float, rsC: np.array, audio_with_deemphasis: np.array, audio_out: np.array
     ):
         # computes a sidechain signal to apply noise reduction
         # TODO If the expander gain is set to high, this gate will always be 1 and defeat the expander.
         #      This would benefit from some auto adjustment to keep the expander curve aligned to the audio.
         #      Perhaps a limiter with slow attack and release would keep the signal within the expander's range.
-        audio_len = min(len(audio), len(audio_out))
-        for i in range(audio_len):
+        audio_end = len(audio_out)
+        audio_start = audio_end - len(audio_with_deemphasis)
+        for i in range(0, audio_start):
+            audio_out[i] = 0
+
+        for i in range(audio_start, audio_end):
             # possibly this gate shouldn't be here
             gate = min(
                 DEFAULT_NR_EXPANDER_GATE_HARD_LIMIT, max(0, rsC[i] * nr_env_gain)
             )
-            audio_out[i] = audio[i] * gate
+            audio_out[i] = audio_with_deemphasis[i-audio_start] * gate
 
     def rs_envelope(self, raw_data):
         # prevent high frequency noise from interfering with envelope detector

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -51,7 +51,7 @@ except ImportError:
 
 from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_NR_EXPANDER_GAIN,
-    DEFAULT_NR_EXPANDER_LOG_STRENGTH,
+    DEFAULT_NR_EXPANDER_RATIO,
     DEFAULT_NR_EXPANDER_ATTACK_TAU,
     DEFAULT_NR_EXPANDER_RELEASE_TAU,
     DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
@@ -79,7 +79,7 @@ class MainUIParameters:
         self.volume: float = 1.0
         self.normalize = False
         self.nr_expander_gain: float = DEFAULT_NR_EXPANDER_GAIN
-        self.nr_expander_strength: float = DEFAULT_NR_EXPANDER_LOG_STRENGTH
+        self.nr_expander_ratio: float = DEFAULT_NR_EXPANDER_RATIO
         self.nr_attack_tau: float = DEFAULT_NR_EXPANDER_ATTACK_TAU
         self.nr_release_tau: float = DEFAULT_NR_EXPANDER_RELEASE_TAU
         self.nr_weighting_shelf_low_tau: float = DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1
@@ -116,7 +116,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
     values.nr_expander_gain = decode_options["nr_expander_gain"]
-    values.nr_expander_strength = decode_options["nr_expander_strength"]
+    values.nr_expander_ratio = decode_options["nr_expander_ratio"]
     values.nr_attack_tau = decode_options["nr_attack_tau"]
     values.nr_release_tau = decode_options["nr_release_tau"]
     values.nr_weighting_shelf_low_tau = decode_options["nr_weighting_shelf_low_tau"]
@@ -156,7 +156,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "auto_fine_tune": values.automatic_fine_tuning,
         "bias_guess": values.bias_guess,
         "nr_expander_gain": values.nr_expander_gain,
-        "nr_expander_strength": values.nr_expander_strength,
+        "nr_expander_ratio": values.nr_expander_ratio,
         "nr_attack_tau": values.nr_attack_tau,
         "nr_release_tau": values.nr_release_tau,
         "nr_weighting_shelf_low_tau": values.nr_weighting_shelf_low_tau,
@@ -656,13 +656,13 @@ class HifiUi(QMainWindow):
         expander_controls_frame.inner_layout.addWidget(self.noise_reduction_checkbox)
         expander_controls_layout = QHBoxLayout()
         self.nr_expander_gain_dial_control = DialControl(
-            self, "Gain", QtGui.QDoubleValidator(), 1, 0, 100
+            self, "Gain (db)", QtGui.QDoubleValidator(), 1, 0, 30
         )
         expander_controls_layout.addWidget(self.nr_expander_gain_dial_control)
-        self.nr_expander_strength_dial_control = DialControl(
-            self, "Strength", QtGui.QDoubleValidator(), 10, 1, 5
+        self.nr_expander_ratio_dial_control = DialControl(
+            self, "Ratio", QtGui.QDoubleValidator(), 1, 1, 10
         )
-        expander_controls_layout.addWidget(self.nr_expander_strength_dial_control)
+        expander_controls_layout.addWidget(self.nr_expander_ratio_dial_control)
         self.nr_attack_tau_dial_control = DialControl(
             self, "Attack (𝜏)", QtGui.QDoubleValidator(), 10e3, 10e-4, 10e-3
         )
@@ -756,7 +756,7 @@ class HifiUi(QMainWindow):
     def setValues(self, values: MainUIParameters):
         self.volume_dial_control.setValue(values.volume)
         self.nr_expander_gain_dial_control.setValue(values.nr_expander_gain)
-        self.nr_expander_strength_dial_control.setValue(values.nr_expander_strength)
+        self.nr_expander_ratio_dial_control.setValue(values.nr_expander_ratio)
         self.nr_attack_tau_dial_control.setValue(values.nr_attack_tau)
         self.nr_release_tau_dial_control.setValue(values.nr_release_tau)
         self.nr_weighting_shelf_low_tau_dial_control.setValue(
@@ -832,7 +832,7 @@ class HifiUi(QMainWindow):
         values = MainUIParameters()
         values.volume = self.volume_dial_control.value()
         values.nr_expander_gain = self.nr_expander_gain_dial_control.value()
-        values.nr_expander_strength = self.nr_expander_strength_dial_control.value()
+        values.nr_expander_ratio = self.nr_expander_ratio_dial_control.value()
         values.nr_attack_tau = self.nr_attack_tau_dial_control.value()
         values.nr_release_tau = self.nr_release_tau_dial_control.value()
         values.nr_weighting_shelf_low_tau = (

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -50,16 +50,16 @@ except ImportError:
     from PyQt5 import QtGui, QtCore
 
 from vhsdecode.hifi.HiFiDecode import (
-    DEFAULT_NR_EXPANDER_GAIN,
-    DEFAULT_NR_EXPANDER_RATIO,
-    DEFAULT_NR_EXPANDER_ATTACK_TAU,
-    DEFAULT_NR_EXPANDER_RELEASE_TAU,
-    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
-    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_NR_DEEMPHASIS_TAU_1,
-    DEFAULT_NR_DEEMPHASIS_TAU_2,
-    DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
+    DEFAULT_EXPANDER_GAIN,
+    DEFAULT_EXPANDER_RATIO,
+    DEFAULT_EXPANDER_ATTACK_TAU,
+    DEFAULT_EXPANDER_RELEASE_TAU,
+    DEFAULT_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_DEEMPHASIS_TAU_1,
+    DEFAULT_DEEMPHASIS_TAU_2,
+    DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEMOD_QUADRATURE,
@@ -78,23 +78,23 @@ class MainUIParameters:
     def __init__(self):
         self.volume: float = 1.0
         self.normalize = False
-        self.nr_expander_gain: float = DEFAULT_NR_EXPANDER_GAIN
-        self.nr_expander_ratio: float = DEFAULT_NR_EXPANDER_RATIO
-        self.nr_attack_tau: float = DEFAULT_NR_EXPANDER_ATTACK_TAU
-        self.nr_release_tau: float = DEFAULT_NR_EXPANDER_RELEASE_TAU
-        self.nr_weighting_shelf_low_tau: float = DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1
-        self.nr_weighting_shelf_high_tau: float = DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2
-        self.nr_weighting_db_per_octave: float = (
-            DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE
+        self.expander_gain: float = DEFAULT_EXPANDER_GAIN
+        self.expander_ratio: float = DEFAULT_EXPANDER_RATIO
+        self.expander_attack_tau: float = DEFAULT_EXPANDER_ATTACK_TAU
+        self.expander_release_tau: float = DEFAULT_EXPANDER_RELEASE_TAU
+        self.expander_weighting_shelf_low_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_1
+        self.expander_weighting_shelf_high_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_2
+        self.expander_weighting_db_per_octave: float = (
+            DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE
         )
-        self.nr_deemphasis_low_tau: float = DEFAULT_NR_DEEMPHASIS_TAU_1
-        self.nr_deemphasis_high_tau: float = DEFAULT_NR_DEEMPHASIS_TAU_2
-        self.nr_deemphasis_db_per_octave: float = DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE
+        self.deemphasis_low_tau: float = DEFAULT_DEEMPHASIS_TAU_1
+        self.deemphasis_high_tau: float = DEFAULT_DEEMPHASIS_TAU_2
+        self.deemphasis_db_per_octave: float = DEFAULT_DEEMPHASIS_DB_PER_OCTAVE
         self.afe_vco_deviation = 0
         self.afe_left_carrier = 0
         self.afe_right_carrier = 0
         self.spectral_nr_amount = DEFAULT_SPECTRAL_NR_AMOUNT
-        self.noise_reduction: bool = True
+        self.enable_expander: bool = True
         self.automatic_fine_tuning: bool = True
         self.bias_guess: bool = False
         self.grc = False
@@ -115,21 +115,21 @@ def decode_options_to_ui_parameters(decode_options):
     values = MainUIParameters()
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
-    values.nr_expander_gain = decode_options["nr_expander_gain"]
-    values.nr_expander_ratio = decode_options["nr_expander_ratio"]
-    values.nr_attack_tau = decode_options["nr_attack_tau"]
-    values.nr_release_tau = decode_options["nr_release_tau"]
-    values.nr_weighting_shelf_low_tau = decode_options["nr_weighting_shelf_low_tau"]
-    values.nr_weighting_shelf_high_tau = decode_options["nr_weighting_shelf_high_tau"]
-    values.nr_weighting_db_per_octave = decode_options["nr_weighting_db_per_octave"]
-    values.nr_deemphasis_low_tau = decode_options["nr_deemphasis_low_tau"]
-    values.nr_deemphasis_high_tau = decode_options["nr_deemphasis_high_tau"]
-    values.nr_deemphasis_db_per_octave = decode_options["nr_deemphasis_db_per_octave"]
+    values.enable_expander = decode_options["enable_expander"]
+    values.expander_gain = decode_options["expander_gain"]
+    values.expander_ratio = decode_options["expander_ratio"]
+    values.expander_attack_tau = decode_options["expander_attack_tau"]
+    values.expander_release_tau = decode_options["expander_release_tau"]
+    values.expander_weighting_shelf_low_tau = decode_options["expander_weighting_shelf_low_tau"]
+    values.expander_weighting_shelf_high_tau = decode_options["expander_weighting_shelf_high_tau"]
+    values.expander_weighting_db_per_octave = decode_options["expander_weighting_db_per_octave"]
+    values.deemphasis_low_tau = decode_options["deemphasis_low_tau"]
+    values.deemphasis_high_tau = decode_options["deemphasis_high_tau"]
+    values.deemphasis_db_per_octave = decode_options["deemphasis_db_per_octave"]
     values.afe_vco_deviation = decode_options["afe_vco_deviation"]
     values.afe_left_carrier = decode_options["afe_left_carrier"]
     values.afe_right_carrier = decode_options["afe_right_carrier"]
     values.spectral_nr_amount = decode_options["spectral_nr_amount"]
-    values.noise_reduction = decode_options["noise_reduction"]
     values.automatic_fine_tuning = decode_options["auto_fine_tune"]
     values.bias_guess = decode_options["bias_guess"]
     values.audio_sample_rate = decode_options["audio_rate"]
@@ -152,19 +152,19 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "standard": "p" if values.standard == "PAL" else "n",
         "format": "vhs" if values.format == "VHS" else "8mm",
         "demod_type": values.demod_type.lower(),
-        "noise_reduction": values.noise_reduction,
         "auto_fine_tune": values.automatic_fine_tuning,
         "bias_guess": values.bias_guess,
-        "nr_expander_gain": values.nr_expander_gain,
-        "nr_expander_ratio": values.nr_expander_ratio,
-        "nr_attack_tau": values.nr_attack_tau,
-        "nr_release_tau": values.nr_release_tau,
-        "nr_weighting_shelf_low_tau": values.nr_weighting_shelf_low_tau,
-        "nr_weighting_shelf_high_tau": values.nr_weighting_shelf_high_tau,
-        "nr_weighting_db_per_octave": values.nr_weighting_db_per_octave,
-        "nr_deemphasis_low_tau": values.nr_deemphasis_low_tau,
-        "nr_deemphasis_high_tau": values.nr_deemphasis_high_tau,
-        "nr_deemphasis_db_per_octave": values.nr_deemphasis_db_per_octave,
+        "enable_expander": values.enable_expander,
+        "expander_gain": values.expander_gain,
+        "expander_ratio": values.expander_ratio,
+        "expander_attack_tau": values.expander_attack_tau,
+        "expander_release_tau": values.expander_release_tau,
+        "expander_weighting_shelf_low_tau": values.expander_weighting_shelf_low_tau,
+        "expander_weighting_shelf_high_tau": values.expander_weighting_shelf_high_tau,
+        "expander_weighting_db_per_octave": values.expander_weighting_db_per_octave,
+        "deemphasis_low_tau": values.deemphasis_low_tau,
+        "deemphasis_high_tau": values.deemphasis_high_tau,
+        "deemphasis_db_per_octave": values.deemphasis_db_per_octave,
         "afe_vco_deviation": values.afe_vco_deviation,
         "afe_left_carrier": values.afe_left_carrier,
         "afe_right_carrier": values.afe_right_carrier,
@@ -301,7 +301,7 @@ class HifiUi(QMainWindow):
         demodulation_options = self.build_demodulation_options_section()
         controls_layout.addLayout(demodulation_options)
 
-        # Expander options
+        # Deemphasis options
         expander_deemphasis_options = self.build_expander_deemphasis_section()
         controls_layout.addLayout(expander_deemphasis_options)
 
@@ -652,25 +652,25 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(expander_controls_frame)
 
-        self.noise_reduction_checkbox = QCheckBox("Enable Expander/Deemphasis")
-        expander_controls_frame.inner_layout.addWidget(self.noise_reduction_checkbox)
+        self.enable_expander_checkbox = QCheckBox("Enable Expander/Deemphasis")
+        expander_controls_frame.inner_layout.addWidget(self.enable_expander_checkbox)
         expander_controls_layout = QHBoxLayout()
-        self.nr_expander_gain_dial_control = DialControl(
+        self.expander_gain_dial_control = DialControl(
             self, "Gain (db)", QtGui.QDoubleValidator(), 1, 0, 30
         )
-        expander_controls_layout.addWidget(self.nr_expander_gain_dial_control)
-        self.nr_expander_ratio_dial_control = DialControl(
-            self, "Ratio", QtGui.QDoubleValidator(), 1, 1, 10
+        expander_controls_layout.addWidget(self.expander_gain_dial_control)
+        self.expander_ratio_dial_control = DialControl(
+            self, "Ratio", QtGui.QDoubleValidator(), 100, 1, 10
         )
-        expander_controls_layout.addWidget(self.nr_expander_ratio_dial_control)
-        self.nr_attack_tau_dial_control = DialControl(
+        expander_controls_layout.addWidget(self.expander_ratio_dial_control)
+        self.expander_attack_tau_dial_control = DialControl(
             self, "Attack (𝜏)", QtGui.QDoubleValidator(), 10e3, 10e-4, 10e-3
         )
-        expander_controls_layout.addWidget(self.nr_attack_tau_dial_control)
-        self.nr_release_tau_dial_control = DialControl(
+        expander_controls_layout.addWidget(self.expander_attack_tau_dial_control)
+        self.expander_release_tau_dial_control = DialControl(
             self, "Release (𝜏)", QtGui.QDoubleValidator(), 10e2, 10e-3, 10e-2
         )
-        expander_controls_layout.addWidget(self.nr_release_tau_dial_control)
+        expander_controls_layout.addWidget(self.expander_release_tau_dial_control)
         expander_controls_frame.inner_layout.addLayout(expander_controls_layout)
 
         expander_sideband_frame = CollapsableSection(
@@ -680,28 +680,28 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(expander_sideband_frame)
         weighting_layout = QHBoxLayout()
-        self.nr_weighting_shelf_low_tau_dial_control = DialControl(
+        self.expander_weighting_shelf_low_tau_dial_control = DialControl(
             self,
             "Low Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
-            DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
+            DEFAULT_EXPANDER_WEIGHTING_TAU_2,
             10e-4,
         )
-        weighting_layout.addWidget(self.nr_weighting_shelf_low_tau_dial_control)
-        self.nr_weighting_shelf_high_tau_dial_control = DialControl(
+        weighting_layout.addWidget(self.expander_weighting_shelf_low_tau_dial_control)
+        self.expander_weighting_shelf_high_tau_dial_control = DialControl(
             self,
             "High Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
             10e-7,
-            DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
+            DEFAULT_EXPANDER_WEIGHTING_TAU_1,
         )
-        weighting_layout.addWidget(self.nr_weighting_shelf_high_tau_dial_control)
-        self.nr_weighting_db_per_octave_dial_control = DialControl(
+        weighting_layout.addWidget(self.expander_weighting_shelf_high_tau_dial_control)
+        self.expander_weighting_db_per_octave_dial_control = DialControl(
             self, "Slope (db/octave)", QtGui.QDoubleValidator(), 10, 0, 12
         )
-        weighting_layout.addWidget(self.nr_weighting_db_per_octave_dial_control)
+        weighting_layout.addWidget(self.expander_weighting_db_per_octave_dial_control)
         expander_sideband_frame.inner_layout.addLayout(weighting_layout)
 
         deemphasis_frame = CollapsableSection(
@@ -709,28 +709,28 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(deemphasis_frame)
         deemphasis_layout = QHBoxLayout()
-        self.nr_deemphasis_low_tau_dial_control = DialControl(
+        self.deemphasis_low_tau_dial_control = DialControl(
             self,
             "Low Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
-            DEFAULT_NR_DEEMPHASIS_TAU_2,
+            DEFAULT_DEEMPHASIS_TAU_2,
             10e-4,
         )
-        deemphasis_layout.addWidget(self.nr_deemphasis_low_tau_dial_control)
-        self.nr_deemphasis_high_tau_dial_control = DialControl(
+        deemphasis_layout.addWidget(self.deemphasis_low_tau_dial_control)
+        self.deemphasis_high_tau_dial_control = DialControl(
             self,
             "High Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
             10e-7,
-            DEFAULT_NR_DEEMPHASIS_TAU_1,
+            DEFAULT_DEEMPHASIS_TAU_1,
         )
-        deemphasis_layout.addWidget(self.nr_deemphasis_high_tau_dial_control)
-        self.nr_deemphasis_db_per_octave_dial_control = DialControl(
+        deemphasis_layout.addWidget(self.deemphasis_high_tau_dial_control)
+        self.deemphasis_db_per_octave_dial_control = DialControl(
             self, "Slope (db/octave)", QtGui.QDoubleValidator(), 10, 0, 12
         )
-        deemphasis_layout.addWidget(self.nr_deemphasis_db_per_octave_dial_control)
+        deemphasis_layout.addWidget(self.deemphasis_db_per_octave_dial_control)
         deemphasis_frame.inner_layout.addLayout(deemphasis_layout)
 
         return layout
@@ -755,28 +755,28 @@ class HifiUi(QMainWindow):
 
     def setValues(self, values: MainUIParameters):
         self.volume_dial_control.setValue(values.volume)
-        self.nr_expander_gain_dial_control.setValue(values.nr_expander_gain)
-        self.nr_expander_ratio_dial_control.setValue(values.nr_expander_ratio)
-        self.nr_attack_tau_dial_control.setValue(values.nr_attack_tau)
-        self.nr_release_tau_dial_control.setValue(values.nr_release_tau)
-        self.nr_weighting_shelf_low_tau_dial_control.setValue(
-            values.nr_weighting_shelf_low_tau
+        self.expander_gain_dial_control.setValue(values.expander_gain)
+        self.expander_ratio_dial_control.setValue(values.expander_ratio)
+        self.expander_attack_tau_dial_control.setValue(values.expander_attack_tau)
+        self.expander_release_tau_dial_control.setValue(values.expander_release_tau)
+        self.expander_weighting_shelf_low_tau_dial_control.setValue(
+            values.expander_weighting_shelf_low_tau
         )
-        self.nr_weighting_shelf_high_tau_dial_control.setValue(
-            values.nr_weighting_shelf_high_tau
+        self.expander_weighting_shelf_high_tau_dial_control.setValue(
+            values.expander_weighting_shelf_high_tau
         )
-        self.nr_weighting_db_per_octave_dial_control.setValue(
-            values.nr_weighting_db_per_octave
+        self.expander_weighting_db_per_octave_dial_control.setValue(
+            values.expander_weighting_db_per_octave
         )
-        self.nr_deemphasis_low_tau_dial_control.setValue(values.nr_deemphasis_low_tau)
-        self.nr_deemphasis_high_tau_dial_control.setValue(values.nr_deemphasis_high_tau)
-        self.nr_deemphasis_db_per_octave_dial_control.setValue(
-            values.nr_deemphasis_db_per_octave
+        self.deemphasis_low_tau_dial_control.setValue(values.deemphasis_low_tau)
+        self.deemphasis_high_tau_dial_control.setValue(values.deemphasis_high_tau)
+        self.deemphasis_db_per_octave_dial_control.setValue(
+            values.deemphasis_db_per_octave
         )
         self.spectral_nr_amount_dial_control.setValue(values.spectral_nr_amount)
         self.normalize_checkbox.setChecked(values.normalize)
         self.muting_checkbox.setChecked(values.muting)
-        self.noise_reduction_checkbox.setChecked(values.noise_reduction)
+        self.enable_expander_checkbox.setChecked(values.enable_expander)
         self.head_switching_interpolation_checkbox.setChecked(
             values.head_switching_interpolation
         )
@@ -831,23 +831,23 @@ class HifiUi(QMainWindow):
     def getValues(self) -> MainUIParameters:
         values = MainUIParameters()
         values.volume = self.volume_dial_control.value()
-        values.nr_expander_gain = self.nr_expander_gain_dial_control.value()
-        values.nr_expander_ratio = self.nr_expander_ratio_dial_control.value()
-        values.nr_attack_tau = self.nr_attack_tau_dial_control.value()
-        values.nr_release_tau = self.nr_release_tau_dial_control.value()
-        values.nr_weighting_shelf_low_tau = (
-            self.nr_weighting_shelf_low_tau_dial_control.value()
+        values.expander_gain = self.expander_gain_dial_control.value()
+        values.expander_ratio = self.expander_ratio_dial_control.value()
+        values.expander_attack_tau = self.expander_attack_tau_dial_control.value()
+        values.expander_release_tau = self.expander_release_tau_dial_control.value()
+        values.expander_weighting_shelf_low_tau = (
+            self.expander_weighting_shelf_low_tau_dial_control.value()
         )
-        values.nr_weighting_shelf_high_tau = (
-            self.nr_weighting_shelf_high_tau_dial_control.value()
+        values.expander_weighting_shelf_high_tau = (
+            self.expander_weighting_shelf_high_tau_dial_control.value()
         )
-        values.nr_weighting_db_per_octave = (
-            self.nr_weighting_db_per_octave_dial_control.value()
+        values.expander_weighting_db_per_octave = (
+            self.expander_weighting_db_per_octave_dial_control.value()
         )
-        values.nr_deemphasis_low_tau = self.nr_deemphasis_low_tau_dial_control.value()
-        values.nr_deemphasis_high_tau = self.nr_deemphasis_high_tau_dial_control.value()
-        values.nr_deemphasis_db_per_octave = (
-            self.nr_deemphasis_db_per_octave_dial_control.value()
+        values.deemphasis_low_tau = self.deemphasis_low_tau_dial_control.value()
+        values.deemphasis_high_tau = self.deemphasis_high_tau_dial_control.value()
+        values.deemphasis_db_per_octave = (
+            self.deemphasis_db_per_octave_dial_control.value()
         )
         values.afe_vco_deviation = self.afe_vco_deviation_spinbox.value()
         values.afe_left_carrier = self.afe_left_carrier_spinbox.value()
@@ -857,7 +857,7 @@ class HifiUi(QMainWindow):
         )
         values.normalize = self.normalize_checkbox.isChecked()
         values.muting = self.muting_checkbox.isChecked()
-        values.noise_reduction = self.noise_reduction_checkbox.isChecked()
+        values.enable_expander = self.enable_expander_checkbox.isChecked()
         values.head_switching_interpolation = (
             self.head_switching_interpolation_checkbox.isChecked()
         )

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -95,6 +95,7 @@ class MainUIParameters:
         self.afe_right_carrier = 0
         self.spectral_nr_amount = DEFAULT_SPECTRAL_NR_AMOUNT
         self.enable_expander: bool = True
+        self.enable_deemphasis: bool = True
         self.automatic_fine_tuning: bool = True
         self.bias_guess: bool = False
         self.grc = False
@@ -116,6 +117,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
     values.enable_expander = decode_options["enable_expander"]
+    values.enable_deemphasis = decode_options["enable_deemphasis"]
     values.expander_gain = decode_options["expander_gain"]
     values.expander_ratio = decode_options["expander_ratio"]
     values.expander_attack_tau = decode_options["expander_attack_tau"]
@@ -155,6 +157,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "auto_fine_tune": values.automatic_fine_tuning,
         "bias_guess": values.bias_guess,
         "enable_expander": values.enable_expander,
+        "enable_deemphasis": values.enable_deemphasis,
         "expander_gain": values.expander_gain,
         "expander_ratio": values.expander_ratio,
         "expander_attack_tau": values.expander_attack_tau,
@@ -652,7 +655,7 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(expander_controls_frame)
 
-        self.enable_expander_checkbox = QCheckBox("Enable Expander/Deemphasis")
+        self.enable_expander_checkbox = QCheckBox("Enabled")
         expander_controls_frame.inner_layout.addWidget(self.enable_expander_checkbox)
         expander_controls_layout = QHBoxLayout()
         self.expander_gain_dial_control = DialControl(
@@ -709,6 +712,9 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(deemphasis_frame)
         deemphasis_layout = QHBoxLayout()
+
+        self.enable_deemphasis_checkbox = QCheckBox("Enabled")
+        deemphasis_frame.inner_layout.addWidget(self.enable_deemphasis_checkbox)
         self.deemphasis_low_tau_dial_control = DialControl(
             self,
             "Low Shelf (𝜏)",
@@ -777,6 +783,7 @@ class HifiUi(QMainWindow):
         self.normalize_checkbox.setChecked(values.normalize)
         self.muting_checkbox.setChecked(values.muting)
         self.enable_expander_checkbox.setChecked(values.enable_expander)
+        self.enable_deemphasis_checkbox.setChecked(values.enable_deemphasis)
         self.head_switching_interpolation_checkbox.setChecked(
             values.head_switching_interpolation
         )
@@ -858,6 +865,7 @@ class HifiUi(QMainWindow):
         values.normalize = self.normalize_checkbox.isChecked()
         values.muting = self.muting_checkbox.isChecked()
         values.enable_expander = self.enable_expander_checkbox.isChecked()
+        values.enable_deemphasis = self.enable_deemphasis_checkbox.isChecked()
         values.head_switching_interpolation = (
             self.head_switching_interpolation_checkbox.isChecked()
         )

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -46,17 +46,17 @@ from vhsdecode.cmdcommons import (
 from vhsdecode.hifi.HiFiDecode import (
     HiFiDecode,
     SpectralNoiseReduction,
-    NoiseReduction,
-    DEFAULT_NR_EXPANDER_GAIN,
-    DEFAULT_NR_EXPANDER_RATIO,
-    DEFAULT_NR_EXPANDER_ATTACK_TAU,
-    DEFAULT_NR_EXPANDER_RELEASE_TAU,
-    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
-    DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_NR_DEEMPHASIS_TAU_1,
-    DEFAULT_NR_DEEMPHASIS_TAU_2,
-    DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
+    Expander,
+    DEFAULT_EXPANDER_GAIN,
+    DEFAULT_EXPANDER_RATIO,
+    DEFAULT_EXPANDER_ATTACK_TAU,
+    DEFAULT_EXPANDER_RELEASE_TAU,
+    DEFAULT_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_DEEMPHASIS_TAU_1,
+    DEFAULT_DEEMPHASIS_TAU_2,
+    DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
@@ -308,90 +308,91 @@ noise_reduction_options_group.add_argument(
     help=f"Sets the amount of broadband spectral noise reduction to apply. (default is {DEFAULT_SPECTRAL_NR_AMOUNT}). "
     f"Range (0~1): 0 being off, 1 being full spectral noise reduction",
 )
-noise_reduction_options_group.add_argument(
-    "--noise_reduction",
-    dest="noise_reduction",
-    type=str.lower,
-    default="on",
-    help="Set noise reduction block (deemphasis and expansion) on/off",
-)
 
 expander_options_group = parser.add_argument_group("Expander tuning options (advanced)")
 expander_options_group.add_argument(
-    "--NR_expander_gain",
-    dest="nr_expander_gain",
+    "--expander",
+    dest="enable_expander",
+    type=str.lower,
+    default="on",
+    help="Set expander block (deemphasis and expansion) on/off",
+)
+
+expander_options_group.add_argument(
+    "--expander_gain",
+    dest="expander_gain",
     type=float,
-    default=DEFAULT_NR_EXPANDER_GAIN,
-    help=f"Sets the expander gain (default is {DEFAULT_NR_EXPANDER_GAIN}). "
+    default=DEFAULT_EXPANDER_GAIN,
+    help=f"Sets the expander gain (default is {DEFAULT_EXPANDER_GAIN}). "
     f"Range (0~30): Higher values increase output gain of the expander",
 )
 expander_options_group.add_argument(
-    "--nr_expander_ratio",
-    dest="nr_expander_ratio",
+    "--expander_ratio",
+    dest="expander_ratio",
     type=float,
-    default=DEFAULT_NR_EXPANDER_RATIO,
-    help=f"Sets the ratio (default is {DEFAULT_NR_EXPANDER_RATIO}). "
+    default=DEFAULT_EXPANDER_RATIO,
+    help=f"Sets the ratio (default is {DEFAULT_EXPANDER_RATIO}). "
     f"Range (1~2): Higher values increase the ratio of the expander",
 )
 expander_options_group.add_argument(
-    "--NR_attack_tau",
-    dest="nr_attack_tau",
+    "--expander_attack_tau",
+    dest="expander_attack_tau",
     type=float,
-    default=DEFAULT_NR_EXPANDER_ATTACK_TAU,
-    help=f"Sets the expander attack speed in tau (default is {DEFAULT_NR_EXPANDER_ATTACK_TAU}).",
+    default=DEFAULT_EXPANDER_ATTACK_TAU,
+    help=f"Sets the expander attack speed in tau (default is {DEFAULT_EXPANDER_ATTACK_TAU}).",
 )
 expander_options_group.add_argument(
-    "--NR_release_tau",
-    dest="nr_release_tau",
+    "--expander_release_tau",
+    dest="expander_release_tau",
     type=float,
-    default=DEFAULT_NR_EXPANDER_RELEASE_TAU,
-    help=f"Sets the expander release speed in tau (default is {DEFAULT_NR_EXPANDER_RELEASE_TAU}).",
+    default=DEFAULT_EXPANDER_RELEASE_TAU,
+    help=f"Sets the expander release speed in tau (default is {DEFAULT_EXPANDER_RELEASE_TAU}).",
 )
 expander_options_group.add_argument(
-    "--NR_weighting_shelf_low_tau",
-    dest="nr_weighting_shelf_low_tau",
+    "--expander_weighting_shelf_low_tau",
+    dest="expander_weighting_shelf_low_tau",
     type=float,
-    default=DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
-    help=f"Sets the expander sidechain high-pass shelf filter low point in tau (default is {DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1}).",
+    default=DEFAULT_EXPANDER_WEIGHTING_TAU_1,
+    help=f"Sets the expander sidechain high-pass shelf filter low point in tau (default is {DEFAULT_EXPANDER_WEIGHTING_TAU_1}).",
 )
 expander_options_group.add_argument(
-    "--NR_weighting_shelf_high_tau",
-    dest="nr_weighting_shelf_high_tau",
+    "--expander_weighting_shelf_high_tau",
+    dest="expander_weighting_shelf_high_tau",
     type=float,
-    default=DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2,
-    help=f"Sets the expander sidechain high-pass shelf filter high point in tau (default is {DEFAULT_NR_EXPANDER_WEIGHTING_TAU_2}).",
+    default=DEFAULT_EXPANDER_WEIGHTING_TAU_2,
+    help=f"Sets the expander sidechain high-pass shelf filter high point in tau (default is {DEFAULT_EXPANDER_WEIGHTING_TAU_2}).",
 )
 expander_options_group.add_argument(
-    "--NR_weighting_db_per_octave",
-    dest="nr_weighting_db_per_octave",
+    "--expander_weighting_db_per_octave",
+    dest="expander_weighting_db_per_octave",
     type=float,
-    default=DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    help=f"Sets the expander sidechain high-pass shelf filter cutoff rate (default is {DEFAULT_NR_EXPANDER_WEIGHTING_DB_PER_OCTAVE}).",
+    default=DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    help=f"Sets the expander sidechain high-pass shelf filter cutoff rate (default is {DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE}).",
 )
 
 deemphasis_options_group = parser.add_argument_group(
     "Deemphasis tuning options (advanced)"
 )
 deemphasis_options_group.add_argument(
-    "--NR_deemphasis_low_tau",
-    dest="nr_deemphasis_low_tau",
+    "--deemphasis_low_tau",
+    dest="deemphasis_low_tau",
     type=float,
-    default=DEFAULT_NR_DEEMPHASIS_TAU_1,
-    help=f"Sets the deemphasis low-pass shelf filter low point in tau (default is {DEFAULT_NR_DEEMPHASIS_TAU_1}).",
+    default=DEFAULT_DEEMPHASIS_TAU_1,
+    help=f"Sets the deemphasis low-pass shelf filter low point in tau (default is {DEFAULT_DEEMPHASIS_TAU_1}).",
 )
 deemphasis_options_group.add_argument(
-    "--NR_deemphasis_high_tau",
-    dest="nr_deemphasis_high_tau",
+    "--deemphasis_high_tau",
+    dest="deemphasis_high_tau",
     type=float,
-    default=DEFAULT_NR_DEEMPHASIS_TAU_2,
-    help=f"Sets the deemphasis low-pass shelf filter high point in tau (default is {DEFAULT_NR_DEEMPHASIS_TAU_2}).",
+    default=DEFAULT_DEEMPHASIS_TAU_2,
+    help=f"Sets the deemphasis low-pass shelf filter high point in tau (default is {DEFAULT_DEEMPHASIS_TAU_2}).",
 )
 deemphasis_options_group.add_argument(
-    "--NR_deemphasis_db_per_octave",
-    dest="nr_deemphasis_db_per_octave",
+    "--deemphasis_db_per_octave",
+    dest="deemphasis_db_per_octave",
     type=float,
-    default=DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE,
-    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (default is {DEFAULT_NR_DEEMPHASIS_DB_PER_OCTAVE}).",
+    default=DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
+    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (default is {DEFAULT_DEEMPHASIS_DB_PER_OCTAVE}).",
 )
 
 
@@ -861,18 +862,18 @@ class PostProcessor:
         peak_gain,
     ):
         self.final_audio_rate = decode_options["audio_rate"]
-        self.use_noise_reduction = decode_options["noise_reduction"]
+        self.enable_expander = decode_options["enable_expander"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
         self.peak_gain = peak_gain
 
         # create processes and wire up queues
         #
         #                                 (left channel)
-        #                               spectral_noise_reduction_worker --> noise_reduction_worker
+        #                               spectral_noise_reduction_worker --> expander_worker
         #                             /                                                            \
         # data in --[block_sorter]----                                                              --> mix_to_stereo_worker --> data out
         #                             \   (right channel)                                          /
-        #                               spectral_noise_reduction_worker --> noise_reduction_worker
+        #                               spectral_noise_reduction_worker --> expander_worker
 
         self.decoder_out_queue = decoder_out_queue
         self.mix_to_stereo_worker_output = out_conn
@@ -893,8 +894,8 @@ class PostProcessor:
             atexit.register(shared_memory.close)
             atexit.register(shared_memory.unlink)
 
-        nr_worker_l_in_output, nr_worker_l_in_input = Pipe(duplex=False)
-        nr_worker_r_in_output, nr_worker_r_in_input = Pipe(duplex=False)
+        spec_nr_worker_l_in_rx, spec_nr_worker_l_in_tx = Pipe(duplex=False)
+        spec_nr_worker_r_in_rx, spec_nr_worker_r_in_tx = Pipe(duplex=False)
         self.block_sorter_process = Process(
             target=PostProcessor.block_sorter_worker,
             name="hifi_block_sort",
@@ -903,21 +904,21 @@ class PostProcessor:
                 self.decoder_shared_memory_idle_queue,
                 self.blocks_enqueued,
                 self.post_processor_shared_memory_idle_queue,
-                nr_worker_l_in_input,
-                nr_worker_r_in_input,
+                spec_nr_worker_l_in_tx,
+                spec_nr_worker_r_in_tx,
             ),
         )
         self.block_sorter_process.start()
         atexit.register(self.block_sorter_process.terminate)
         atexit.register(self.block_sorter_process.join)
 
-        spectral_nr_worker_l_output, spectral_nr_worker_l_input = Pipe(duplex=False)
+        spectral_nr_worker_l_rx, spectral_nr_worker_l_tx = Pipe(duplex=False)
         self.spectral_nr_worker_l = Process(
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_l",
             args=(
-                nr_worker_l_in_output,
-                spectral_nr_worker_l_input,
+                spec_nr_worker_l_in_rx,
+                spectral_nr_worker_l_tx,
                 self.spectral_nr_amount,
                 self.final_audio_rate,
             ),
@@ -926,13 +927,13 @@ class PostProcessor:
         atexit.register(self.spectral_nr_worker_l.terminate)
         atexit.register(self.spectral_nr_worker_l.join)
 
-        spectral_nr_worker_r_output, spectral_nr_worker_r_input = Pipe(duplex=False)
+        spectral_nr_worker_r_rx, spectral_nr_worker_r_tx = Pipe(duplex=False)
         self.spectral_nr_worker_r = Process(
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_r",
             args=(
-                nr_worker_r_in_output,
-                spectral_nr_worker_r_input,
+                spec_nr_worker_r_in_rx,
+                spectral_nr_worker_r_tx,
                 self.spectral_nr_amount,
                 self.final_audio_rate,
             ),
@@ -941,62 +942,62 @@ class PostProcessor:
         atexit.register(self.spectral_nr_worker_r.terminate)
         atexit.register(self.spectral_nr_worker_r.join)
 
-        nr_worker_l_out_output, nr_worker_l_out_input = Pipe(duplex=False)
-        self.nr_worker_l = Process(
-            target=PostProcessor.noise_reduction_worker,
+        expander_worker_l_out_rx, expander_worker_l_out_tx = Pipe(duplex=False)
+        self.expander_worker_l = Process(
+            target=PostProcessor.expander_worker,
             name="hifi_expander_l",
             args=(
-                spectral_nr_worker_l_output,
-                nr_worker_l_out_input,
-                self.use_noise_reduction,
+                spectral_nr_worker_l_rx,
+                expander_worker_l_out_tx,
+                self.enable_expander,
                 self.final_audio_rate,
-                decode_options["nr_expander_gain"],
-                decode_options["nr_expander_ratio"],
-                decode_options["nr_attack_tau"],
-                decode_options["nr_release_tau"],
-                decode_options["nr_weighting_shelf_low_tau"],
-                decode_options["nr_weighting_shelf_high_tau"],
-                decode_options["nr_weighting_db_per_octave"],
-                decode_options["nr_deemphasis_low_tau"],
-                decode_options["nr_deemphasis_high_tau"],
-                decode_options["nr_deemphasis_db_per_octave"],
+                decode_options["expander_gain"],
+                decode_options["expander_ratio"],
+                decode_options["expander_attack_tau"],
+                decode_options["expander_release_tau"],
+                decode_options["expander_weighting_shelf_low_tau"],
+                decode_options["expander_weighting_shelf_high_tau"],
+                decode_options["expander_weighting_db_per_octave"],
+                decode_options["deemphasis_low_tau"],
+                decode_options["deemphasis_high_tau"],
+                decode_options["deemphasis_db_per_octave"],
             ),
         )
-        self.nr_worker_l.start()
-        atexit.register(self.nr_worker_l.terminate)
-        atexit.register(self.nr_worker_l.join)
+        self.expander_worker_l.start()
+        atexit.register(self.expander_worker_l.terminate)
+        atexit.register(self.expander_worker_l.join)
 
-        nr_worker_r_out_output, nr_worker_r_out_input = Pipe(duplex=False)
-        self.nr_worker_r = Process(
-            target=PostProcessor.noise_reduction_worker,
+        expander_worker_r_out_rx, expander_worker_r_out_tx = Pipe(duplex=False)
+        self.expander_worker_r = Process(
+            target=PostProcessor.expander_worker,
             name="hifi_expander_r",
             args=(
-                spectral_nr_worker_r_output,
-                nr_worker_r_out_input,
-                self.use_noise_reduction,
+                spectral_nr_worker_r_rx,
+                expander_worker_r_out_tx,
+                self.enable_expander,
                 self.final_audio_rate,
-                decode_options["nr_expander_gain"],
-                decode_options["nr_expander_ratio"],
-                decode_options["nr_attack_tau"],
-                decode_options["nr_release_tau"],
-                decode_options["nr_weighting_shelf_low_tau"],
-                decode_options["nr_weighting_shelf_high_tau"],
-                decode_options["nr_weighting_db_per_octave"],
-                decode_options["nr_deemphasis_low_tau"],
-                decode_options["nr_deemphasis_high_tau"],
-                decode_options["nr_deemphasis_db_per_octave"],
+                decode_options["expander_gain"],
+                decode_options["expander_ratio"],
+                decode_options["expander_attack_tau"],
+                decode_options["expander_release_tau"],
+                decode_options["expander_weighting_shelf_low_tau"],
+                decode_options["expander_weighting_shelf_high_tau"],
+                decode_options["expander_weighting_db_per_octave"],
+                decode_options["deemphasis_low_tau"],
+                decode_options["deemphasis_high_tau"],
+                decode_options["deemphasis_db_per_octave"],
             ),
         )
-        self.nr_worker_r.start()
-        atexit.register(self.nr_worker_r.terminate)
-        atexit.register(self.nr_worker_r.join)
+        self.expander_worker_r.start()
+        atexit.register(self.expander_worker_r.terminate)
+        atexit.register(self.expander_worker_r.join)
 
         self.mix_to_stereo_worker_process = Process(
             target=PostProcessor.mix_to_stereo_worker,
             name="hifi_stereo_mix",
             args=(
-                nr_worker_l_out_output,
-                nr_worker_r_out_output,
+                expander_worker_l_out_rx,
+                expander_worker_r_out_rx,
                 self.mix_to_stereo_worker_output,
                 self.peak_gain,
                 self.final_audio_rate,
@@ -1044,10 +1045,10 @@ class PostProcessor:
             buffer = PostProcessorSharedMemory(decoder_state)
             if channel_num == 0:
                 pre = buffer.get_pre_left()
-                spectral_nr_out = buffer.get_nr_left()
+                spectral_nr_out = buffer.get_post_left()
             else:
                 pre = buffer.get_pre_right()
-                spectral_nr_out = buffer.get_nr_right()
+                spectral_nr_out = buffer.get_post_right()
 
             if spectral_nr_amount > 0:
                 spectral_nr.spectral_nr(pre, spectral_nr_out)
@@ -1060,35 +1061,35 @@ class PostProcessor:
             out_conn.send((decoder_state, channel_num))
 
     @staticmethod
-    def noise_reduction_worker(
+    def expander_worker(
         in_conn,
         out_conn,
-        use_noise_reduction,
+        enable_expander,
         final_audio_rate,
-        nr_expander_gain,
-        nr_expander_ratio,
-        nr_attack_tau,
-        nr_release_tau,
-        nr_weighting_shelf_low_tau,
-        nr_weighting_shelf_high_tau,
-        nr_weighting_db_per_octave,
-        nr_deemphasis_low_tau,
-        nr_deemphasis_high_tau,
-        nr_deemphasis_db_per_octave,
+        expander_gain,
+        expander_ratio,
+        expander_attack_tau,
+        expander_release_tau,
+        expander_weighting_shelf_low_tau,
+        expander_weighting_shelf_high_tau,
+        expander_weighting_db_per_octave,
+        deemphasis_low_tau,
+        deemphasis_high_tau,
+        deemphasis_db_per_octave,
     ):
         setproctitle(current_process().name)
-        noise_reduction = NoiseReduction(
+        expander = Expander(
             final_audio_rate,
-            nr_expander_gain,
-            nr_expander_ratio,
-            nr_attack_tau,
-            nr_release_tau,
-            nr_weighting_shelf_low_tau,
-            nr_weighting_shelf_high_tau,
-            nr_weighting_db_per_octave,
-            nr_deemphasis_low_tau,
-            nr_deemphasis_high_tau,
-            nr_deemphasis_db_per_octave,
+            expander_gain,
+            expander_ratio,
+            expander_attack_tau,
+            expander_release_tau,
+            expander_weighting_shelf_low_tau,
+            expander_weighting_shelf_high_tau,
+            expander_weighting_db_per_octave,
+            deemphasis_low_tau,
+            deemphasis_high_tau,
+            deemphasis_db_per_octave,
         )
 
         while True:
@@ -1104,16 +1105,16 @@ class PostProcessor:
             buffer = PostProcessorSharedMemory(decoder_state)
             if channel_num == 0:
                 pre = buffer.get_pre_left()
-                nr_out = buffer.get_nr_left()
+                expander_out = buffer.get_post_left()
             else:
                 pre = buffer.get_pre_right()
-                nr_out = buffer.get_nr_right()
+                expander_out = buffer.get_post_right()
 
-            if use_noise_reduction:
-                noise_reduction.noise_reduction(pre, nr_out)
+            if enable_expander:
+                expander.expand(pre, expander_out)
             else:
                 DecoderSharedMemory.copy_data_float32(
-                    pre, nr_out, decoder_state.block_audio_final_len
+                    pre, expander_out, decoder_state.block_audio_final_len
                 )
 
             buffer.close()
@@ -1121,13 +1122,13 @@ class PostProcessor:
 
     @staticmethod
     def mix_to_stereo_worker(
-        nr_l_in_conn, nr_r_in_conn, out_conn, peak_gain, sample_rate
+        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
     ):
         setproctitle(current_process().name)
         while True:
             while True:
                 try:
-                    l_decoder_state = nr_l_in_conn.recv()
+                    l_decoder_state = expander_l_in_conn.recv()
                     break
                 except InterruptedError:
                     pass
@@ -1136,7 +1137,7 @@ class PostProcessor:
 
             while True:
                 try:
-                    r_decoder_state = nr_r_in_conn.recv()
+                    r_decoder_state = expander_r_in_conn.recv()
                     break
                 except InterruptedError:
                     pass
@@ -1149,8 +1150,8 @@ class PostProcessor:
 
             decoder_state = l_decoder_state
             buffer = PostProcessorSharedMemory(decoder_state)
-            l = buffer.get_nr_left()
-            r = buffer.get_nr_right()
+            l = buffer.get_post_left()
+            r = buffer.get_post_right()
             stereo = buffer.get_stereo()
 
             max_gain = PostProcessor.stereo_interleave(
@@ -1217,8 +1218,8 @@ class PostProcessor:
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
         post_processor_shared_memory_idle_queue,
-        nr_worker_l_in_conn,
-        nr_worker_r_in_conn,
+        l_tx,
+        r_tx,
     ):
         setproctitle(current_process().name)
         next_block = 0
@@ -1297,8 +1298,8 @@ class PostProcessor:
                         decoder_state.block_audio_final_len,
                     )
 
-                    nr_worker_l_in_conn.send((decoder_state, 0))
-                    nr_worker_r_in_conn.send((decoder_state, 1))
+                    l_tx.send((decoder_state, 0))
+                    r_tx.send((decoder_state, 1))
 
                     next_block += 1
                     last_block_submitted = decoder_state.block_num
@@ -1308,8 +1309,8 @@ class PostProcessor:
         cleanup_process(self.block_sorter_process)
         cleanup_process(self.spectral_nr_worker_l)
         cleanup_process(self.spectral_nr_worker_r)
-        cleanup_process(self.nr_worker_l)
-        cleanup_process(self.nr_worker_r)
+        cleanup_process(self.expander_worker_l)
+        cleanup_process(self.expander_worker_r)
         cleanup_process(self.mix_to_stereo_worker_process)
 
 
@@ -1415,7 +1416,7 @@ class SoundDeviceProcess:
 
 
 def write_soundfile_process_worker(
-    post_processor_out_output_conn,
+    post_processor_out_rx_conn,
     blocks_enqueued,
     post_processor_shared_memory_idle_queue,
     start_time,
@@ -1442,7 +1443,7 @@ def write_soundfile_process_worker(
         while not done:
             while True:
                 try:
-                    decoder_state = post_processor_out_output_conn.recv()
+                    decoder_state = post_processor_out_rx_conn.recv()
                     break
                 except InterruptedError:
                     pass
@@ -1563,7 +1564,7 @@ async def decode_parallel(
         decoder_processes.append(decoder_process)
 
     # set up the post processor
-    post_processor_out_output_conn, post_processor_out_input_conn = Pipe(duplex=False)
+    post_processor_out_rx_conn, post_processor_out_tx_conn = Pipe(duplex=False)
     post_processor_shared_memory_idle_queue = SimpleQueue()
     post_processor = PostProcessor(
         decode_options,
@@ -1572,7 +1573,7 @@ async def decode_parallel(
         post_processor_shared_memory_idle_queue,
         shared_memory_idle_queue,
         blocks_enqueued,
-        post_processor_out_input_conn,
+        post_processor_out_tx_conn,
         peak_gain,
     )
     atexit.register(post_processor.close)
@@ -1582,7 +1583,7 @@ async def decode_parallel(
         target=write_soundfile_process_worker,
         name="hifi_output_encoder",
         args=(
-            post_processor_out_output_conn,
+            post_processor_out_rx_conn,
             blocks_enqueued,
             post_processor_shared_memory_idle_queue,
             start_time,
@@ -1921,20 +1922,20 @@ def main() -> int:
         "spectral_nr_amount": args.spectral_nr_amount if not args.preview else 0,
         "head_switching_interpolation": args.head_switching_interpolation == "on",
         "muting": args.muting == "on",
-        "noise_reduction": args.noise_reduction == "on",
+        "enable_expander": args.enable_expander == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "bias_guess": args.bias_guess,
         "normalize": args.normalize,
-        "nr_expander_gain": args.nr_expander_gain,
-        "nr_expander_ratio": args.nr_expander_ratio,
-        "nr_attack_tau": args.nr_attack_tau,
-        "nr_release_tau": args.nr_release_tau,
-        "nr_weighting_shelf_low_tau": args.nr_weighting_shelf_low_tau,
-        "nr_weighting_shelf_high_tau": args.nr_weighting_shelf_high_tau,
-        "nr_weighting_db_per_octave": args.nr_weighting_db_per_octave,
-        "nr_deemphasis_low_tau": args.nr_deemphasis_low_tau,
-        "nr_deemphasis_high_tau": args.nr_deemphasis_high_tau,
-        "nr_deemphasis_db_per_octave": args.nr_deemphasis_db_per_octave,
+        "expander_gain": args.expander_gain,
+        "expander_ratio": args.expander_ratio,
+        "expander_attack_tau": args.expander_attack_tau,
+        "expander_release_tau": args.expander_release_tau,
+        "expander_weighting_shelf_low_tau": args.expander_weighting_shelf_low_tau,
+        "expander_weighting_shelf_high_tau": args.expander_weighting_shelf_high_tau,
+        "expander_weighting_db_per_octave": args.expander_weighting_db_per_octave,
+        "deemphasis_low_tau": args.deemphasis_low_tau,
+        "deemphasis_high_tau": args.deemphasis_high_tau,
+        "deemphasis_db_per_octave": args.deemphasis_db_per_octave,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,
         "gain": args.gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -964,6 +964,7 @@ class PostProcessor:
         )
         self.nr_worker_l.start()
         atexit.register(self.nr_worker_l.terminate)
+        atexit.register(self.nr_worker_l.join)
 
         nr_worker_r_out_output, nr_worker_r_out_input = Pipe(duplex=False)
         self.nr_worker_r = Process(

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -7,12 +7,12 @@ from multiprocessing import (
     Pipe,
     SimpleQueue,
     Process,
-    Value,
     freeze_support,
     current_process,
     Event,
     set_start_method
 )
+from multiprocessing.sharedctypes import Value
 from datetime import datetime, timedelta
 import os
 import sys

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -10,7 +10,6 @@ from multiprocessing import (
     freeze_support,
     current_process,
     Event,
-    set_start_method
 )
 from multiprocessing.sharedctypes import Value
 from datetime import datetime, timedelta
@@ -1490,7 +1489,7 @@ def write_soundfile_process_worker(
                 total_samples_decoded.value = int(
                     total_samples_decoded.value + samples_decoded
                 )
-                
+
             log_decode(
                 start_time,
                 input_position.value,
@@ -2092,5 +2091,4 @@ else:
 
 if __name__ == "__main__":
     freeze_support()
-    set_start_method('spawn')
-    Process(target=main).start()
+    sys.exit(main())

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -2071,4 +2071,4 @@ else:
 if __name__ == "__main__":
     freeze_support()
     set_start_method('spawn')
-    sys.exit(main())
+    Process(target=main).start()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -11,6 +11,7 @@ from multiprocessing import (
     freeze_support,
     current_process,
     Event,
+    set_start_method
 )
 from datetime import datetime, timedelta
 import os
@@ -2064,4 +2065,5 @@ else:
 
 if __name__ == "__main__":
     freeze_support()
+    set_start_method('spawn')
     sys.exit(main())

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -48,7 +48,7 @@ from vhsdecode.hifi.HiFiDecode import (
     SpectralNoiseReduction,
     NoiseReduction,
     DEFAULT_NR_EXPANDER_GAIN,
-    DEFAULT_NR_EXPANDER_LOG_STRENGTH,
+    DEFAULT_NR_EXPANDER_RATIO,
     DEFAULT_NR_EXPANDER_ATTACK_TAU,
     DEFAULT_NR_EXPANDER_RELEASE_TAU,
     DEFAULT_NR_EXPANDER_WEIGHTING_TAU_1,
@@ -323,15 +323,15 @@ expander_options_group.add_argument(
     type=float,
     default=DEFAULT_NR_EXPANDER_GAIN,
     help=f"Sets the expander gain (default is {DEFAULT_NR_EXPANDER_GAIN}). "
-    f"Range (20~100): Higher values increase the effect of the expander",
+    f"Range (0~30): Higher values increase output gain of the expander",
 )
 expander_options_group.add_argument(
-    "--NR_expander_strength",
-    dest="nr_expander_strength",
+    "--nr_expander_ratio",
+    dest="nr_expander_ratio",
     type=float,
-    default=DEFAULT_NR_EXPANDER_LOG_STRENGTH,
-    help=f"Sets the expander logarithmic strength (default is {DEFAULT_NR_EXPANDER_LOG_STRENGTH}). "
-    f"Range (1~2): Higher values increase the logarithmic slope of the expander",
+    default=DEFAULT_NR_EXPANDER_RATIO,
+    help=f"Sets the ratio (default is {DEFAULT_NR_EXPANDER_RATIO}). "
+    f"Range (1~2): Higher values increase the ratio of the expander",
 )
 expander_options_group.add_argument(
     "--NR_attack_tau",
@@ -951,7 +951,7 @@ class PostProcessor:
                 self.use_noise_reduction,
                 self.final_audio_rate,
                 decode_options["nr_expander_gain"],
-                decode_options["nr_expander_strength"],
+                decode_options["nr_expander_ratio"],
                 decode_options["nr_attack_tau"],
                 decode_options["nr_release_tau"],
                 decode_options["nr_weighting_shelf_low_tau"],
@@ -976,7 +976,7 @@ class PostProcessor:
                 self.use_noise_reduction,
                 self.final_audio_rate,
                 decode_options["nr_expander_gain"],
-                decode_options["nr_expander_strength"],
+                decode_options["nr_expander_ratio"],
                 decode_options["nr_attack_tau"],
                 decode_options["nr_release_tau"],
                 decode_options["nr_weighting_shelf_low_tau"],
@@ -1066,7 +1066,7 @@ class PostProcessor:
         use_noise_reduction,
         final_audio_rate,
         nr_expander_gain,
-        nr_expander_strength,
+        nr_expander_ratio,
         nr_attack_tau,
         nr_release_tau,
         nr_weighting_shelf_low_tau,
@@ -1080,7 +1080,7 @@ class PostProcessor:
         noise_reduction = NoiseReduction(
             final_audio_rate,
             nr_expander_gain,
-            nr_expander_strength,
+            nr_expander_ratio,
             nr_attack_tau,
             nr_release_tau,
             nr_weighting_shelf_low_tau,
@@ -1926,7 +1926,7 @@ def main() -> int:
         "bias_guess": args.bias_guess,
         "normalize": args.normalize,
         "nr_expander_gain": args.nr_expander_gain,
-        "nr_expander_strength": args.nr_expander_strength,
+        "nr_expander_ratio": args.nr_expander_ratio,
         "nr_attack_tau": args.nr_attack_tau,
         "nr_release_tau": args.nr_release_tau,
         "nr_weighting_shelf_low_tau": args.nr_weighting_shelf_low_tau,

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -86,7 +86,7 @@ class PostProcessorSharedMemory:
         self.audio_dtype_item_size = np.dtype(self.audio_dtype).itemsize
 
         ### Post Processing Memory
-        # |--pre_left--|--pre_right--|--nr_left--|--nr_right--|
+        # |--pre_left--|--pre_right--|--post_left--|--post_right--|
         # |-----------stereo---------|
 
         # pre left
@@ -106,18 +106,18 @@ class PostProcessorSharedMemory:
 
         ## noise reduction out
         # left
-        self.l_nr_offset = to_aligned_offset(
+        self.l_post_offset = to_aligned_offset(
             max(
                 self.stereo_offset + self.stereo_bytes,
                 self.r_pre_offset + self.r_pre_bytes,
             )
         )
-        self.l_nr_len = self.channel_len
-        self.l_nr_bytes = self.l_nr_len * self.audio_dtype_item_size
+        self.l_post_len = self.channel_len
+        self.l_post_bytes = self.l_post_len * self.audio_dtype_item_size
         # right
-        self.r_nr_offset = to_aligned_offset(self.l_nr_offset + self.l_nr_bytes)
-        self.r_nr_len = self.channel_len
-        self.r_nr_bytes = self.r_nr_len * self.audio_dtype_item_size
+        self.r_post_offset = to_aligned_offset(self.l_post_offset + self.l_post_bytes)
+        self.r_post_len = self.channel_len
+        self.r_post_bytes = self.r_post_len * self.audio_dtype_item_size
 
     @staticmethod
     def get_shared_memory(channel_size, name, audio_dtype=REAL_DTYPE):
@@ -163,19 +163,19 @@ class PostProcessorSharedMemory:
             buffer=self.buf,
         )
 
-    def get_nr_left(self) -> np.array:
+    def get_post_left(self) -> np.array:
         return np.ndarray(
-            self.l_nr_len,
+            self.l_post_len,
             dtype=self.audio_dtype,
-            offset=self.l_nr_offset,
+            offset=self.l_post_offset,
             buffer=self.buf,
         )
 
-    def get_nr_right(self) -> np.array:
+    def get_post_right(self) -> np.array:
         return np.ndarray(
-            self.r_nr_len,
+            self.r_post_len,
             dtype=self.audio_dtype,
-            offset=self.r_nr_offset,
+            offset=self.r_post_offset,
             buffer=self.buf,
         )
 


### PR DESCRIPTION
## Fixes
* Fix the expander so it uses a 1:2 ratio
* Fix possible segfault

## Features
* Add `--deemphasis` that allows enabled / disabled independent of the expander
* Reduce I/Q oscillator memory by half by storing half a cycle, and store in each process

## Parameter Renames
### Renamed expander parameters
|Old Name|New Name|
|-|-|
|`--noise_reduction`|`--expander`|
|`--NR_expander_gain`|`--expander_gain`|
|`--NR_expander_strength`|`--expander_ratio`|
|`--NR_attack_tau`|`--expander_attack_tau`|
|`--NR_release_tau`|`--expander_release_tau`|
|`--NR_weighting_shelf_low_tau`|`--expander_weighting_shelf_low_tau`|
|`--NR_weighting_shelf_high_tau`|`--expander_weighting_shelf_high_tau`|
|`--NR_weighting_db_per_octave`|`--expander_weighting_db_per_octave`|

### Renamed deemphasis parameters
|Old Name|New Name|
|-|-|
|`--NR_deemphasis_low_tau`|`--deemphasis_low_tau`|
|`--NR_deemphasis_high_tau`|`--deemphasis_high_tau`|
|`--NR_deemphasis_db_per_octave`|`--deemphasis_db_per_octave`|