### PR TITLE
hifi-decode: fix phase, expander / deemphasis tuning

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -48,7 +48,7 @@ import matplotlib.pyplot as plt
 # lower increases expander strength and decreases overall gain
 DEFAULT_EXPANDER_GAIN = 16
 DEFAULT_EXPANDER_RATIO = 2
-DEFAULT_EXPANDER_ATTACK_TAU = 3e-3
+DEFAULT_EXPANDER_ATTACK_TAU = 5e-3
 DEFAULT_EXPANDER_RELEASE_TAU = 70e-3
 
 # High shelf filter parameters for weighted sidechain input to expander
@@ -864,12 +864,11 @@ class Expander:
 
         # makeup gain to apply after expansion
         self.gain = 10 ** (gain / 20)
-        self.ratio = ratio
+        self.ratio = float(ratio)
+        self.atkCoeff = np.exp(-1.0 / (attack_tau * self.audio_rate))
+        self.relCoeff = np.exp(-1.0 / (release_tau * self.audio_rate))
 
-        self.weighting_attack_Lo_cut = tau_as_freq(attack_tau)
-        self.weighting_attack_Lo_transition = 1e3
-        self.weighting_release_Lo_cut = tau_as_freq(release_tau)
-        self.weighting_release_Lo_transition = 1e3
+        self.env = 0.0
 
         # this is set to avoid high frequency noise to interfere with the NR envelope tracking
         self.Lo_cut = 19e3
@@ -882,7 +881,7 @@ class Expander:
         )
 
         self.WeightedLowpass = FiltersClass(
-            np.array(locut_iirb), np.array(locut_iira), dtype=np.float64
+            np.array(locut_iirb), np.array(locut_iira), dtype=np.float32
         )
 
         # weighted filter for envelope detector
@@ -900,95 +899,72 @@ class Expander:
             self.audio_rate,
         )
 
-        self.WeightedHighpass = FiltersClass(np.array(env_iirb), np.array(env_iira), dtype=np.float64)
-
-        # expander attack
-        loenv_iirb, loenv_iira = firdes_lowpass(
-            self.audio_rate,
-            self.weighting_attack_Lo_cut,
-            self.weighting_attack_Lo_transition,
-        )
-        self.attack_Lowpass = FiltersClass(loenv_iirb, loenv_iira, dtype=np.float64)
-
-        # expander release
-        loenvr_iirb, loenvr_iira = firdes_lowpass(
-            self.audio_rate,
-            self.weighting_release_Lo_cut,
-            self.weighting_release_Lo_transition,
-        )
-        self.release_Lowpass = FiltersClass(loenvr_iirb, loenvr_iira, dtype=np.float64)
-
-    def rs_envelope(self, raw_data):
-        # prevent high frequency noise from interfering with envelope detector
-        low_pass = self.WeightedLowpass.filtfilt(raw_data)
-
-        # high pass weighted input to envelope detector
-        audio_env = self.WeightedHighpass.lfilt(low_pass)
-
-        Expander.expand_to_ratio(audio_env, self.ratio)
-
-        return audio_env
+        self.WeightedHighpass = FiltersClass(np.array(env_iirb), np.array(env_iira), dtype=np.float32)
 
     @staticmethod
     @njit(
-        [
-            (
-                numba.types.Array(numba.types.float64, 1, "A"),
-                numba.types.float32
-            ),
-            (
-                numba.types.Array(numba.types.float32, 1, "A"),
-                numba.types.float32
-            )
-        ],
+        [(
+            NumbaAudioArray,
+            NumbaAudioArray,
+            numba.types.float32,
+            numba.types.float32,
+            numba.types.float32,
+            numba.types.float32,
+            numba.types.float32
+        )],
         cache=True,
         fastmath=True,
-        nogil=True,
+        nogil=True
     )
