### PR TITLE
hifi-decode: 8mm deemphasis

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -64,23 +64,21 @@ DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH = 2
 # Low shelf filter for deemphasis
 # low end of shelf curve
 # T1 standard 240e-6
-DEFAULT_DEEMPHASIS_TAU_1 = 185e-6
+DEFAULT_VHS_DEEMPHASIS_TAU_1 = 185e-6
 # high end of shelf curve
 # T2 standard 56e-6
-DEFAULT_DEEMPHASIS_TAU_2 = 22e-6
+DEFAULT_VHS_DEEMPHASIS_TAU_2 = 22e-6
 # slope of the filter
-DEFAULT_DEEMPHASIS_DB_PER_OCTAVE = 6
-DEFAULT_DEEMPHASIS_BANDWIDTH = 2.76
+DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE = 6
+DEFAULT_VHS_DEEMPHASIS_BANDWIDTH = 2.76
 
-# 240e-6
-# 18e-6
-# 5
-# 2.8
-
-# 120e-6
-# 37e-05
-# 11
-# 2.8
+# low end of shelf curve
+DEFAULT_8MM_DEEMPHASIS_TAU_1 = 1e-4
+# high end of shelf curve
+DEFAULT_8MM_DEEMPHASIS_TAU_2 = 1.27e-5
+# slope of the filter
+DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE = 6
+DEFAULT_8MM_DEEMPHASIS_BANDWIDTH = 2.4
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
@@ -810,10 +808,10 @@ class Deemphasis:
     def __init__(
         self,
         audio_rate,
-        deemphasis_low_tau: float = DEFAULT_DEEMPHASIS_TAU_1,
-        deemphasis_high_tau: float = DEFAULT_DEEMPHASIS_TAU_2,
-        deemphasis_db_per_octave: float = DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
-        deemphasis_bandwidth: float = DEFAULT_DEEMPHASIS_BANDWIDTH,
+        deemphasis_low_tau: float,
+        deemphasis_high_tau: float,
+        deemphasis_db_per_octave: float,
+        deemphasis_bandwidth: float,
     ):
         self.audio_rate = audio_rate
 

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -66,10 +66,14 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_EXPANDER_WEIGHTING_TAU_2,
     DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
     DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
-    DEFAULT_DEEMPHASIS_TAU_1,
-    DEFAULT_DEEMPHASIS_TAU_2,
-    DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_VHS_DEEMPHASIS_TAU_1,
+    DEFAULT_VHS_DEEMPHASIS_TAU_2,
+    DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
+    DEFAULT_VHS_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_8MM_DEEMPHASIS_TAU_1,
+    DEFAULT_8MM_DEEMPHASIS_TAU_2,
+    DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE,
+    DEFAULT_8MM_DEEMPHASIS_BANDWIDTH,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEMOD_QUADRATURE,
@@ -99,10 +103,10 @@ class MainUIParameters:
         self.expander_weighting_shelf_high_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_2
         self.expander_weighting_db_per_octave: float = DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE
         self.expander_weighting_bandwidth: float = DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH
-        self.deemphasis_low_tau: float = DEFAULT_DEEMPHASIS_TAU_1
-        self.deemphasis_high_tau: float = DEFAULT_DEEMPHASIS_TAU_2
-        self.deemphasis_db_per_octave: float = DEFAULT_DEEMPHASIS_DB_PER_OCTAVE
-        self.deemphasis_bandwidth: float = DEFAULT_DEEMPHASIS_BANDWIDTH
+        self.deemphasis_low_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_1
+        self.deemphasis_high_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_2
+        self.deemphasis_db_per_octave: float = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
+        self.deemphasis_bandwidth: float = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
         self.afe_vco_deviation = 0
         self.afe_left_carrier = 0
         self.afe_right_carrier = 0
@@ -748,7 +752,7 @@ class HifiUi(QMainWindow):
             "Low Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
-            DEFAULT_DEEMPHASIS_TAU_2,
+            DEFAULT_VHS_DEEMPHASIS_TAU_2,
             10e-4,
         )
         deemphasis_layout.addWidget(self.deemphasis_low_tau_dial_control)
