### PR TITLE
relaxed line0 option (makes my poor-condition tapes decode successfully)

### DIFF
--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -429,7 +429,7 @@ def get_line0_fallback(
                     first_field_backup = first_field
                     first_field_confidence_backup = first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 20), i):
+                for j in range(max(0, i - 20), i) if relaxed else range(max(0, i - 16), i - 4):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         line_0 = filtered_pulses[j].start
                         break
@@ -520,7 +520,7 @@ def get_line0_fallback(
                     first_field_backup = _first_field
                     first_field_confidence_backup = _first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 15), i):
+                for j in range(max(0, i - 15), i) if relaxed else range(max(0, i - 10), i - 3):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         if (
                             line_0 != filtered_pulses[j].start
@@ -554,8 +554,8 @@ def get_line0_fallback(
             abs(disPpspp - 0.5) < 0.06
             and abs(disPPspp - 0.5) < 0.06
             and abs(dispPSpp - 0.5) < 0.06
-            and abs(disppSPp - 0.5) < 0.06
-            and abs(disppsPP - 0.5) < 0.06
+            and abs(disppSPp - 1.0) < 0.06
+            and abs(disppsPP - 1.0) < 0.06
         )
         check_relaxed = (
             # abs(disPpspp - 0.5) < 0.06 and 
@@ -588,28 +588,24 @@ def get_line0_fallback(
             ) / 2.0
 
             if hsync_pulse_len / eq_pulse_len > 1.75:
-                # Assume we found the transition point
-                if frame_lines == 625:
-                     line_offset = 7.0
-                else:
-                     line_offset = 8.0
-                _first_field = 0
-                _first_field_confidence = 60
-                
                 if filtered_pulses[i].len < eq_pulse_len * 1.25:
-                    # i is likely an EQ pulse, so i+1 is the start of HSYNCs
-                    # This matches the standard pattern (EQ, EQ, EQ, HSYNC, HSYNC)
-                    # line_0 should be HSYNC
-                    pass
-                elif filtered_pulses[i].len > hsync_pulse_len * 0.75:
-                    # i is likely an HSYNC pulse
-                    # If i is HSYNC, and i-1 is EQ (implied by transition)
-                    # Then we shift prediction.
                     if frame_lines == 625:
-                        line_offset = 7.0 # Adjust?
+                        line_offset = 7.0
+                    else:
+                        line_offset = 8.0
+                    _first_field = 0
+                    _first_field_confidence = (
+                        80 if filtered_pulses[i].len < eq_pulse_len * 1.1 else 60
+                    )
+                elif filtered_pulses[i].len > hsync_pulse_len * 0.75:
+                    if frame_lines == 625:
+                        line_offset = 7.0
                     else:
                         line_offset = 9.0
                     _first_field = 1
+                    _first_field_confidence = (
+                        80 if filtered_pulses[i].len > hsync_pulse_len * 0.9 else 60
+                    )
                     
             if line_offset is not None:
                 # in case we cannot find a matching pulse, we can still use this prediction
@@ -625,7 +621,7 @@ def get_line0_fallback(
                     first_field_backup = _first_field
                     first_field_confidence_backup = _first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 25), i):
+                for j in range(max(0, i - 25), i) if relaxed else range(max(0, i - 20), i - 4):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         if (
                             line_0 != filtered_pulses[j].start

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -231,7 +231,7 @@ def debug_plot_line0_fallback(
 
 
 def get_line0_fallback(
-    valid_pulses, raw_pulses, demod_05, lt_vsync, linelen, num_eq_pulses, frame_lines
+    valid_pulses, raw_pulses, demod_05, lt_vsync, linelen, num_eq_pulses, frame_lines, relaxed=False
 ):
     """
     Try a more primitive way of locating line 0 if the normal approach fails.
@@ -429,7 +429,7 @@ def get_line0_fallback(
                     first_field_backup = first_field
                     first_field_confidence_backup = first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 16), i - 4):
+                for j in range(max(0, i - 20), i):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         line_0 = filtered_pulses[j].start
                         break
@@ -520,7 +520,7 @@ def get_line0_fallback(
                     first_field_backup = _first_field
                     first_field_confidence_backup = _first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 10), i - 3):
+                for j in range(max(0, i - 15), i):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         if (
                             line_0 != filtered_pulses[j].start
@@ -549,12 +549,24 @@ def get_line0_fallback(
             filtered_pulses[i + 2].start - filtered_pulses[i + 1].start
         ) / linelen
 
-        if (
+        # Relaxed check: ignore the first interval (disPpspp) to handle dropouts better
+        check_strict = (
             abs(disPpspp - 0.5) < 0.06
             and abs(disPPspp - 0.5) < 0.06
             and abs(dispPSpp - 0.5) < 0.06
+            and abs(disppSPp - 0.5) < 0.06
+            and abs(disppsPP - 0.5) < 0.06
+        )
+        check_relaxed = (
+            # abs(disPpspp - 0.5) < 0.06 and 
+            abs(disPPspp - 0.5) < 0.06
+            and abs(dispPSpp - 0.5) < 0.06
             and abs(disppSPp - 1.0) < 0.06
             and abs(disppsPP - 1.0) < 0.06
+        )
+
+        if (
+            (check_relaxed if relaxed else check_strict)
             and filtered_pulses[i - 2].len < SHORT_PULSE_MAX
             and filtered_pulses[i - 1].len < SHORT_PULSE_MAX
             and filtered_pulses[i].len < SHORT_PULSE_MAX
@@ -576,24 +588,29 @@ def get_line0_fallback(
             ) / 2.0
 
             if hsync_pulse_len / eq_pulse_len > 1.75:
+                # Assume we found the transition point
+                if frame_lines == 625:
+                     line_offset = 7.0
+                else:
+                     line_offset = 8.0
+                _first_field = 0
+                _first_field_confidence = 60
+                
                 if filtered_pulses[i].len < eq_pulse_len * 1.25:
-                    if frame_lines == 625:
-                        line_offset = 7.0
-                    else:
-                        line_offset = 8.0
-                    _first_field = 0
-                    _first_field_confidence = (
-                        80 if filtered_pulses[i].len < eq_pulse_len * 1.1 else 60
-                    )
+                    # i is likely an EQ pulse, so i+1 is the start of HSYNCs
+                    # This matches the standard pattern (EQ, EQ, EQ, HSYNC, HSYNC)
+                    # line_0 should be HSYNC
+                    pass
                 elif filtered_pulses[i].len > hsync_pulse_len * 0.75:
+                    # i is likely an HSYNC pulse
+                    # If i is HSYNC, and i-1 is EQ (implied by transition)
+                    # Then we shift prediction.
                     if frame_lines == 625:
-                        line_offset = 7.0
+                        line_offset = 7.0 # Adjust?
                     else:
                         line_offset = 9.0
                     _first_field = 1
-                    _first_field_confidence = (
-                        80 if filtered_pulses[i].len > hsync_pulse_len * 0.9 else 60
-                    )
+                    
             if line_offset is not None:
                 # in case we cannot find a matching pulse, we can still use this prediction
                 line_0_est = (
@@ -608,7 +625,7 @@ def get_line0_fallback(
                     first_field_backup = _first_field
                     first_field_confidence_backup = _first_field_confidence
                 # find pulse
-                for j in range(max(0, i - 20), i - 4):
+                for j in range(max(0, i - 25), i):
                     if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
                         if (
                             line_0 != filtered_pulses[j].start
@@ -637,12 +654,24 @@ def get_line0_fallback(
             filtered_pulses[i + 3].start - filtered_pulses[i + 2].start
         ) / linelen
 
-        if (
+        # Relaxed check: ignore the last interval (disppspP)
+        check_strict = (
             abs(disPPspp - 1.0) < 0.06
             and abs(dispPSpp - 1.0) < 0.06
             and abs(disppSPp - 0.5) < 0.06
             and abs(disppsPP - 0.5) < 0.06
             and abs(disppspP - 0.5) < 0.06
+        )
+        check_relaxed = (
+            abs(disPPspp - 1.0) < 0.06
+            and abs(dispPSpp - 1.0) < 0.06
+            and abs(disppSPp - 0.5) < 0.06
+            and abs(disppsPP - 0.5) < 0.06
+            # and abs(disppspP - 0.5) < 0.06
+        )
+
+        if (
+            (check_relaxed if relaxed else check_strict)
             and filtered_pulses[i - 2].len < SHORT_PULSE_MAX
             and filtered_pulses[i - 1].len < SHORT_PULSE_MAX
             and filtered_pulses[i].len < SHORT_PULSE_MAX
@@ -791,9 +820,16 @@ def get_line0_fallback(
         first_field = first_field_backup
         first_field_confidence = first_field_confidence_backup - 20
     elif line_0 is not None and line_0 > (linelen * (frame_lines - 1) / 2):
-        ldd.logger.info(
-            "WARNING, line0 hsync not found for current field, probably skipping one field."
-        )
+        # Check if we have a backup that is valid (within first half of frame)
+        if relaxed and line_0_backup is not None and line_0_backup < (linelen * (frame_lines - 1) / 2):
+             ldd.logger.info("Switching to backup line0 estimation as primary is out of range.")
+             line_0 = line_0_backup
+             first_field = first_field_backup
+             first_field_confidence = first_field_confidence_backup - 20
+        else:
+            ldd.logger.info(
+                "WARNING, line0 hsync not found for current field, probably skipping one field."
+            )
 
     if line_0 is None and line_0_backup is not None:
         ldd.logger.info(
@@ -1075,6 +1111,7 @@ class FieldShared:
             self.inlinelen,
             self.rf.SysParams["numPulses"],
             self.rf.SysParams["frame_lines"],
+            relaxed=self.rf.options.relaxed_line0,
         )
         # Not needed after this.
         del self.lt_vsync

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -858,7 +858,8 @@ def get_line0_fallback(
     if (line_0 is None or line_0 > (linelen * (frame_lines - 1) / 2)) and expected_line0 is not None:
         limit = (linelen * (frame_lines - 1) / 2)
         if expected_line0 < limit and expected_line0 > -5 * linelen:
-            ldd.logger.info(f"Attempting to use predicted line0 from previous field: {expected_line0}")
+            if DEBUG_PRINT:
+                print(f"Attempting to use predicted line0 from previous field: {expected_line0}")
             best_p = None
             min_diff = 1000000
             # Search range: Only snap to a pulse if it is very close to the prediction (0.7 lines).
@@ -879,7 +880,8 @@ def get_line0_fallback(
                     first_field = expected_first_field
                     first_field_confidence = 50
             elif relaxed and expected_line0 > 0:
-                ldd.logger.info(f"No pulse found near prediction, forcing expected location: {expected_line0}")
+                if DEBUG_PRINT:
+                    print(f"No pulse found near prediction, forcing expected location: {expected_line0}")
                 line_0 = expected_line0
                 if expected_first_field is not None:
                     first_field = expected_first_field

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -290,7 +290,7 @@ def get_line0_fallback(
     LONG_PULSE_MIN = 0.35 * linelen
 
     if DEBUG_PRINT:
-        print("get_line0_fallback called")
+        print(f"get_line0_fallback called. Raw pulses: {len(raw_pulses)}, Filtered: {len(filtered_pulses)} (filtering logic skipped for debug print)")
 
     # First try: Find end of long sync pulses
     i = 15
@@ -549,6 +549,10 @@ def get_line0_fallback(
             filtered_pulses[i + 2].start - filtered_pulses[i + 1].start
         ) / linelen
 
+        if DEBUG_PRINT and i < 60:
+             print(f"Try 3 scan i={i}: Pps={disPpspp:.3f} PPs={disPPspp:.3f} pSP={dispPSpp:.3f} ppS={disppSPp:.3f} pps={disppsPP:.3f}")
+             print(f"  lens: {filtered_pulses[i - 2].len:.1f}, {filtered_pulses[i - 1].len:.1f}, {filtered_pulses[i].len:.1f}")
+
         # Relaxed check: ignore the first interval (disPpspp) to handle dropouts better
         check_strict = (
             abs(disPpspp - 0.5) < 0.06
@@ -621,8 +625,14 @@ def get_line0_fallback(
                     first_field_backup = _first_field
                     first_field_confidence_backup = _first_field_confidence
                 # find pulse
+                if DEBUG_PRINT:
+                     print(f"Searching for pulse near {line_0_est} (range {max(0, i - 25)} to {i})")
                 for j in range(max(0, i - 25), i) if relaxed else range(max(0, i - 20), i - 4):
-                    if abs(filtered_pulses[j].start - line_0_est) / linelen < 0.08:
+                    diff = abs(filtered_pulses[j].start - line_0_est) / linelen
+                    if DEBUG_PRINT:
+                        print(f"    Checking pulse {j}: start={filtered_pulses[j].start}, est={line_0_est}, diff_lines={diff:.4f}")
+
+                    if diff < 0.08:
                         if (
                             line_0 != filtered_pulses[j].start
                             or _first_field_confidence > first_field_confidence

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -874,7 +874,8 @@ def get_line0_fallback(
                         min_diff = diff
                         best_p = p
             if best_p:
-                ldd.logger.info(f"Found pulse near prediction: {best_p.start} (diff {min_diff/linelen:.2f} lines)")
+                if DEBUG_PRINT:
+                    print(f"Found pulse near prediction: {best_p.start} (diff {min_diff/linelen:.2f} lines)")
                 line_0 = best_p.start
                 if expected_first_field is not None:
                     first_field = expected_first_field
@@ -887,7 +888,8 @@ def get_line0_fallback(
                     first_field = expected_first_field
                     first_field_confidence = 40
             else:
-                ldd.logger.info("Prediction available but no matching pulse found and relaxed mode disabled.")
+                if DEBUG_PRINT:
+                    print("Prediction available but no matching pulse found and relaxed mode disabled.")
                 if line_0 is not None and line_0 > (linelen * (frame_lines - 1) / 2):
                     ldd.logger.info(
                         "WARNING, line0 hsync not found for current field, probably skipping one field."

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -231,7 +231,16 @@ def debug_plot_line0_fallback(
 
 
 def get_line0_fallback(
-    valid_pulses, raw_pulses, demod_05, lt_vsync, linelen, num_eq_pulses, frame_lines, relaxed=False
+    valid_pulses,
+    raw_pulses,
+    demod_05,
+    lt_vsync,
+    linelen,
+    num_eq_pulses,
+    frame_lines,
+    relaxed=False,
+    expected_line0=None,
+    expected_first_field=None,
 ):
     """
     Try a more primitive way of locating line 0 if the normal approach fails.
@@ -833,9 +842,10 @@ def get_line0_fallback(
              first_field = first_field_backup
              first_field_confidence = first_field_confidence_backup - 20
         else:
-            ldd.logger.info(
-                "WARNING, line0 hsync not found for current field, probably skipping one field."
-            )
+            if expected_line0 is None:
+                ldd.logger.info(
+                    "WARNING, line0 hsync not found for current field, probably skipping one field."
+                )
 
     if line_0 is None and line_0_backup is not None:
         ldd.logger.info(
@@ -844,6 +854,43 @@ def get_line0_fallback(
         line_0 = line_0_backup
         first_field = first_field_backup
         first_field_confidence = first_field_confidence_backup - 20
+
+    if (line_0 is None or line_0 > (linelen * (frame_lines - 1) / 2)) and expected_line0 is not None:
+        limit = (linelen * (frame_lines - 1) / 2)
+        if expected_line0 < limit and expected_line0 > -5 * linelen:
+            ldd.logger.info(f"Attempting to use predicted line0 from previous field: {expected_line0}")
+            best_p = None
+            min_diff = 1000000
+            # Search range: Only snap to a pulse if it is very close to the prediction (0.7 lines).
+            # A wider range (e.g. 10 lines) causes it to snap to the wrong pulse (e.g. adjacent HSYNC/EQ)
+            # when the correct VSYNC pulse is missing due to dropout.
+            # search_range = 10.0 * linelen # Original search range
+            search_range = 0.7 * linelen
+            for p in filtered_pulses:
+                diff = abs(p.start - expected_line0)
+                if diff < search_range:
+                    if diff < min_diff:
+                        min_diff = diff
+                        best_p = p
+            if best_p:
+                ldd.logger.info(f"Found pulse near prediction: {best_p.start} (diff {min_diff/linelen:.2f} lines)")
+                line_0 = best_p.start
+                if expected_first_field is not None:
+                    first_field = expected_first_field
+                    first_field_confidence = 50
+            elif relaxed and expected_line0 > 0:
+                ldd.logger.info(f"No pulse found near prediction, forcing expected location: {expected_line0}")
+                line_0 = expected_line0
+                if expected_first_field is not None:
+                    first_field = expected_first_field
+                    first_field_confidence = 40
+            else:
+                ldd.logger.info("Prediction available but no matching pulse found and relaxed mode disabled.")
+                if line_0 is not None and line_0 > (linelen * (frame_lines - 1) / 2):
+                    ldd.logger.info(
+                        "WARNING, line0 hsync not found for current field, probably skipping one field."
+                    )
+
 
     if line_0 is not None:
         if DEBUG_PLOT:
@@ -1109,6 +1156,20 @@ class FieldShared:
         return dsout, dsaudio, dsefm
 
     def _get_line0_fallback(self, valid_pulses):
+        expected_line0 = None
+        expected_first_field = None
+
+        if hasattr(self.rf, "prev_first_hsync_readloc") and self.rf.prev_first_hsync_readloc != -1:
+            prev_abs = self.rf.prev_first_hsync_readloc + self.rf.prev_first_hsync_loc
+            lines_per_field = self.rf.SysParams["frame_lines"] / 2.0
+            target_abs = prev_abs + (lines_per_field * self.meanlinelen)
+            # Target VSYNC area approx 8 lines before active video (Start of VSYNC block)
+            expected_line0_abs = target_abs - (8.0 * self.meanlinelen)
+            expected_line0 = expected_line0_abs - self.readloc
+
+            if hasattr(self.rf, "prev_first_field") and self.rf.prev_first_field != -1:
+                expected_first_field = 1 - self.rf.prev_first_field
+
         res = get_line0_fallback(
             valid_pulses,
             self.rawpulses,
@@ -1118,6 +1179,8 @@ class FieldShared:
             self.rf.SysParams["numPulses"],
             self.rf.SysParams["frame_lines"],
             relaxed=self.rf.options.relaxed_line0,
+            expected_line0=expected_line0,
+            expected_first_field=expected_first_field,
         )
         # Not needed after this.
         del self.lt_vsync

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -290,6 +290,16 @@ def main(args=None, use_gui=False):
         ),
     )
     debug_group.add_argument(
+        "--relaxed_line0",
+        dest="relaxed_line0",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable relaxed line0 detection fallback logic. Useful for damaged tapes where "
+            "standard detection fails. Requires --fallback_vsync."
+        ),
+    )
+    debug_group.add_argument(
         "--field_order_confidence",
         dest="field_order_confidence",
         default=100,
@@ -476,6 +486,7 @@ def main(args=None, use_gui=False):
     rf_options["disable_right_hsync"] = args.disable_right_hsync
     rf_options["level_detect_divisor"] = args.level_detect_divisor
     rf_options["fallback_vsync"] = args.fallback_vsync
+    rf_options["relaxed_line0"] = args.relaxed_line0
     rf_options["field_order_confidence"] = int(max(0, min(100, args.field_order_confidence)))
     rf_options["saved_levels"] = args.saved_levels
     rf_options["skip_hsync_refine"] = args.skip_hsync_refine

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -686,6 +686,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "chroma_offset",
                 "ire0_adjust",
                 "gnrc_afe",
+                "relaxed_line0",
             ],
         )(
             self.iretohz(100) * 2,
@@ -720,6 +721,7 @@ class VHSRFDecode(ldd.RFDecode):
             int(self.DecoderParams.get("chroma_offset", 5) * (self.freq / 40.0)),
             ire0_adjust,
             rf_options.get("gnrc_afe", False),
+            rf_options.get("relaxed_line0", False),
         )
 
         # As agc can alter these sysParams values, store a copy to then


### PR DESCRIPTION
A disclaimer: I don't really know _why_ this works, or what is particularly wrong with my tapes that makes them not decode properly (I suspect they are misrecorded in a way that makes --fallback_vsync line0 detection _just barely_ work (one out of every few fields), and this makes it reliable). But I threw the problem at an LLM, and it came up with this solution. I added it as an option, but maybe this should be default? I have no idea..

Video sample, first clip is without the fix, then repeating after with the fix: (without fix it drops a bunch of fields as shown here, leading to "stuck" fields, or (not shown) without fix and and with `--field_order_action none` it seems to have all the fields but there is vertical jitter instead, like on my JVC VCR TBC.

With fix is the second half:

https://github.com/user-attachments/assets/f22270cc-c8a5-4c6a-a231-39d44e678c1f

RF sample for the above, for someone who wants to play with it: 

https://drive.google.com/file/d/1b5ZNJsAoePecl45MCpBz2228os3fr3kU/view?usp=drive_link

Not tested with NTSC or other tapes, **I suspect that this may not work correctly for NTSC** (but not tested)