-    def expand_to_ratio(in_out: np.array, ratio: float):
-        for i in range(len(in_out)):        
-            # Convert to dB (amplitude)
-            db = 20 * log10(max(1e-12, abs(in_out[i])))
-            
-            # Apply expansion
-            db_expanded = db / ratio
-            
-            # Convert back to linear
-            in_out[i] = 10 ** (db_expanded / 20)
-
-    @staticmethod
-    @njit(
-        [
-            (
-                numba.types.float32,
-                numba.types.Array(numba.types.float64, 1, "C"),
-                numba.types.Array(numba.types.float64, 1, "C"),
-                NumbaAudioArray, 
-            )
-        ],
-        cache=True,
-        fastmath=True,
-        nogil=True,
-    )
-    def apply_gate(
-        env_gain: float, 
-        attacks: np.array, 
-        releases: np.array, 
-        audio: np.array
+    def expand(
+        audio,
+        side_chain,
+        env,
+        atkCoeff,
+        relCoeff,
+        gain,
+        ratio,
     ):
-        for i in range(len(audio)):
-            attack = attacks[i]
-            release = releases[i]
-            envelope = release if attack < release else attack
+        audio_len = audio.shape[0]
+        ratio_m1 = ratio - 1
+        cutoff_threshold = 1e-12
 
-            audio[i] = audio[i] * envelope * env_gain
+        for i in range(audio_len):
+            sc_abs = abs(side_chain[i])
+
+            # Envelope follower
+            if sc_abs > env:
+                # attack
+                env = atkCoeff * env + (1.0 - atkCoeff) * sc_abs
+            else:
+                # release
+                env = relCoeff * env + (1.0 - relCoeff) * sc_abs
+
+            if env < cutoff_threshold:
+                env_gain = 0.0
+            else:
+                env_gain = env ** ratio_m1
+    
+            audio[i] *= env_gain * gain
+    
+        return env
 
     def process(self, pre_in, audio_out):
-        audio_env = self.rs_envelope(pre_in)
-        attack = self.attack_Lowpass.lfilt(audio_env)
-        release = self.release_Lowpass.lfilt(audio_env)
+        # prevent high frequency noise from interfering with envelope detector
+        pre_in_low_pass = self.WeightedLowpass.filtfilt(pre_in)
 
-        Expander.apply_gate(self.gain, attack, release, audio_out)
+        # high pass weighted input to envelope detector
+        side_chain = self.WeightedHighpass.lfilt(pre_in_low_pass)
+
+        self.env = Expander.expand(
+            audio_out,
+            side_chain,
+            self.env,
+            self.atkCoeff,
+            self.relCoeff,
+            self.gain,
+            self.ratio
+        )
 
 
 @dataclass

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -29,6 +29,7 @@ from scipy.signal import (
     istft,
     fftconvolve,
     find_peaks,
+    freqz
 )
 from scipy.interpolate import interp1d
 from soxr import ResampleStream, resample
@@ -46,7 +47,7 @@ import matplotlib.pyplot as plt
 
 
 # lower increases expander strength and decreases overall gain
-DEFAULT_EXPANDER_GAIN = 16
+DEFAULT_EXPANDER_GAIN = 20
 DEFAULT_EXPANDER_RATIO = 2
 DEFAULT_EXPANDER_ATTACK_TAU = 5e-3
 DEFAULT_EXPANDER_RELEASE_TAU = 70e-3
@@ -62,12 +63,24 @@ DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH = 2
 
 # Low shelf filter for deemphasis
 # low end of shelf curve
-DEFAULT_DEEMPHASIS_TAU_1 = 240e-6
+# T1 standard 240e-6
+DEFAULT_DEEMPHASIS_TAU_1 = 185e-6
 # high end of shelf curve
-DEFAULT_DEEMPHASIS_TAU_2 = 56e-6
+# T2 standard 56e-6
+DEFAULT_DEEMPHASIS_TAU_2 = 22e-6
 # slope of the filter
-DEFAULT_DEEMPHASIS_DB_PER_OCTAVE = 8
-DEFAULT_DEEMPHASIS_BANDWIDTH = 3
+DEFAULT_DEEMPHASIS_DB_PER_OCTAVE = 6
+DEFAULT_DEEMPHASIS_BANDWIDTH = 2.76
+
+# 240e-6
+# 18e-6
+# 5
+# 2.8
+
+# 120e-6
+# 37e-05
+# 11
+# 2.8
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
@@ -810,7 +823,7 @@ class Deemphasis:
         self.deemphasis_db_per_octave = deemphasis_db_per_octave
         self.deemphasis_bandwidth = deemphasis_bandwidth
 
-        deemph_b, deemph_a = build_shelf_filter(
+        self.deemph_b, self.deemph_a = build_shelf_filter(
             "low",
             self.deemphasis_T1,
             self.deemphasis_T2,
@@ -819,14 +832,22 @@ class Deemphasis:
             self.audio_rate,
         )
 
-        self.DeemphasisLowpass = FiltersClass(np.array(deemph_b), np.array(deemph_a))
+        self.DeemphasisLowpass = FiltersClass(np.array(self.deemph_b), np.array(self.deemph_a))
 
+    def get_response(self):
+        # compute frequency response
+        w, h_total = freqz(self.deemph_b, self.deemph_a, worN=4096, fs=self.audio_rate)
+    
+        magnitude_db = 20 * np.log10(np.abs(h_total))
+
+        return w, magnitude_db
+    
     @staticmethod
     @njit(
         [
             (
-                NumbaAudioArray, 
-                NumbaAudioArray, 
+                NumbaAudioArray,
+                NumbaAudioArray,
             )
         ],
         cache=True,
@@ -874,14 +895,14 @@ class Expander:
         self.Lo_cut = 19e3
         self.Lo_transition = 10e3
 
-        locut_iirb, locut_iira = firdes_lowpass(
+        self.locut_iirb, self.locut_iira = firdes_lowpass(
             self.audio_rate,
             self.Lo_cut,
             self.Lo_transition,
         )
 
         self.WeightedLowpass = FiltersClass(
-            np.array(locut_iirb), np.array(locut_iira), dtype=np.float32
+            np.array(self.locut_iirb), np.array(self.locut_iira), dtype=np.float32
         )
 
         # weighted filter for envelope detector
@@ -890,7 +911,7 @@ class Expander:
         self.weighting_db_per_octave = weighting_db_per_octave
         self.weighting_bandwidth = weighting_bandwidth
 
-        env_iirb, env_iira = build_shelf_filter(
+        self.env_iirb, self.env_iira = build_shelf_filter(
             "high",
             self.weighting_T1,
             self.weighting_T2,
@@ -899,7 +920,18 @@ class Expander:
             self.audio_rate,
         )
 
-        self.WeightedHighpass = FiltersClass(np.array(env_iirb), np.array(env_iira), dtype=np.float32)
+        self.WeightedHighpass = FiltersClass(np.array(self.env_iirb), np.array(self.env_iira), dtype=np.float32)
+
+    def get_response(self):
+        # compute frequency response
+        w, h_low = freqz(self.locut_iirb, self.locut_iira, worN=4096, fs=self.audio_rate)
+        _, h_high = freqz(self.env_iirb, self.env_iira, worN=4096, fs=self.audio_rate)
+    
+        h_total = h_low * h_high
+    
+        magnitude_db = 20 * np.log10(np.abs(h_total))
+
+        return w, magnitude_db
 
     @staticmethod
     @njit(

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -511,8 +511,8 @@ class FMdemod:
                 corrected = current_angle
 
             unwrapped = prev_unwrapped + (corrected - prev_angle)
-            diff = unwrapped - prev_unwrapped
-            out = -(diff / diff_divisor - carrier) / deviation
+            diff = prev_unwrapped - unwrapped
+            out = (carrier - diff / diff_divisor) / deviation
 
             out_demod[i - 1] = max(min_float, min(max_float, out))
 

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -2,7 +2,6 @@ import os.path
 import sys
 import math
 
-from scipy import signal
 import numpy as np
 
 import matplotlib
@@ -76,9 +75,10 @@ from vhsdecode.hifi.HiFiDecode import (
     DEMOD_QUADRATURE,
     DEMOD_HILBERT,
     DEFAULT_DEMOD,
-    build_shelf_filter,
     tau_as_freq,
     HiFiDecode,
+    Deemphasis,
+    Expander
 )
 
 STOP_STATE = 0
@@ -1455,14 +1455,8 @@ class PlotWindow(QWidget):
         self.setLayout(layout)
         self.getValues = getValues
 
-    def plot_response(self, label, color, direction, t1, t2, db_per_octave, bandwidth, fs):
+    def plot_response(self, label, color, freq, mag_db, t1, t2):
         # Compute the frequency response
-        b, a = build_shelf_filter(direction, t1, t2, db_per_octave, bandwidth, fs)
-
-        w, h = signal.freqz(b, a)
-        freq = 0.5 * fs * w / np.pi      # Convert rad/sample → Hz
-        mag_db = 20 * np.log10(np.abs(h))
-    
         # Convert taus to frequencies
         t1_f = round(tau_as_freq(t1))
         t2_f = round(tau_as_freq(t2))
@@ -1493,31 +1487,46 @@ class PlotWindow(QWidget):
         self.ax.clear()
         ui_values = self.getValues()
 
-        self.plot_response(
-            "Sideband",
-            "green",
-            "high",
-            ui_values.expander_weighting_shelf_low_tau,
-            ui_values.expander_weighting_shelf_high_tau,
-            ui_values.expander_weighting_db_per_octave,
-            ui_values.expander_weighting_bandwidth,
-            ui_values.audio_sample_rate
-        )
-        self.plot_response(
-            "Deemphasis",
-            "blue",
-            "low",
+        deemphasis = Deemphasis(
+            ui_values.audio_sample_rate,
             ui_values.deemphasis_low_tau,
             ui_values.deemphasis_high_tau,
             ui_values.deemphasis_db_per_octave,
             ui_values.deemphasis_bandwidth,
-            ui_values.audio_sample_rate
+        )
+        deemphasis_freqs, deemphasis_mag_db = deemphasis.get_response()
+
+        expander = Expander(
+            ui_values.audio_sample_rate,
+            weighting_shelf_low_tau = ui_values.expander_weighting_shelf_low_tau,
+            weighting_shelf_high_tau = ui_values.expander_weighting_shelf_high_tau,
+            weighting_db_per_octave = ui_values.expander_weighting_db_per_octave,
+            weighting_bandwidth = ui_values.expander_weighting_bandwidth
+        )
+        expander_freqs, expander_mag_db = expander.get_response()
+
+        self.plot_response(
+            "Sideband",
+            "green",
+            expander_freqs,
+            expander_mag_db,
+            ui_values.expander_weighting_shelf_low_tau,
+            ui_values.expander_weighting_shelf_high_tau,
+        )
+        self.plot_response(
+            "Deemphasis",
+            "blue",
+            deemphasis_freqs,
+            deemphasis_mag_db,
+            ui_values.deemphasis_low_tau,
+            ui_values.deemphasis_high_tau,
         )
 
         self.ax.grid(True, which="both")
         self.ax.set_xlabel("Frequency [Hz]")
         self.ax.set_ylabel("Amplitude [dB]")
         self.ax.set_xlim([1, ui_values.audio_sample_rate/2])
+        self.ax.set_ylim([-20, 3])
         
         self.ax.legend()
         self.canvas.draw()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -418,9 +418,8 @@ deemphasis_options_group.add_argument(
     help=f"Sets the deemphasis low-pass shelf filter bandwidth (default is {DEFAULT_DEEMPHASIS_BANDWIDTH}).",
 )
 
-
-def test_if_ld_ldf_reader_is_installed():
-    shell_command = ["ld-ldf-reader", "--help"]
+def test_ld_tools(ld_tool):
+    shell_command = [ld_tool, "--help"]
     try:
         p = subprocess.Popen(
             shell_command,
@@ -430,12 +429,11 @@ def test_if_ld_ldf_reader_is_installed():
             stderr=subprocess.PIPE,
             universal_newlines=False,
         )
-        print("Found ld-ldf-reader")
+        print(f"Found {ld_tool}")
         p.communicate()
         return True
     except (FileNotFoundError, subprocess.CalledProcessError):
-        print("WARN: ld-ldf-reader not installed (or not in PATH)")
-
+        print(f"WARN: {ld_tool} not installed (or not in PATH)")
 
 def test_if_flac_is_installed():
     shell_command = ["flac", "-version"]
@@ -520,9 +518,9 @@ class BufferedInputStream(io.RawIOBase):
         return self.tell()
 
 
-class LDFFileReader(BufferedInputStream):
-    def __init__(self, file_path):
-        shell_command = ["ld-ldf-reader", file_path]
+class LDToolFileReader(BufferedInputStream):
+    def __init__(self, ld_tool, file_path, input_argument=""):
+        shell_command = [ld_tool, input_argument, file_path]
         p = subprocess.Popen(
             shell_command,
             shell=False,
@@ -564,7 +562,8 @@ class FFMpegFileReader(BufferedInputStream):
         shell_command = [
             "ffmpeg",
             "-hide_banner",
-            "-loglevel error",
+            "-loglevel",
+            "error",
             "-ignore_unknown",
             "-i",
             file_path,
@@ -706,9 +705,9 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         )
     elif "ldf" == extension:
         try:
-            if test_if_ld_ldf_reader_is_installed():
+            if test_ld_tools("ld-ldf-reader"):
                 return UnseekableSoundFile(
-                    LDFFileReader(pathR),
+                    LDToolFileReader("ld-ldf-reader", pathR),
                     "r",
                     channels=1,
                     samplerate=int(sample_rate),
@@ -752,6 +751,25 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             pathR,
             "r",
         )
+    elif "lds" == extension:
+        try:
+            if test_ld_tools("ld-lds-converter"):
+                return UnseekableSoundFile(
+                    LDToolFileReader("ld-lds-converter", pathR, "-i"),
+                    "r",
+                    channels=1,
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                )
+            print(
+                "ERROR: Unable to decode LDS without ld-lds-converter. Please install the program and try again."
+            )
+        except Exception as e:
+            print(
+                "ERROR: Unexpected error opening ld-lds-converter", e
+            )
     elif "-" == path:
         try:
             return UnseekableSoundFile(


### PR DESCRIPTION
## General Fixes
* Support `.lds` files
* Fix phase inversion issue with quadrature demodulation

## Expander / Deemphasis Tuning
* Rewrite expander envelope and attack / release section to use simpler and more accurate envelope follower
* Tune expander attack `3ms` -> `5ms`
* Tune deemphasis filter curve based on white noise sample

I generated a white noise sample, recorded it to tape, then decoded that and used it to fit the deemphasis curve. The blue line on the top is the white noise without deemphasis, the orange line is with deemphasis. The curves below are the deemphasis and expander weighting.
<img width="1901" height="1247" alt="hifi_deemphasis" src="https://github.com/user-attachments/assets/93fd0043-065e-48e5-b5c1-2f22ec830fde" />