@@ -758,7 +762,7 @@ class HifiUi(QMainWindow):
             QtGui.QDoubleValidator(),
             10e5,
             10e-7,
-            DEFAULT_DEEMPHASIS_TAU_1,
+            DEFAULT_VHS_DEEMPHASIS_TAU_1,
         )
         deemphasis_layout.addWidget(self.deemphasis_high_tau_dial_control)
         self.deemphasis_db_per_octave_dial_control = DialControl(
@@ -902,6 +906,7 @@ class HifiUi(QMainWindow):
             values.afe_left_carrier,
             values.afe_right_carrier,
         )
+        self.update_deemphasis_values(values.format)
 
         self.input_file = values.input_file
         self.output_file = values.output_file
@@ -978,6 +983,18 @@ class HifiUi(QMainWindow):
         self.afe_left_carrier_spinbox.setValue(int(standard.LCarrierRef))
         self.afe_right_carrier_spinbox.setValue(int(standard.RCarrierRef))
 
+    def update_deemphasis_values(self, format):
+        if format == "VHS":
+            self.deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_1)
+            self.deemphasis_high_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_2)
+            self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE)
+            self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_BANDWIDTH)
+        else:
+            self.deemphasis_low_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_1)
+            self.deemphasis_high_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_2)
+            self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE)
+            self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_BANDWIDTH)
+
     def on_standard_change(self):
         self.update_afe_values(
             format=self.format_combo.currentText(),
@@ -989,6 +1006,7 @@ class HifiUi(QMainWindow):
             format=self.format_combo.currentText(),
             standard=self.standard_combo.currentText(),
         )
+        self.update_deemphasis_values(self.format_combo.currentText())
 
     def change_button_color(self, button, color):
         button.setStyleSheet(

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -55,10 +55,14 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_EXPANDER_WEIGHTING_TAU_2,
     DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
     DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
-    DEFAULT_DEEMPHASIS_TAU_1,
-    DEFAULT_DEEMPHASIS_TAU_2,
-    DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_VHS_DEEMPHASIS_TAU_1,
+    DEFAULT_VHS_DEEMPHASIS_TAU_2,
+    DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
+    DEFAULT_VHS_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_8MM_DEEMPHASIS_TAU_1,
+    DEFAULT_8MM_DEEMPHASIS_TAU_2,
+    DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE,
+    DEFAULT_8MM_DEEMPHASIS_BANDWIDTH,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
@@ -136,7 +140,7 @@ parser.add_argument(
     dest="inputfreq",
     metavar="FREQ",
     type=lddu.parse_frequency,
-    default=40000000,
+    default=40,
     help="RF sampling frequency in source file (default is 40MHz)",
 )
 parser.add_argument(
@@ -393,29 +397,25 @@ deemphasis_options_group.add_argument(
     "--deemphasis_low_tau",
     dest="deemphasis_low_tau",
     type=float,
-    default=DEFAULT_DEEMPHASIS_TAU_1,
-    help=f"Sets the deemphasis low-pass shelf filter low point in tau (default is {DEFAULT_DEEMPHASIS_TAU_1}).",
+    help=f"Sets the deemphasis low-pass shelf filter low point in tau (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_TAU_1}] [8mm: {DEFAULT_8MM_DEEMPHASIS_TAU_1}])",
 )
 deemphasis_options_group.add_argument(
     "--deemphasis_high_tau",
     dest="deemphasis_high_tau",
     type=float,
-    default=DEFAULT_DEEMPHASIS_TAU_2,
-    help=f"Sets the deemphasis low-pass shelf filter high point in tau (default is {DEFAULT_DEEMPHASIS_TAU_2}).",
+    help=f"Sets the deemphasis low-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_TAU_2}] [8mm: {DEFAULT_8MM_DEEMPHASIS_TAU_2}])",
 )
 deemphasis_options_group.add_argument(
     "--deemphasis_db_per_octave",
     dest="deemphasis_db_per_octave",
     type=float,
-    default=DEFAULT_DEEMPHASIS_DB_PER_OCTAVE,
-    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (default is {DEFAULT_DEEMPHASIS_DB_PER_OCTAVE}).",
+    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE}] [8mm: {DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE}])",
 )
 deemphasis_options_group.add_argument(
     "--deemphasis_bandwidth",
     dest="deemphasis_bandwidth",
     type=float,
-    default=DEFAULT_DEEMPHASIS_BANDWIDTH,
-    help=f"Sets the deemphasis low-pass shelf filter bandwidth (default is {DEFAULT_DEEMPHASIS_BANDWIDTH}).",
+    help=f"Sets the deemphasis low-pass shelf filter bandwidth (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_BANDWIDTH}] [8mm: {DEFAULT_8MM_DEEMPHASIS_BANDWIDTH}])",
 )
 
 def test_ld_tools(ld_tool):
