### PR TITLE
hifi-decode: Expander tuning

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -792,6 +792,50 @@ class SpectralNoiseReduction:
             nr, audio_out, len(nr) - len(audio_out) - self.end_padding, len(audio_out)
         )
 
+class DCBlocker:
+    def __init__(self, sample_rate, cutoff):
+        # Compute pole R so cutoff is approximately fc Hz:
+        R = 1 - (2 * np.pi * cutoff) / sample_rate
+        if R < 0:
+            R = 0
+        if R > 0.999999:
+            R = 0.999999  # numerical stability
+
+        self.R = R
+
+        # State
+        self.prev_x = 0.0
+        self.prev_y = 0.0
+
+    @staticmethod
+    @njit(
+        [
+            numba.types.UniTuple(numba.types.float32, 2)(
+                NumbaAudioArray,
+                numba.types.float32,
+                numba.types.float32,
+                numba.types.float32
+            )
+        ],
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def dc_block(audio, px, py, R):
+        for i in range(len(audio)):
+            y = audio[i] - px + R * py
+
+            px = audio[i]
+            py = y
+
+            audio[i] = y
+
+        return px, py
+
+    def process(self, audio):
+        self.prev_x, self.prev_y = DCBlocker.dc_block(audio, self.prev_x, self.prev_y, self.R)
+        
+
 class Deemphasis:
     def __init__(
         self,

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -52,31 +52,29 @@ DEFAULT_EXPANDER_RATIO = 2
 DEFAULT_EXPANDER_ATTACK_TAU = 5e-3
 DEFAULT_EXPANDER_RELEASE_TAU = 70e-3
 
-# High shelf filter parameters for weighted sidechain input to expander
-# low end of shelf curve
-DEFAULT_EXPANDER_WEIGHTING_TAU_1 = 240e-6
-# high end of shelf curve
-DEFAULT_EXPANDER_WEIGHTING_TAU_2 = 24e-6
-# slope of the filter
-DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE = 3
-DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH = 2
+# TAU_1         low end of shelf curve
+# TAU_2         high end of shelf curve
+# DB_PER_OCTAVE slope of the filter
+
+# High shelf filter filter for weighted input to expander
+DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1 = 240e-6
+DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2 = 6.4e-5
+DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE = 6
+DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH = 2.58
+
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1 = 5.5e-5
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 2.35e-5
+DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE = 6
+DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH = 2.4
 
 # Low shelf filter for deemphasis
-# low end of shelf curve
-# T1 standard 240e-6
-DEFAULT_VHS_DEEMPHASIS_TAU_1 = 185e-6
-# high end of shelf curve
-# T2 standard 56e-6
-DEFAULT_VHS_DEEMPHASIS_TAU_2 = 22e-6
-# slope of the filter
+DEFAULT_VHS_DEEMPHASIS_TAU_1 = 230e-6
+DEFAULT_VHS_DEEMPHASIS_TAU_2 = 21.8e-6
 DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE = 6
-DEFAULT_VHS_DEEMPHASIS_BANDWIDTH = 2.76
+DEFAULT_VHS_DEEMPHASIS_BANDWIDTH = 2.9
 
-# low end of shelf curve
-DEFAULT_8MM_DEEMPHASIS_TAU_1 = 1e-4
-# high end of shelf curve
-DEFAULT_8MM_DEEMPHASIS_TAU_2 = 1.27e-5
-# slope of the filter
+DEFAULT_8MM_DEEMPHASIS_TAU_1 = 1.1e-4
+DEFAULT_8MM_DEEMPHASIS_TAU_2 = 1.3e-5
 DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE = 6
 DEFAULT_8MM_DEEMPHASIS_BANDWIDTH = 2.4
 
@@ -874,10 +872,10 @@ class Expander:
         ratio: float = DEFAULT_EXPANDER_RATIO,
         attack_tau: float = DEFAULT_EXPANDER_ATTACK_TAU,
         release_tau: float = DEFAULT_EXPANDER_RELEASE_TAU,
-        weighting_shelf_low_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_1,
-        weighting_shelf_high_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_2,
-        weighting_db_per_octave: float = DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-        weighting_bandwidth: float = DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
+        weighting_low_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
+        weighting_high_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
+        weighting_db_per_octave: float = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+        weighting_bandwidth: float = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
     ):
         self.audio_rate = audio_rate
 
@@ -904,8 +902,8 @@ class Expander:
         )
 
         # weighted filter for envelope detector
-        self.weighting_T1 = weighting_shelf_low_tau
-        self.weighting_T2 = weighting_shelf_high_tau
+        self.weighting_T1 = weighting_low_tau
+        self.weighting_T2 = weighting_high_tau
         self.weighting_db_per_octave = weighting_db_per_octave
         self.weighting_bandwidth = weighting_bandwidth
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -233,6 +233,7 @@ class AFEFilterable:
             self.filter_reject_other.filtfilt(self.filter_reject_image.filtfilt(data))
         )
 
