### PR TITLE
cvbsdecode/main.py: fix to allow running from the source directory

### DIFF
--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -4,6 +4,10 @@ import os
 import sys
 import signal
 import traceback
+
+import numpy
+import pyximport; pyximport.install(language_level=3, setup_args={'include_dirs': numpy.get_include()}, reload_support=True)  # noqa: E702
+
 import lddecode.utils as lddu
 from lddecode.utils_logging import init_logging
 from cvbsdecode.process import CVBSDecode


### PR DESCRIPTION
Copied from vhsdecode/main.py.  Without this, it fails to import vhsdecode.sync