@@ -1175,10 +1175,6 @@ class PostProcessor:
                     # prime the expander's gain if this is the first block
                     expander.process(pre, np.copy(post))
                 expander.process(pre, post)
-            else:
-                DecoderSharedMemory.copy_data_float32(
-                    pre, post, len(post)
-                )
 
             buffer.close()
             out_conn.send(decoder_state)
@@ -1963,10 +1959,23 @@ def main() -> int:
     else:
         resampler_quality = DEFAULT_RESAMPLER_QUALITY
 
+    if args.format_8mm:
+        tape_format = "8mm"
+        default_deemphasis_low_tau = DEFAULT_8MM_DEEMPHASIS_TAU_1
+        default_deemphasis_high_tau = DEFAULT_8MM_DEEMPHASIS_TAU_2
+        default_deemphasis_db_per_octave = DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE
+        default_deemphasis_bandwidth = DEFAULT_8MM_DEEMPHASIS_BANDWIDTH
+    else:
+        tape_format = "vhs"
+        default_deemphasis_low_tau = DEFAULT_VHS_DEEMPHASIS_TAU_1
+        default_deemphasis_high_tau = DEFAULT_VHS_DEEMPHASIS_TAU_2
+        default_deemphasis_db_per_octave = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
+        default_deemphasis_bandwidth = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
+
     decode_options = {
         "input_rate": sample_freq * 1e6,
         "standard": "p" if system == "PAL" else "n",
-        "format": "vhs" if not args.format_8mm else "8mm",
+        "format": tape_format,
         "preview": args.preview,
         "preview_available": SOUNDDEVICE_AVAILABLE,
         "demod_type": args.demod_type,
@@ -1990,10 +1999,10 @@ def main() -> int:
         "expander_weighting_shelf_high_tau": args.expander_weighting_shelf_high_tau,
         "expander_weighting_db_per_octave": args.expander_weighting_db_per_octave,
         "expander_weighting_bandwidth": args.expander_weighting_bandwidth,
-        "deemphasis_low_tau": args.deemphasis_low_tau,
-        "deemphasis_high_tau": args.deemphasis_high_tau,
-        "deemphasis_db_per_octave": args.deemphasis_db_per_octave,
-        "deemphasis_bandwidth": args.deemphasis_bandwidth,
+        "deemphasis_low_tau": args.deemphasis_low_tau or default_deemphasis_low_tau,
+        "deemphasis_high_tau": args.deemphasis_high_tau or default_deemphasis_high_tau,
+        "deemphasis_db_per_octave": args.deemphasis_db_per_octave or default_deemphasis_db_per_octave,
+        "deemphasis_bandwidth": args.deemphasis_bandwidth or default_deemphasis_bandwidth,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,
         "gain": args.gain,


### PR DESCRIPTION
### Features
* Add deemphasis curve for 8mm (tuned using 8mm VCR)

### Fixes
* Default input sample rate was being multiplied twice
* Correctly use the post deemphasis audio when expander is disabled

Video 8 curve response:
<img width="1507" height="1069" alt="8mm curve" src="https://github.com/user-attachments/assets/9bbfc823-bfa8-4ec9-8e3f-d83ab154f9b8" />