+QUADRATURE_LP_ORDER = 5
 
 class FMdemod:
     def __init__(
@@ -248,7 +249,7 @@ class FMdemod:
         self.min_float = float_info.min + float_info.epsneg
 
         if self.type == DEMOD_QUADRATURE:
-            quadrature_lp_b, quadrature_lp_a = butter(5, self.carrier / self.sample_rate / 2)
+            quadrature_lp_b, quadrature_lp_a = butter(QUADRATURE_LP_ORDER, self.carrier / self.sample_rate / 2)
             self.quadrature_lp_b = quadrature_lp_b.astype(DEMOD_DTYPE_NP)
             self.quadrature_lp_a = quadrature_lp_a.astype(DEMOD_DTYPE_NP)
         
@@ -447,24 +448,23 @@ class FMdemod:
         # demod = inst_freq - carrier
 
         # constants
-        two_pi: numba.types.Literal = 2 * pi
+        two_pi = 2 * pi
         diff_divisor = two_pi * (1 / sample_rate)
-        order = len(filter_b) - 1
         iq_len = len(i_osc)
         rf_len = len(in_rf)
 
         #
         # low pass filter history
         #
-        i_in_hist = np.zeros(order, dtype=np.float64)
-        q_in_hist = np.zeros(order, dtype=np.float64)
-        i_filtered_hist = np.zeros(order, dtype=np.float64)
-        q_filtered_hist = np.zeros(order, dtype=np.float64)
+        i_in_hist = np.zeros(QUADRATURE_LP_ORDER, dtype=np.float64)
+        q_in_hist = np.zeros(QUADRATURE_LP_ORDER, dtype=np.float64)
+        i_filtered_hist = np.zeros(QUADRATURE_LP_ORDER, dtype=np.float64)
+        q_filtered_hist = np.zeros(QUADRATURE_LP_ORDER, dtype=np.float64)
 
         prev_angle = 0  # doesn't matter since the final chunks have overlap
         prev_unwrapped = prev_angle
 
-        for i in range(1, rf_len - order):
+        for i in range(1, rf_len - QUADRATURE_LP_ORDER):
             #
             # mix in i/q, reflect the sine and cosine
             #
@@ -480,21 +480,20 @@ class FMdemod:
             i_filtered = filter_b[0] * i_in
             q_filtered = filter_b[0] * q_in
 
-            for f_idx in range(order - 1, -1, -1):
-                next_f_idx = f_idx + 1
-                i_filtered += filter_b[next_f_idx] * i_in_hist[f_idx]
-                i_filtered -= filter_a[next_f_idx] * i_filtered_hist[f_idx]
+            i_filtered += filter_b[QUADRATURE_LP_ORDER] * i_in_hist[QUADRATURE_LP_ORDER - 1] - filter_a[QUADRATURE_LP_ORDER] * i_filtered_hist[QUADRATURE_LP_ORDER - 1]
+            q_filtered += filter_b[QUADRATURE_LP_ORDER] * q_in_hist[QUADRATURE_LP_ORDER - 1] - filter_a[QUADRATURE_LP_ORDER] * q_filtered_hist[QUADRATURE_LP_ORDER - 1]
 
-                q_filtered += filter_b[next_f_idx] * q_in_hist[f_idx]
-                q_filtered -= filter_a[next_f_idx] * q_filtered_hist[f_idx]
+            for f_idx in range(QUADRATURE_LP_ORDER - 2, -1, -1):
+                next_f_idx = f_idx + 1
+                i_filtered += filter_b[next_f_idx] * i_in_hist[f_idx] - filter_a[next_f_idx] * i_filtered_hist[f_idx]
+                q_filtered += filter_b[next_f_idx] * q_in_hist[f_idx] - filter_a[next_f_idx] * q_filtered_hist[f_idx]
 
                 # Shift histories forward
-                if next_f_idx < order:
-                    i_in_hist[next_f_idx] = i_in_hist[f_idx]
-                    i_filtered_hist[next_f_idx] = i_filtered_hist[f_idx]
+                i_in_hist[next_f_idx] = i_in_hist[f_idx]
+                i_filtered_hist[next_f_idx] = i_filtered_hist[f_idx]
 
-                    q_in_hist[next_f_idx] = q_in_hist[f_idx]
-                    q_filtered_hist[next_f_idx] = q_filtered_hist[f_idx]
+                q_in_hist[next_f_idx] = q_in_hist[f_idx]
+                q_filtered_hist[next_f_idx] = q_filtered_hist[f_idx]
 
             i_in_hist[0] = i_in
             i_filtered_hist[0] = i_filtered

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from fractions import Fraction
-from math import log, log10, pi, sqrt, ceil, floor, atan2, log1p, cos, sin, lcm
+from math import log, pi, sqrt, ceil, floor, atan2, log1p, cos, sin, lcm, exp
 from typing import Tuple
 from time import perf_counter
 from setproctitle import setproctitle
@@ -480,9 +480,8 @@ class FMdemod:
             i_filtered = filter_b[0] * i_in
             q_filtered = filter_b[0] * q_in
 
-            f_idx = order - 1
-            next_f_idx = order
-            while f_idx >= 0:
+            for f_idx in range(order - 1, -1, -1):
+                next_f_idx = f_idx + 1
                 i_filtered += filter_b[next_f_idx] * i_in_hist[f_idx]
                 i_filtered -= filter_a[next_f_idx] * i_filtered_hist[f_idx]
 
@@ -497,9 +496,6 @@ class FMdemod:
                     q_in_hist[next_f_idx] = q_in_hist[f_idx]
                     q_filtered_hist[next_f_idx] = q_filtered_hist[f_idx]
 
-                next_f_idx = f_idx
-                f_idx -= 1
-
             i_in_hist[0] = i_in
             i_filtered_hist[0] = i_filtered
 
@@ -512,18 +508,13 @@ class FMdemod:
             current_angle = atan2(q_filtered, i_filtered)
             delta = current_angle - prev_angle
 
-            if delta > pi:
-                corrected = current_angle - two_pi
-            elif delta < -pi:
-                corrected = current_angle + two_pi
-            else:
-                corrected = current_angle
+            correction = -two_pi * (delta > pi) + two_pi * (delta < -pi)
+            unwrapped = prev_unwrapped + delta + correction
 
-            unwrapped = prev_unwrapped + (corrected - prev_angle)
             diff = prev_unwrapped - unwrapped
             out = (carrier - diff / diff_divisor) / deviation
 
-            out_demod[i - 1] = max(min_float, min(max_float, out))
+            out_demod[i - 1] = min(max(out, min_float), max_float)
 
             prev_angle = current_angle
             prev_unwrapped = unwrapped
@@ -878,6 +869,8 @@ class Expander:
         weighting_bandwidth: float = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
     ):
         self.audio_rate = audio_rate
