### PR TITLE
check free space and pause decode instead of failing

### DIFF
--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -592,16 +592,16 @@ def main(args=None, use_gui=False):
             output_dir = os.path.dirname(os.path.abspath(outname)) or "."
             try:
                 free_space = shutil.disk_usage(output_dir).free
-                if free_space < 1024 * 1024 * 1024:  # 1GB, 500 fields needs around 675MB, 1GB for a bit of margin.
+                if free_space < 1024 * 1024 * 1024:  # 10GB, 500 fields_written needs around 675MB, 1G0B for some margin because there can be other things writing to the disk as well, the disk might fill before the next check otherwise.
                     print(
-                        "\nLess than 1GB of space is remaining, decoding paused. Decoding will resume once there is more space, or press Ctrl+C to exit.",
+                        "\nLess than 10GB of space is remaining, decoding paused. Decoding will resume once there is more space, or press Ctrl+C to exit.",
                         file=sys.stderr,
                     )
                     while True:
                         try:
                             time.sleep(1)
                             free_space = shutil.disk_usage(output_dir).free
-                            if free_space >= 1024 * 1024 * 1024:
+                            if free_space >= 1024 * 1024 * 1024 * 10:  # 10GB
                                 print("\nDisk space available, resuming decode.", file=sys.stderr)
                                 break
                         except KeyboardInterrupt:

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -592,10 +592,9 @@ def main(args=None, use_gui=False):
             output_dir = os.path.dirname(os.path.abspath(outname)) or "."
             try:
                 free_space = shutil.disk_usage(output_dir).free
-                if free_space < 1024 * 1024 * 1024:  # 1GB
+                if free_space < 1024 * 1024 * 1024:  # 1GB, 500 fields needs around 675MB, 1GB for a bit of margin.
                     print(
-                        "\nLess than 1GB of space is remaining, decoding paused. "
-                        "Decoding will resume once there is more space, or press Ctrl+C to exit.",
+                        "\nLess than 1GB of space is remaining, decoding paused. Decoding will resume once there is more space, or press Ctrl+C to exit.",
                         file=sys.stderr,
                     )
                     while True:

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -589,7 +589,7 @@ def main(args=None, use_gui=False):
         if vhsd.fields_written < 100 or ((vhsd.fields_written % 500) == 0):
             jsondumper.write()
             # Check free disk space
-            output_dir = os.path.dirname(os.path.abspath(outname)) or "."
+            output_dir = os.path.dirname(os.path.abspath(outname))
             try:
                 free_space = shutil.disk_usage(output_dir).free
                 if free_space < 1024 * 1024 * 1024 * 10:  # 10GB, 500 fields_written needs around 675MB, 1G0B for some margin because there can be other things writing to the disk as well, the disk might fill before the next check otherwise.

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -4,6 +4,8 @@ import sys
 import signal
 import traceback
 import json
+import shutil
+import time
 
 import numpy
 
@@ -586,6 +588,29 @@ def main(args=None, use_gui=False):
 
         if vhsd.fields_written < 100 or ((vhsd.fields_written % 500) == 0):
             jsondumper.write()
+            # Check free disk space
+            output_dir = os.path.dirname(os.path.abspath(outname)) or "."
+            try:
+                free_space = shutil.disk_usage(output_dir).free
+                if free_space < 1024 * 1024 * 1024:  # 1GB
+                    print(
+                        "\nLess than 1GB of space is remaining, decoding paused. "
+                        "Decoding will resume once there is more space, or press Ctrl+C to exit.",
+                        file=sys.stderr,
+                    )
+                    while True:
+                        try:
+                            time.sleep(1)
+                            free_space = shutil.disk_usage(output_dir).free
+                            if free_space >= 1024 * 1024 * 1024:
+                                print("\nDisk space available, resuming decode.", file=sys.stderr)
+                                break
+                        except KeyboardInterrupt:
+                            print("\nTerminated, saving JSON and exiting")
+                            cleanup()
+                            sys.exit(1)
+            except OSError:
+                pass  # Ignore if we can't check disk space
 
     if vhsd.fields_written:
         print("\nCompleted: saving JSON and exiting.", file=sys.stderr)

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -592,9 +592,9 @@ def main(args=None, use_gui=False):
             output_dir = os.path.dirname(os.path.abspath(outname)) or "."
             try:
                 free_space = shutil.disk_usage(output_dir).free
-                if free_space < 1024 * 1024 * 1024:  # 10GB, 500 fields_written needs around 675MB, 1G0B for some margin because there can be other things writing to the disk as well, the disk might fill before the next check otherwise.
+                if free_space < 1024 * 1024 * 1024 * 10:  # 10GB, 500 fields_written needs around 675MB, 1G0B for some margin because there can be other things writing to the disk as well, the disk might fill before the next check otherwise.
                     print(
-                        "\nLess than 10GB of space is remaining, decoding paused. Decoding will resume once there is more space, or press Ctrl+C to exit.",
+                        "\nLess than 10GB of free disk space is remaining, decoding paused. Decoding will resume once there is more space, or press Ctrl+C to exit.",
                         file=sys.stderr,
                     )
                     while True:


### PR DESCRIPTION
This happens often enough to me that I wrote a fix for it: running out of space leaving an unusable partial decode, and running out of space with multiple decodes in parallel results in all of them being unusable.

This adds a free space check that pauses decoding until more than 10GB of space is available (again).

Performance impact is minimal because it's only done every 500 fields (after the first 100).