### PR TITLE
Fix missing library on ld-analyze imports

### DIFF
--- a/tools/ld-analyse/whitesnranalysisdialog.h
+++ b/tools/ld-analyse/whitesnranalysisdialog.h
@@ -36,6 +36,7 @@
 #include <qwt_scale_widget.h>
 #include <qwt_scale_draw.h>
 #include <qwt_plot_marker.h>
+#include <cmath>
 
 namespace Ui {
 class WhiteSnrAnalysisDialog;


### PR DESCRIPTION
cmath was removed, but it's needed for std::isnan to exist.

(curious why oln did that, but ok xP)