+        self.linear_to_db = 20 / log(10)
+        self.db_to_linear = log(10) / 20
 
         # makeup gain to apply after expansion
         self.gain = 10 ** (gain / 20)
@@ -885,7 +878,7 @@ class Expander:
         self.atkCoeff = np.exp(-1.0 / (attack_tau * self.audio_rate))
         self.relCoeff = np.exp(-1.0 / (release_tau * self.audio_rate))
 
-        self.env = 0.0
+        self.env_db = -120.0
 
         # this is set to avoid high frequency noise to interfere with the NR envelope tracking
         self.Lo_cut = 19e3
@@ -938,6 +931,8 @@ class Expander:
             numba.types.float32,
             numba.types.float32,
             numba.types.float32,
+            numba.types.float32,
+            numba.types.float32,
             numba.types.float32
         )],
         cache=True,
@@ -947,7 +942,9 @@ class Expander:
     def expand(
         audio,
         side_chain,
-        env,
+        env_db,
+        linear_to_db,
+        db_to_linear,
         atkCoeff,
         relCoeff,
         gain,
@@ -955,27 +952,19 @@ class Expander:
     ):
         audio_len = audio.shape[0]
         ratio_m1 = ratio - 1
-        cutoff_threshold = 1e-12
 
         for i in range(audio_len):
-            sc_abs = abs(side_chain[i])
+            # envelope in db
+            sc_db = log(abs(side_chain[i]) + 1e-20) * linear_to_db
 
-            # Envelope follower
-            if sc_abs > env:
-                # attack
-                env = atkCoeff * env + (1.0 - atkCoeff) * sc_abs
-            else:
-                # release
-                env = relCoeff * env + (1.0 - relCoeff) * sc_abs
+            coeff = relCoeff + (atkCoeff - relCoeff) * (sc_db > env_db)
+            env_db = coeff * env_db + (1.0 - coeff) * sc_db
 
-            if env < cutoff_threshold:
-                env_gain = 0.0
-            else:
-                env_gain = env ** ratio_m1
+            gain_db = ratio_m1 * env_db
+
+            audio[i] *= exp(gain_db * db_to_linear) * gain
     
-            audio[i] *= env_gain * gain
-    
-        return env
+        return env_db
 
     def process(self, pre_in, audio_out):
         # prevent high frequency noise from interfering with envelope detector
@@ -984,10 +973,12 @@ class Expander:
         # high pass weighted input to envelope detector
         side_chain = self.WeightedHighpass.lfilt(pre_in_low_pass)
 
-        self.env = Expander.expand(
+        self.env_db = Expander.expand(
             audio_out,
             side_chain,
-            self.env,
+            self.env_db,
+            self.linear_to_db,
+            self.db_to_linear,
             self.atkCoeff,
             self.relCoeff,
             self.gain,

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -2,8 +2,6 @@ import os.path
 import sys
 import math
 
-from scipy.io import wavfile
-from scipy.fft import rfft, rfftfreq
 import numpy as np
 
 import matplotlib

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -2,6 +2,8 @@ import os.path
 import sys
 import math
 
+from scipy.io import wavfile
+from scipy.fft import rfft, rfftfreq
 import numpy as np
 
 import matplotlib
@@ -62,18 +64,24 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_EXPANDER_RATIO,
     DEFAULT_EXPANDER_ATTACK_TAU,
     DEFAULT_EXPANDER_RELEASE_TAU,
-    DEFAULT_EXPANDER_WEIGHTING_TAU_1,
-    DEFAULT_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
     DEFAULT_VHS_DEEMPHASIS_TAU_1,
     DEFAULT_VHS_DEEMPHASIS_TAU_2,
     DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_VHS_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+
     DEFAULT_8MM_DEEMPHASIS_TAU_1,
     DEFAULT_8MM_DEEMPHASIS_TAU_2,
     DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE,
     DEFAULT_8MM_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH,
+
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEMOD_QUADRATURE,
@@ -99,10 +107,10 @@ class MainUIParameters:
         self.expander_ratio: float = DEFAULT_EXPANDER_RATIO
         self.expander_attack_tau: float = DEFAULT_EXPANDER_ATTACK_TAU
         self.expander_release_tau: float = DEFAULT_EXPANDER_RELEASE_TAU
-        self.expander_weighting_shelf_low_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_1
-        self.expander_weighting_shelf_high_tau: float = DEFAULT_EXPANDER_WEIGHTING_TAU_2
-        self.expander_weighting_db_per_octave: float = DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE
-        self.expander_weighting_bandwidth: float = DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH
+        self.expander_weighting_low_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1
+        self.expander_weighting_high_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2
+        self.expander_weighting_db_per_octave: float = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE
+        self.expander_weighting_bandwidth: float = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH
         self.deemphasis_low_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_1
         self.deemphasis_high_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_2
         self.deemphasis_db_per_octave: float = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
@@ -139,8 +147,8 @@ def decode_options_to_ui_parameters(decode_options):
     values.expander_ratio = decode_options["expander_ratio"]
     values.expander_attack_tau = decode_options["expander_attack_tau"]
     values.expander_release_tau = decode_options["expander_release_tau"]
-    values.expander_weighting_shelf_low_tau = decode_options["expander_weighting_shelf_low_tau"]
-    values.expander_weighting_shelf_high_tau = decode_options["expander_weighting_shelf_high_tau"]
+    values.expander_weighting_low_tau = decode_options["expander_weighting_low_tau"]
+    values.expander_weighting_high_tau = decode_options["expander_weighting_high_tau"]
     values.expander_weighting_db_per_octave = decode_options["expander_weighting_db_per_octave"]
     values.expander_weighting_bandwidth = decode_options["expander_weighting_bandwidth"]
     values.deemphasis_low_tau = decode_options["deemphasis_low_tau"]
@@ -181,8 +189,8 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "expander_ratio": values.expander_ratio,
         "expander_attack_tau": values.expander_attack_tau,
         "expander_release_tau": values.expander_release_tau,
-        "expander_weighting_shelf_low_tau": values.expander_weighting_shelf_low_tau,
-        "expander_weighting_shelf_high_tau": values.expander_weighting_shelf_high_tau,
+        "expander_weighting_low_tau": values.expander_weighting_low_tau,
+        "expander_weighting_high_tau": values.expander_weighting_high_tau,
         "expander_weighting_db_per_octave": values.expander_weighting_db_per_octave,
         "expander_weighting_bandwidth": values.expander_weighting_bandwidth,
         "deemphasis_low_tau": values.deemphasis_low_tau,
@@ -707,24 +715,24 @@ class HifiUi(QMainWindow):
         )
         layout.addLayout(expander_sideband_frame)
         weighting_layout = QHBoxLayout()
-        self.expander_weighting_shelf_low_tau_dial_control = DialControl(
+        self.expander_weighting_low_tau_dial_control = DialControl(
             self,
             "Low Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
-            DEFAULT_EXPANDER_WEIGHTING_TAU_2,
+            DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
             10e-4,
         )
-        weighting_layout.addWidget(self.expander_weighting_shelf_low_tau_dial_control)
-        self.expander_weighting_shelf_high_tau_dial_control = DialControl(
+        weighting_layout.addWidget(self.expander_weighting_low_tau_dial_control)
+        self.expander_weighting_high_tau_dial_control = DialControl(
             self,
             "High Shelf (𝜏)",
             QtGui.QDoubleValidator(),
             10e5,
             10e-7,
-            DEFAULT_EXPANDER_WEIGHTING_TAU_1,
+            DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
         )
-        weighting_layout.addWidget(self.expander_weighting_shelf_high_tau_dial_control)
+        weighting_layout.addWidget(self.expander_weighting_high_tau_dial_control)
         self.expander_weighting_db_per_octave_dial_control = DialControl(
             self, "Slope (db/oct)", QtGui.QDoubleValidator(), 10, 0, 12
         )
@@ -792,8 +800,8 @@ class HifiUi(QMainWindow):
         self._plot_update_timer.setSingleShot(True)
         self._plot_update_timer.timeout.connect(self.weighting_deemphasis_plot.update_plot)
 
-        self.expander_weighting_shelf_low_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
-        self.expander_weighting_shelf_high_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_weighting_low_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_weighting_high_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
         self.expander_weighting_db_per_octave_dial_control.valueChanged.connect(self.schedule_plot_update)
         self.expander_weighting_bandwidth_dial_control.valueChanged.connect(self.schedule_plot_update)
 
@@ -834,11 +842,11 @@ class HifiUi(QMainWindow):
         self.expander_ratio_dial_control.setValue(values.expander_ratio)
         self.expander_attack_tau_dial_control.setValue(values.expander_attack_tau)
         self.expander_release_tau_dial_control.setValue(values.expander_release_tau)
-        self.expander_weighting_shelf_low_tau_dial_control.setValue(
-            values.expander_weighting_shelf_low_tau
+        self.expander_weighting_low_tau_dial_control.setValue(
+            values.expander_weighting_low_tau
         )
-        self.expander_weighting_shelf_high_tau_dial_control.setValue(
-            values.expander_weighting_shelf_high_tau
+        self.expander_weighting_high_tau_dial_control.setValue(
+            values.expander_weighting_high_tau
         )
         self.expander_weighting_db_per_octave_dial_control.setValue(
             values.expander_weighting_db_per_octave
@@ -906,7 +914,8 @@ class HifiUi(QMainWindow):
             values.afe_left_carrier,
             values.afe_right_carrier,
         )
-        self.update_deemphasis_values(values.format)
+
+        self.update_deemphasis_expander_values(values.format)
 
         self.input_file = values.input_file
         self.output_file = values.output_file
@@ -918,11 +927,11 @@ class HifiUi(QMainWindow):
         values.expander_ratio = self.expander_ratio_dial_control.value()
         values.expander_attack_tau = self.expander_attack_tau_dial_control.value()
         values.expander_release_tau = self.expander_release_tau_dial_control.value()
-        values.expander_weighting_shelf_low_tau = (
-            self.expander_weighting_shelf_low_tau_dial_control.value()
+        values.expander_weighting_low_tau = (
+            self.expander_weighting_low_tau_dial_control.value()
         )
-        values.expander_weighting_shelf_high_tau = (
-            self.expander_weighting_shelf_high_tau_dial_control.value()
+        values.expander_weighting_high_tau = (
+            self.expander_weighting_high_tau_dial_control.value()
         )
         values.expander_weighting_db_per_octave = (
             self.expander_weighting_db_per_octave_dial_control.value()
@@ -983,17 +992,25 @@ class HifiUi(QMainWindow):
         self.afe_left_carrier_spinbox.setValue(int(standard.LCarrierRef))
         self.afe_right_carrier_spinbox.setValue(int(standard.RCarrierRef))
 
-    def update_deemphasis_values(self, format):
+    def update_deemphasis_expander_values(self, format):
         if format == "VHS":
             self.deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_1)
             self.deemphasis_high_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_2)
             self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE)
             self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_BANDWIDTH)
+            self.expander_weighting_low_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1)
+            self.expander_weighting_high_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2)
+            self.expander_weighting_db_per_octave_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE)
+            self.expander_weighting_bandwidth_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH)
         else:
             self.deemphasis_low_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_1)
             self.deemphasis_high_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_2)
             self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE)
             self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_BANDWIDTH)
+            self.expander_weighting_low_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1)
+            self.expander_weighting_high_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2)
+            self.expander_weighting_db_per_octave_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE)
+            self.expander_weighting_bandwidth_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH)
 
     def on_standard_change(self):
         self.update_afe_values(
@@ -1006,7 +1023,7 @@ class HifiUi(QMainWindow):
             format=self.format_combo.currentText(),
             standard=self.standard_combo.currentText(),
         )
-        self.update_deemphasis_values(self.format_combo.currentText())
+        self.update_deemphasis_expander_values(self.format_combo.currentText())
 
     def change_button_color(self, button, color):
         button.setStyleSheet(
@@ -1516,8 +1533,8 @@ class PlotWindow(QWidget):
 
         expander = Expander(
             ui_values.audio_sample_rate,
-            weighting_shelf_low_tau = ui_values.expander_weighting_shelf_low_tau,
-            weighting_shelf_high_tau = ui_values.expander_weighting_shelf_high_tau,
+            weighting_low_tau = ui_values.expander_weighting_low_tau,
+            weighting_high_tau = ui_values.expander_weighting_high_tau,
             weighting_db_per_octave = ui_values.expander_weighting_db_per_octave,
             weighting_bandwidth = ui_values.expander_weighting_bandwidth
         )
@@ -1528,8 +1545,8 @@ class PlotWindow(QWidget):
             "green",
             expander_freqs,
             expander_mag_db,
-            ui_values.expander_weighting_shelf_low_tau,
-            ui_values.expander_weighting_shelf_high_tau,
+            ui_values.expander_weighting_low_tau,
+            ui_values.expander_weighting_high_tau,
         )
         self.plot_response(
             "Deemphasis",

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -362,28 +362,24 @@ expander_options_group.add_argument(
     "--expander_weighting_low_tau",
     dest="expander_weighting_low_tau",
     type=float,
-    default=DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
     help=f"Sets the expander weighting high-pass shelf filter low point in tau (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_high_tau",
     dest="expander_weighting_high_tau",
     type=float,
-    default=DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
     help=f"Sets the expander weighting high-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_db_per_octave",
     dest="expander_weighting_db_per_octave",
     type=float,
-    default=DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
     help=f"Sets the expander weighting high-pass shelf filter cutoff rate (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_bandwidth",
     dest="expander_weighting_bandwidth",
     type=float,
-    default=DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
     help=f"Sets the expander weighting high-pass shelf filter bandwidth (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH}]).",
 )
 
@@ -1964,21 +1960,25 @@ def main() -> int:
         resampler_quality = DEFAULT_RESAMPLER_QUALITY
 
     if args.format_8mm:
+        print("using 8mm")
         tape_format = "8mm"
         default_deemphasis_low_tau = DEFAULT_8MM_DEEMPHASIS_TAU_1
         default_deemphasis_high_tau = DEFAULT_8MM_DEEMPHASIS_TAU_2
         default_deemphasis_db_per_octave = DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE
         default_deemphasis_bandwidth = DEFAULT_8MM_DEEMPHASIS_BANDWIDTH
+
         default_expander_weighting_low_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1
         default_expander_weighting_high_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2
         default_expander_weighting_db_per_octave = DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE
         default_expander_weighting_bandwidth = DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH
     else:
+        print("using vhs")
         tape_format = "vhs"
         default_deemphasis_low_tau = DEFAULT_VHS_DEEMPHASIS_TAU_1
         default_deemphasis_high_tau = DEFAULT_VHS_DEEMPHASIS_TAU_2
         default_deemphasis_db_per_octave = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
         default_deemphasis_bandwidth = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
+
         default_expander_weighting_low_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1
         default_expander_weighting_high_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2
         default_expander_weighting_db_per_octave = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -45,6 +45,7 @@ from vhsdecode.cmdcommons import (
 from vhsdecode.hifi.HiFiDecode import (
     HiFiDecode,
     SpectralNoiseReduction,
+    DCBlocker,
     Expander,
     Deemphasis,
     DEFAULT_EXPANDER_GAIN,
@@ -936,8 +937,8 @@ class PostProcessor:
             atexit.register(shared_memory.close)
             atexit.register(shared_memory.unlink)
 
-        spec_nr_worker_l_in_rx, spec_nr_worker_l_in_tx = Pipe(duplex=False)
-        spec_nr_worker_r_in_rx, spec_nr_worker_r_in_tx = Pipe(duplex=False)
+        block_sort_l_in_rx, block_sort_l_in_tx = Pipe(duplex=False)
+        block_sort_r_in_rx, block_sort_r_in_tx = Pipe(duplex=False)
         self.block_sorter_process = Process(
             target=PostProcessor.block_sorter_worker,
             name="hifi_block_sort",
@@ -946,20 +947,48 @@ class PostProcessor:
                 self.decoder_shared_memory_idle_queue,
                 self.blocks_enqueued,
                 self.post_processor_shared_memory_idle_queue,
-                spec_nr_worker_l_in_tx,
-                spec_nr_worker_r_in_tx,
+                block_sort_l_in_tx,
+                block_sort_r_in_tx,
             ),
         )
         self.block_sorter_process.start()
         atexit.register(self.block_sorter_process.terminate)
         atexit.register(self.block_sorter_process.join)
 
+        dc_blocker_worker_l_rx, dc_blocker_worker_l_tx = Pipe(duplex=False)
+        self.dc_blocker_worker_l = Process(
+            target=PostProcessor.dc_block_worker,
+            name="hifi_dc_block_l",
+            args=(
+                block_sort_l_in_rx,
+                dc_blocker_worker_l_tx,
+                self.final_audio_rate,
+            ),
+        )
+        self.dc_blocker_worker_l.start()
+        atexit.register(self.dc_blocker_worker_l.terminate)
+        atexit.register(self.dc_blocker_worker_l.join)
+
+        dc_blocker_worker_r_rx, dc_blocker_worker_r_tx = Pipe(duplex=False)
+        self.dc_blocker_worker_r = Process(
+            target=PostProcessor.dc_block_worker,
+            name="hifi_dc_block_r",
+            args=(
+                block_sort_r_in_rx,
+                dc_blocker_worker_r_tx,
+                self.final_audio_rate,
+            ),
+        )
+        self.dc_blocker_worker_r.start()
+        atexit.register(self.dc_blocker_worker_r.terminate)
+        atexit.register(self.dc_blocker_worker_r.join)
+
         spectral_nr_worker_l_rx, spectral_nr_worker_l_tx = Pipe(duplex=False)
         self.spectral_nr_worker_l = Process(
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_l",
             args=(
-                spec_nr_worker_l_in_rx,
+                dc_blocker_worker_l_rx,
                 spectral_nr_worker_l_tx,
                 self.spectral_nr_amount,
                 self.final_audio_rate,
@@ -974,7 +1003,7 @@ class PostProcessor:
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_r",
             args=(
-                spec_nr_worker_r_in_rx,
+                dc_blocker_worker_r_rx,
                 spectral_nr_worker_r_tx,
                 self.spectral_nr_amount,
                 self.final_audio_rate,
@@ -1068,6 +1097,39 @@ class PostProcessor:
             audio[i] = audio[i] * gain
 
     @staticmethod
+    def dc_block_worker(
+        in_conn,
+        out_conn,
+        final_audio_rate
+    ):
+        setproctitle(current_process().name)
+        dc_blocker = DCBlocker(
+            final_audio_rate,
+            8
+        )
+
+        while True:
+            while True:
+                try:
+                    decoder_state, channel_num = in_conn.recv()
+                    break
+                except InterruptedError:
+                    pass
+                except EOFError:
+                    return
+
+            buffer = PostProcessorSharedMemory(decoder_state)
+            if channel_num == 0:
+                pre = buffer.get_pre_left()
+            else:
+                pre = buffer.get_pre_right()
+
+            dc_blocker.process(pre)
+
+            buffer.close()
+            out_conn.send((decoder_state, channel_num))
+        
+    @staticmethod
     def spectral_noise_reduction_worker(
         in_conn,
         out_conn,
@@ -1129,6 +1191,14 @@ class PostProcessor:
         deemphasis_bandwidth
     ):
         setproctitle(current_process().name)
+        deemphasis = Deemphasis(
+            final_audio_rate,
+            deemphasis_low_tau,
+            deemphasis_high_tau,
+            deemphasis_db_per_octave,
+            deemphasis_bandwidth
+        )
+
         expander = Expander(
             final_audio_rate,
             expander_gain,
@@ -1139,14 +1209,6 @@ class PostProcessor:
             expander_weighting_high_tau,
             expander_weighting_db_per_octave,
             expander_weighting_bandwidth
-        )
-
-        deemphasis = Deemphasis(
-            final_audio_rate,
-            deemphasis_low_tau,
-            deemphasis_high_tau,
-            deemphasis_db_per_octave,
-            deemphasis_bandwidth
         )
 
         while True:
@@ -1368,6 +1430,8 @@ class PostProcessor:
 
     def close(self):
         cleanup_process(self.block_sorter_process)
+        cleanup_process(self.dc_blocker_worker_l)
+        cleanup_process(self.dc_blocker_worker_r)
         cleanup_process(self.spectral_nr_worker_l)
         cleanup_process(self.spectral_nr_worker_r)
         cleanup_process(self.expander_worker_l)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -51,10 +51,14 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_EXPANDER_RATIO,
     DEFAULT_EXPANDER_ATTACK_TAU,
     DEFAULT_EXPANDER_RELEASE_TAU,
-    DEFAULT_EXPANDER_WEIGHTING_TAU_1,
-    DEFAULT_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH,
     DEFAULT_VHS_DEEMPHASIS_TAU_1,
     DEFAULT_VHS_DEEMPHASIS_TAU_2,
     DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
@@ -355,32 +359,32 @@ expander_options_group.add_argument(
     help=f"Sets the expander release speed in tau (default is {DEFAULT_EXPANDER_RELEASE_TAU}).",
 )
 expander_options_group.add_argument(
-    "--expander_weighting_shelf_low_tau",
-    dest="expander_weighting_shelf_low_tau",
+    "--expander_weighting_low_tau",
+    dest="expander_weighting_low_tau",
     type=float,
-    default=DEFAULT_EXPANDER_WEIGHTING_TAU_1,
-    help=f"Sets the expander sidechain high-pass shelf filter low point in tau (default is {DEFAULT_EXPANDER_WEIGHTING_TAU_1}).",
+    default=DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
+    help=f"Sets the expander weighting high-pass shelf filter low point in tau (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1}]).",
 )
 expander_options_group.add_argument(
-    "--expander_weighting_shelf_high_tau",
-    dest="expander_weighting_shelf_high_tau",
+    "--expander_weighting_high_tau",
+    dest="expander_weighting_high_tau",
     type=float,
-    default=DEFAULT_EXPANDER_WEIGHTING_TAU_2,
-    help=f"Sets the expander sidechain high-pass shelf filter high point in tau (default is {DEFAULT_EXPANDER_WEIGHTING_TAU_2}).",
+    default=DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
+    help=f"Sets the expander weighting high-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_db_per_octave",
     dest="expander_weighting_db_per_octave",
     type=float,
-    default=DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    help=f"Sets the expander sidechain high-pass shelf filter cutoff rate (default is {DEFAULT_EXPANDER_WEIGHTING_DB_PER_OCTAVE}).",
+    default=DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
+    help=f"Sets the expander weighting high-pass shelf filter cutoff rate (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_bandwidth",
     dest="expander_weighting_bandwidth",
     type=float,
-    default=DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH,
-    help=f"Sets the expander sidechain high-pass shelf filter bandwidth (default is {DEFAULT_EXPANDER_WEIGHTING_BANDWIDTH}).",
+    default=DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+    help=f"Sets the expander weighting high-pass shelf filter bandwidth (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH}]).",
 )
 
 deemphasis_options_group = parser.add_argument_group(
@@ -998,8 +1002,8 @@ class PostProcessor:
                 decode_options["expander_ratio"],
                 decode_options["expander_attack_tau"],
                 decode_options["expander_release_tau"],
-                decode_options["expander_weighting_shelf_low_tau"],
-                decode_options["expander_weighting_shelf_high_tau"],
+                decode_options["expander_weighting_low_tau"],
+                decode_options["expander_weighting_high_tau"],
                 decode_options["expander_weighting_db_per_octave"],
                 decode_options["expander_weighting_bandwidth"],
                 decode_options["deemphasis_low_tau"],
@@ -1026,8 +1030,8 @@ class PostProcessor:
                 decode_options["expander_ratio"],
                 decode_options["expander_attack_tau"],
                 decode_options["expander_release_tau"],
-                decode_options["expander_weighting_shelf_low_tau"],
-                decode_options["expander_weighting_shelf_high_tau"],
+                decode_options["expander_weighting_low_tau"],
+                decode_options["expander_weighting_high_tau"],
                 decode_options["expander_weighting_db_per_octave"],
                 decode_options["expander_weighting_bandwidth"],
                 decode_options["deemphasis_low_tau"],
@@ -1119,8 +1123,8 @@ class PostProcessor:
         expander_ratio,
         expander_attack_tau,
         expander_release_tau,
-        expander_weighting_shelf_low_tau,
-        expander_weighting_shelf_high_tau,
+        expander_weighting_low_tau,
+        expander_weighting_high_tau,
         expander_weighting_db_per_octave,
         expander_weighting_bandwidth,
         deemphasis_low_tau,
@@ -1135,8 +1139,8 @@ class PostProcessor:
             expander_ratio,
             expander_attack_tau,
             expander_release_tau,
-            expander_weighting_shelf_low_tau,
-            expander_weighting_shelf_high_tau,
+            expander_weighting_low_tau,
+            expander_weighting_high_tau,
             expander_weighting_db_per_octave,
             expander_weighting_bandwidth
         )
@@ -1965,12 +1969,20 @@ def main() -> int:
         default_deemphasis_high_tau = DEFAULT_8MM_DEEMPHASIS_TAU_2
         default_deemphasis_db_per_octave = DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE
         default_deemphasis_bandwidth = DEFAULT_8MM_DEEMPHASIS_BANDWIDTH
+        default_expander_weighting_low_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1
+        default_expander_weighting_high_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2
+        default_expander_weighting_db_per_octave = DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE
+        default_expander_weighting_bandwidth = DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH
     else:
         tape_format = "vhs"
         default_deemphasis_low_tau = DEFAULT_VHS_DEEMPHASIS_TAU_1
         default_deemphasis_high_tau = DEFAULT_VHS_DEEMPHASIS_TAU_2
         default_deemphasis_db_per_octave = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
         default_deemphasis_bandwidth = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
+        default_expander_weighting_low_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1
+        default_expander_weighting_high_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2
+        default_expander_weighting_db_per_octave = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE
+        default_expander_weighting_bandwidth = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH
 
     decode_options = {
         "input_rate": sample_freq * 1e6,
@@ -1995,10 +2007,10 @@ def main() -> int:
         "expander_ratio": args.expander_ratio,
         "expander_attack_tau": args.expander_attack_tau,
         "expander_release_tau": args.expander_release_tau,
-        "expander_weighting_shelf_low_tau": args.expander_weighting_shelf_low_tau,
-        "expander_weighting_shelf_high_tau": args.expander_weighting_shelf_high_tau,
-        "expander_weighting_db_per_octave": args.expander_weighting_db_per_octave,
-        "expander_weighting_bandwidth": args.expander_weighting_bandwidth,
+        "expander_weighting_low_tau": args.expander_weighting_low_tau or default_expander_weighting_low_tau,
+        "expander_weighting_high_tau": args.expander_weighting_high_tau or default_expander_weighting_high_tau,
+        "expander_weighting_db_per_octave": args.expander_weighting_db_per_octave or default_expander_weighting_db_per_octave,
+        "expander_weighting_bandwidth": args.expander_weighting_bandwidth or default_expander_weighting_bandwidth,
         "deemphasis_low_tau": args.deemphasis_low_tau or default_deemphasis_low_tau,
         "deemphasis_high_tau": args.deemphasis_high_tau or default_deemphasis_high_tau,
         "deemphasis_db_per_octave": args.deemphasis_db_per_octave or default_deemphasis_db_per_octave,


### PR DESCRIPTION
* Add tuned expander settings for 8mm
* Tune VHS expander weighting
* Use logarithmic attack and release vs. linear
* Add high pass filter to block DC and sub sonic components that were interfering with normalization gain calculation