### PR TITLE
hifi-decode: rework deemphasis and expander

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -2071,7 +2071,7 @@ class HiFiDecode:
     def mix_for_mode_stereo(
         l_raw: np.array, r_raw: np.array, decode_mode: str
     ) -> Tuple[np.array, np.array]:
-        if decode_mode == "mpx":
+        if decode_mode == "ms":
             l = np.multiply(np.add(l_raw, r_raw), 0.5)
             r = np.multiply(np.subtract(l_raw, r_raw), 0.5)
         elif decode_mode == "l":

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -13,11 +13,9 @@ from copy import deepcopy
 import string
 from random import SystemRandom
 
-import atexit
-
 import numpy as np
 import numba
-from numba import njit, guvectorize
+from numba import njit
 from scipy.signal import (
     lfilter_zi,
     filtfilt,
@@ -29,14 +27,14 @@ from scipy.signal import (
     istft,
     fftconvolve,
     find_peaks,
-    freqz
+    freqz,
+    bilinear
 )
 from scipy.interpolate import interp1d
 from soxr import ResampleStream, resample
 
 from noisereduce.spectralgate.nonstationary import SpectralGateNonStationary
 
-from vhsdecode.addons.FMdeemph import gen_shelf
 from vhsdecode.addons.gnuradioZMQ import ZMQSend, ZMQ_AVAILABLE
 from vhsdecode.utils import firdes_lowpass, firdes_highpass, StackableMA
 
@@ -45,38 +43,44 @@ from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray
 
 import matplotlib.pyplot as plt
 
+DEFAULT_VHS_EXPANDER_GAIN = 30
+DEFAULT_VHS_EXPANDER_RATIO = 2 #           2:1 logarithmic
+DEFAULT_VHS_EXPANDER_ATTACK_TAU = 10e-3 #  3ms to 10ms
+DEFAULT_VHS_EXPANDER_HOLD_TAU = 0
+DEFAULT_VHS_EXPANDER_RELEASE_TAU = 70e-3 # 70ms +-20%
 
-# lower increases expander strength and decreases overall gain
-DEFAULT_EXPANDER_GAIN = 20
-DEFAULT_EXPANDER_RATIO = 2
-DEFAULT_EXPANDER_ATTACK_TAU = 5e-3
-DEFAULT_EXPANDER_RELEASE_TAU = 70e-3
+DEFAULT_8MM_EXPANDER_GAIN = 6
+DEFAULT_8MM_EXPANDER_RATIO = 2 #           2:1 logarithmic
+DEFAULT_8MM_EXPANDER_ATTACK_TAU = 3e-3 #   3ms +- 0.6ms
+DEFAULT_8MM_EXPANDER_HOLD_TAU = 15e-3 #    15ms +- 3ms, gain is held until this time before releasing
+DEFAULT_8MM_EXPANDER_RELEASE_TAU = 40e-3 # 40ms +- 3ms
 
 # TAU_1         low end of shelf curve
 # TAU_2         high end of shelf curve
-# DB_PER_OCTAVE slope of the filter
 
-# High shelf filter filter for weighted input to expander
+# High shelf filter for weighted input to expander
 DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1 = 240e-6
-DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2 = 6.4e-5
-DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE = 6
-DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH = 2.58
+DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2 = 24e-6
+DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS = 20000
+DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
 
-DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1 = 5.5e-5
-DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 2.35e-5
-DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE = 6
-DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH = 2.4
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1 = 75e-6
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 27e-6
+DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS = 20000
+DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
 
 # Low shelf filter for deemphasis
-DEFAULT_VHS_DEEMPHASIS_TAU_1 = 230e-6
-DEFAULT_VHS_DEEMPHASIS_TAU_2 = 21.8e-6
-DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE = 6
-DEFAULT_VHS_DEEMPHASIS_BANDWIDTH = 2.9
+DEFAULT_VHS_DEEMPHASIS_TAU_1 = 56e-6 # 56us +- 20%
+DEFAULT_VHS_DEEMPHASIS_TAU_2 = 20e-6 # 20us +- 20%
 
-DEFAULT_8MM_DEEMPHASIS_TAU_1 = 1.1e-4
-DEFAULT_8MM_DEEMPHASIS_TAU_2 = 1.3e-5
-DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE = 6
-DEFAULT_8MM_DEEMPHASIS_BANDWIDTH = 2.4
+DEFAULT_8MM_DEEMPHASIS_TAU_1 = 75e-6
+DEFAULT_8MM_DEEMPHASIS_TAU_2 = 27e-6
+
+DEFAULT_VHS_NR_DEEMPHASIS_TAU_1 = 240e-6
+DEFAULT_VHS_NR_DEEMPHASIS_TAU_2 = 56e-6
+
+DEFAULT_8MM_NR_DEEMPHASIS_TAU_1 = 75e-6
+DEFAULT_8MM_NR_DEEMPHASIS_TAU_2 = 19e-6
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
@@ -549,11 +553,10 @@ def tau_as_freq(tau):
     return 1 / (2 * pi * tau)
 
 
-# Creates a low or high pass shelving filter from two time constants and a db/octave gain
+# Creates a low or high pass bilinear shelving filter from two time constants
 # Where:
 #   * T1 is the low shelf frequency
 #   * T2 is the high shelf frequency
-#   * db/octave is the slope of the shelf at db/octave
 #
 #   ------\ T1
 #          \
@@ -562,26 +565,28 @@ def tau_as_freq(tau):
 #          T2 \________
 #
 def build_shelf_filter(
-    direction, t1_low, t2_high, db_per_octave, bandwidth, audio_rate
+    direction,
+    tau1,
+    tau2,
+    fs
 ):
-    t1_f = tau_as_freq(t1_low)
-    t2_f = tau_as_freq(t2_high)
+    # set high point of filter to have no gain
+    b_1 = 1 / (tau1 / tau2)
 
-    # find center of the frequencies
-    center_f = sqrt(t2_f * t1_f)
-    # calculate how many octaves exist between the center and outer frequencies
-    # bandwidth = log(t2_f/center_f, 2)
+    if direction == "low":
+        b_analog = [tau2 ** 2 / tau1, b_1]
+        a_analog = [tau1, 1]
+        gain = b_analog[1] / a_analog[1]
+    else:
+        b_analog = [tau2, b_1]
+        a_analog = [tau2, 1]
+        gain = b_analog[0] / a_analog[0]
 
-    # calculate total gain between the two frequencies based db per octave
-    gain = log(t2_f / t1_f, 2) * db_per_octave
+    b_analog = [b / gain for b in b_analog]
 
-    b, a = gen_shelf(center_f, gain, direction, audio_rate, bandwidth=bandwidth)
+    b_digital, a_digital = bilinear(b_analog, a_analog, fs)
 
-    # scale the filter such that the top of the shelf is at 0db gain
-    scale_factor = 10 ** (-gain / 20)
-    b = [x * scale_factor for x in b]
-
-    return b, a
+    return b_digital, a_digital
 
 
 class SpectralNoiseReduction:
@@ -834,7 +839,6 @@ class DCBlocker:
 
     def process(self, audio):
         self.prev_x, self.prev_y = DCBlocker.dc_block(audio, self.prev_x, self.prev_y, self.R)
-        
 
 class Deemphasis:
     def __init__(
@@ -842,124 +846,154 @@ class Deemphasis:
         audio_rate,
         deemphasis_low_tau: float,
         deemphasis_high_tau: float,
-        deemphasis_db_per_octave: float,
-        deemphasis_bandwidth: float,
     ):
         self.audio_rate = audio_rate
 
         # deemphasis filter for output audio
         self.deemphasis_T1 = deemphasis_low_tau
         self.deemphasis_T2 = deemphasis_high_tau
-        self.deemphasis_db_per_octave = deemphasis_db_per_octave
-        self.deemphasis_bandwidth = deemphasis_bandwidth
 
         self.deemph_b, self.deemph_a = build_shelf_filter(
             "low",
             self.deemphasis_T1,
             self.deemphasis_T2,
-            self.deemphasis_db_per_octave,
-            self.deemphasis_bandwidth,
             self.audio_rate,
         )
-
-        self.DeemphasisLowpass = FiltersClass(np.array(self.deemph_b), np.array(self.deemph_a))
+        self.zi_deemph_x = 0.0
+        self.zi_deemph_y = 0.0
 
     def get_response(self):
         # compute frequency response
-        w, h_total = freqz(self.deemph_b, self.deemph_a, worN=4096, fs=self.audio_rate)
-    
-        magnitude_db = 20 * np.log10(np.abs(h_total))
+        w, h_deemph = freqz(self.deemph_b, self.deemph_a, worN=4096, fs=self.audio_rate)
+
+        magnitude_db = 20 * np.log10(np.abs(h_deemph))
 
         return w, magnitude_db
-    
+
     @staticmethod
     @njit(
         [
             (
-                NumbaAudioArray,
-                NumbaAudioArray,
+                numba.types.Array(numba.types.float32, 1, "C"),
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
+            ),
+            (
+                numba.types.Array(numba.types.float64, 1, "C"),
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
+                numba.types.float64,
             )
         ],
         cache=True,
         fastmath=True,
         nogil=True,
     )
-    def align_audio(audio_in, audio_out):
-        audio_end = len(audio_out)
-        audio_start = audio_end - len(audio_in)
-        for i in range(0, audio_start):
-            audio_out[i] = 0
+    def lfilt_inplace(x, b0, b1, a1, zi_x, zi_y):
+        """
+        In-place first-order IIR filter (lfilter equivalent).
+    
+        Implements:
+            y[n] = b0*x[n] + b1*x[n-1] - a1*y[n-1]
+        """
 
-        for i in range(audio_start, audio_end):
-            audio_out[i] = audio_in[i-audio_start]
+        for i in range(x.shape[0]):
+            xi = x[i]
+            yi = b0 * xi + b1 * zi_x - a1 * zi_y
+    
+            x[i] = yi
+    
+            zi_x = xi
+            zi_y = yi
+    
+        return zi_x, zi_y
 
     def process(self, audio_out):
-        audio_filtered = self.DeemphasisLowpass.lfilt(audio_out)
-        Deemphasis.align_audio(audio_filtered, audio_out)
+        self.zi_deemph_x, self.zi_deemph_y = Deemphasis.lfilt_inplace(
+            audio_out,
+            self.deemph_b[0],
+            self.deemph_b[1],
+            self.deemph_a[1],
+            self.zi_deemph_x,
+            self.zi_deemph_y
+        )
 
+def simple_lowpass(fs, tau):
+    b_analog = [1]
+    a_analog = [tau, 1]
+
+    b_digital, a_digital = bilinear(b_analog, a_analog, fs)
+    return b_digital, a_digital
 
 class Expander:
     def __init__(
         self,
         audio_rate,
-        gain: float = DEFAULT_EXPANDER_GAIN,
-        ratio: float = DEFAULT_EXPANDER_RATIO,
-        attack_tau: float = DEFAULT_EXPANDER_ATTACK_TAU,
-        release_tau: float = DEFAULT_EXPANDER_RELEASE_TAU,
-        weighting_low_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
-        weighting_high_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
-        weighting_db_per_octave: float = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-        weighting_bandwidth: float = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+        gain: float,
+        ratio: float,
+        attack_tau: float,
+        hold_tau: float,
+        release_tau: float,
+        weighting_low_tau: float,
+        weighting_high_tau: float,
+        weighting_low_pass: float,
+        weighting_low_pass_transition: float
     ):
         self.audio_rate = audio_rate
         self.linear_to_db = 20 / log(10)
         self.db_to_linear = log(10) / 20
 
         # makeup gain to apply after expansion
-        self.gain = 10 ** (gain / 20)
+        self.gain = gain
         self.ratio = float(ratio)
-        self.atkCoeff = np.exp(-1.0 / (attack_tau * self.audio_rate))
-        self.relCoeff = np.exp(-1.0 / (release_tau * self.audio_rate))
+
+        error_db = 20
+        target_db = 2
+        #K = np.log(target_db / error_db)
+        #K = -np.log(9)
+        K = -1
+        self.atkCoeff = np.exp(K / (attack_tau * self.audio_rate))
+        self.relCoeff = np.exp(K / (release_tau * self.audio_rate))
+        self.hold_samples = round(hold_tau * self.audio_rate)
 
         self.env_db = -120.0
+        self.hold_state = 0
 
-        # this is set to avoid high frequency noise to interfere with the NR envelope tracking
-        self.Lo_cut = 19e3
-        self.Lo_transition = 10e3
-
-        self.locut_iirb, self.locut_iira = firdes_lowpass(
+        self.lowpass_iirb, self.lowpass_iira = firdes_lowpass(
             self.audio_rate,
-            self.Lo_cut,
-            self.Lo_transition,
+            min(weighting_low_pass, self.audio_rate / 2 - 1), # limit to nyquist
+            weighting_low_pass_transition,
         )
-
-        self.WeightedLowpass = FiltersClass(
-            np.array(self.locut_iirb), np.array(self.locut_iira), dtype=np.float32
+        self.WeightedLowcut = FiltersClass(
+            np.array(self.lowpass_iirb), np.array(self.lowpass_iira), dtype=np.float64
         )
 
         # weighted filter for envelope detector
         self.weighting_T1 = weighting_low_tau
         self.weighting_T2 = weighting_high_tau
-        self.weighting_db_per_octave = weighting_db_per_octave
-        self.weighting_bandwidth = weighting_bandwidth
-
         self.env_iirb, self.env_iira = build_shelf_filter(
             "high",
             self.weighting_T1,
             self.weighting_T2,
-            self.weighting_db_per_octave,
-            self.weighting_bandwidth,
             self.audio_rate,
         )
-
-        self.WeightedHighpass = FiltersClass(np.array(self.env_iirb), np.array(self.env_iira), dtype=np.float32)
+        self.zi_x = 0.0
+        self.zi_y = 0.0
 
     def get_response(self):
         # compute frequency response
-        w, h_low = freqz(self.locut_iirb, self.locut_iira, worN=4096, fs=self.audio_rate)
-        _, h_high = freqz(self.env_iirb, self.env_iira, worN=4096, fs=self.audio_rate)
+        _, h_low = freqz(self.lowpass_iirb, self.lowpass_iira, worN=4096, fs=self.audio_rate)
+        w, h_high = freqz(self.env_iirb, self.env_iira, worN=4096, fs=self.audio_rate)
     
-        h_total = h_low * h_high
+        h_total = (
+            h_low * 
+            h_high
+        )
     
         magnitude_db = 20 * np.log10(np.abs(h_total))
 
@@ -969,14 +1003,16 @@ class Expander:
     @njit(
         [(
             NumbaAudioArray,
-            NumbaAudioArray,
-            numba.types.float32,
-            numba.types.float32,
-            numba.types.float32,
-            numba.types.float32,
-            numba.types.float32,
-            numba.types.float32,
-            numba.types.float32
+            numba.types.Array(numba.types.float64, 1, "C"),
+            numba.types.float64,
+            numba.types.float64,
+            numba.types.float64,
+            numba.types.float64,
+            numba.types.float64,
+            numba.types.int32,
+            numba.types.int32,
+            numba.types.float64,
+            numba.types.float64
         )],
         cache=True,
         fastmath=True,
@@ -990,33 +1026,61 @@ class Expander:
         db_to_linear,
         atkCoeff,
         relCoeff,
+        hold_state,
+        hold_samples,
         gain,
-        ratio,
+        ratio
     ):
-        audio_len = audio.shape[0]
-        ratio_m1 = ratio - 1
+        n = audio.shape[0]
+        epsilon = np.finfo(np.float64).eps
+        one_minus_atkCoeff = 1 - atkCoeff
+        one_minus_relCoeff = 1 - relCoeff
 
-        for i in range(audio_len):
-            # envelope in db
-            sc_db = log(abs(side_chain[i]) + 1e-20) * linear_to_db
+        # calculate envelope and apply ratio for target db (can be vectorized)
+        for i in range(n):
+            # detect envelope for current sample
+            sc_db = log(max(abs(side_chain[i]), epsilon)) * linear_to_db + gain
+            
+            # apply ratio (target db)
+            side_chain[i] = sc_db * ratio - sc_db
 
-            coeff = relCoeff + (atkCoeff - relCoeff) * (sc_db > env_db)
-            env_db = coeff * env_db + (1.0 - coeff) * sc_db
+        # apply attack / release to target db (must be done as scalar, since envelope and hold are stateful)
+        for i in range(n):
+            target_gain_db = side_chain[i]
 
-            gain_db = ratio_m1 * env_db
+            is_release = env_db > target_gain_db
+            # apply attack / release
+            if is_release:
+                if hold_state > 0:
+                    hold_state -= 1
+                else:
+                    env_db = relCoeff * env_db + one_minus_relCoeff * target_gain_db
+            else:
+                hold_state = hold_samples
+                env_db = atkCoeff * env_db + one_minus_atkCoeff * target_gain_db
 
-            audio[i] *= exp(gain_db * db_to_linear) * gain
-    
-        return env_db
+            side_chain[i] = env_db
+
+        # apply expansion to audio (can be vectorized)
+        for i in range(n):
+            audio[i] *= exp(side_chain[i] * db_to_linear)
+
+        return env_db, hold_state
 
     def process(self, pre_in, audio_out):
-        # prevent high frequency noise from interfering with envelope detector
-        pre_in_low_pass = self.WeightedLowpass.filtfilt(pre_in)
+        side_chain = self.WeightedLowcut.lfilt(pre_in)
 
         # high pass weighted input to envelope detector
-        side_chain = self.WeightedHighpass.lfilt(pre_in_low_pass)
+        self.zi_x, self.zi_y = Deemphasis.lfilt_inplace(
+            side_chain,
+            self.env_iirb[0],
+            self.env_iirb[1],
+            self.env_iira[1],
+            self.zi_x,
+            self.zi_y
+        )
 
-        self.env_db = Expander.expand(
+        self.env_db, self.hold_state = Expander.expand(
             audio_out,
             side_chain,
             self.env_db,
@@ -1024,6 +1088,8 @@ class Expander:
             self.db_to_linear,
             self.atkCoeff,
             self.relCoeff,
+            self.hold_state,
+            self.hold_samples,
             self.gain,
             self.ratio
         )

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -43,44 +43,72 @@ from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray
 
 import matplotlib.pyplot as plt
 
+# TAU_1         low end of shelf curve
+# TAU_2         high end of shelf curve
+
+# *********************
+# VHS Filter Parameters
+# *********************
 DEFAULT_VHS_EXPANDER_GAIN = 30
+# IEC 60774-2 5.1: Noise Reduction
 DEFAULT_VHS_EXPANDER_RATIO = 2 #           2:1 logarithmic
 DEFAULT_VHS_EXPANDER_ATTACK_TAU = 10e-3 #  3ms to 10ms
-DEFAULT_VHS_EXPANDER_HOLD_TAU = 0
+DEFAULT_VHS_EXPANDER_HOLD_TAU = 0 #        None (only used for 8mm)
 DEFAULT_VHS_EXPANDER_RELEASE_TAU = 70e-3 # 70ms +-20%
 
+# IEC 60774-2 5.2: Pre-emphasis (filter parameters)
+# IEC 60774-2 Figure 2, 4: Pre-emphasis (location in block diagram)
+# for VHS, this deemphasis stage affects both the audio and weighted input to the expander
+DEFAULT_VHS_DEEMPHASIS_TAU_1 = 56e-6 # 56us +- 20%
+DEFAULT_VHS_DEEMPHASIS_TAU_2 = 20e-6 # 20us +- 20%
+
+# IEC 60774-2 Figure 5: Weighting
+DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1 = 240e-6
+DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2 = 24e-6
+
+# this low pass filter appears in Panasonic AN3664NFB HiFi signal processing chip, however it is not documented in IEC 60774-2
+# parameters are guessed
+# this may help to remove any high frequency noise interfering with the expander envelope
+DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS = 20000
+DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
+
+# IEC 60774-2 Figure 5: Noise Reduction Emphasis
+DEFAULT_VHS_NR_DEEMPHASIS_TAU_1 = 240e-6
+DEFAULT_VHS_NR_DEEMPHASIS_TAU_2 = 56e-6
+
+
+# *********************
+# 8mm (Video 8, Hi 8) Filter Parameters
+# *********************
 DEFAULT_8MM_EXPANDER_GAIN = 6
+
+# IEC 60843-1 6.5.1.1 Compression Ratio
 DEFAULT_8MM_EXPANDER_RATIO = 2 #           2:1 logarithmic
+
+# IEC 60843-1 6.5.1.2 Transient response
 DEFAULT_8MM_EXPANDER_ATTACK_TAU = 3e-3 #   3ms +- 0.6ms
 DEFAULT_8MM_EXPANDER_HOLD_TAU = 15e-3 #    15ms +- 3ms, gain is held until this time before releasing
 DEFAULT_8MM_EXPANDER_RELEASE_TAU = 40e-3 # 40ms +- 3ms
 
-# TAU_1         low end of shelf curve
-# TAU_2         high end of shelf curve
+# IEC 60843-1 6.5.1.5 Figure 34 Noise Reduction, System Configuration
+# IEC 60843-1 6.5.1.5 Figure 34, Emphasis 1
+DEFAULT_8MM_NR_DEEMPHASIS_TAU_1 = 75e-6
+DEFAULT_8MM_NR_DEEMPHASIS_TAU_2 = 19e-6
 
-# High shelf filter for weighted input to expander
-DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1 = 240e-6
-DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2 = 24e-6
-DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS = 20000
-DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
-
-DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1 = 75e-6
-DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 27e-6
-DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS = 20000
-DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
-
-# Low shelf filter for deemphasis
-DEFAULT_VHS_DEEMPHASIS_TAU_1 = 56e-6 # 56us +- 20%
-DEFAULT_VHS_DEEMPHASIS_TAU_2 = 20e-6 # 20us +- 20%
-
+# IEC 60843-1 6.5.1.5 Figure 34, Emphasis 2
 DEFAULT_8MM_DEEMPHASIS_TAU_1 = 75e-6
 DEFAULT_8MM_DEEMPHASIS_TAU_2 = 27e-6
 
-DEFAULT_VHS_NR_DEEMPHASIS_TAU_1 = 240e-6
-DEFAULT_VHS_NR_DEEMPHASIS_TAU_2 = 56e-6
+# IEC 60843-1 6.5.1.5 Figure 34, Weighting
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1 = 75e-6
+DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 27e-6
 
-DEFAULT_8MM_NR_DEEMPHASIS_TAU_1 = 75e-6
-DEFAULT_8MM_NR_DEEMPHASIS_TAU_2 = 19e-6
+# this low pass filter appears in Panasonic AN3664NFB HiFi signal processing chip, however it is not documented in IEC 60843-1
+# parameters are guessed
+# this may help to remove any high frequency noise interfering with the expander envelope
+DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS = 20000
+DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
+
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -149,8 +149,8 @@ class MainUIParameters:
 def decode_options_to_ui_parameters(decode_options):
     if decode_options["mode"] == "s":
         mode = "Stereo"
-    elif decode_options["mode"] == "mpx":
-        mode = "Stereo MPX"
+    elif decode_options["mode"] == "ms":
+        mode = "Stereo Mid/Side"
     elif decode_options["mode"] == "l":
         mode = "L"
     elif decode_options["mode"] == "r":
@@ -199,8 +199,8 @@ def decode_options_to_ui_parameters(decode_options):
 def ui_parameters_to_decode_options(values: MainUIParameters):
     if values.audio_mode == "Stereo":
         mode = "s"
-    elif values.audio_mode == "Stereo MPX":
-        mode = "mpx"
+    elif values.audio_mode == "Stereo Mid/Side":
+        mode = "ms"
     elif values.audio_mode == "L":
         mode = "l"
     elif values.audio_mode == "R":
@@ -668,11 +668,11 @@ class HifiUi(QMainWindow):
         normalize_layout.addWidget(self.normalize_checkbox)
         gain_section_layout.addLayout(normalize_layout, 1)
 
-        # Audio mode (mono L/mono R/stereo/stereo mpx)
+        # Audio mode (mono L/mono R/stereo/stereo ms)
         audio_mode_layout = QHBoxLayout()
         audio_mode_label = QLabel("Output Channel Mode")
         self.audio_mode_combo = QComboBox(self)
-        self.audio_mode_combo.addItems(["Stereo", "L", "R", "Stereo MPX", "Sum"])
+        self.audio_mode_combo.addItems(["Stereo", "L", "R", "Stereo Mid/Side", "Sum"])
         audio_mode_layout.addWidget(audio_mode_label)
         audio_mode_layout.addWidget(self.audio_mode_combo)
         advanced_format_options_frame.inner_layout.addLayout(audio_mode_layout)

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -58,27 +58,37 @@ except ImportError:
     from PyQt5 import QtGui, QtCore
 
 from vhsdecode.hifi.HiFiDecode import (
-    DEFAULT_EXPANDER_GAIN,
-    DEFAULT_EXPANDER_RATIO,
-    DEFAULT_EXPANDER_ATTACK_TAU,
-    DEFAULT_EXPANDER_RELEASE_TAU,
-    DEFAULT_VHS_DEEMPHASIS_TAU_1,
-    DEFAULT_VHS_DEEMPHASIS_TAU_2,
-    DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_VHS_DEEMPHASIS_BANDWIDTH,
+    DEFAULT_VHS_EXPANDER_GAIN,
+    DEFAULT_VHS_EXPANDER_RATIO,
+    DEFAULT_VHS_EXPANDER_ATTACK_TAU,
+    DEFAULT_VHS_EXPANDER_HOLD_TAU,
+    DEFAULT_VHS_EXPANDER_RELEASE_TAU,
+
+    DEFAULT_8MM_EXPANDER_GAIN,
+    DEFAULT_8MM_EXPANDER_RATIO,
+    DEFAULT_8MM_EXPANDER_ATTACK_TAU,
+    DEFAULT_8MM_EXPANDER_HOLD_TAU,
+    DEFAULT_8MM_EXPANDER_RELEASE_TAU,
+
     DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
     DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION,
 
-    DEFAULT_8MM_DEEMPHASIS_TAU_1,
-    DEFAULT_8MM_DEEMPHASIS_TAU_2,
-    DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_8MM_DEEMPHASIS_BANDWIDTH,
     DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1,
     DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION,
+
+    DEFAULT_VHS_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_VHS_NR_DEEMPHASIS_TAU_2,
+    DEFAULT_8MM_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_8MM_NR_DEEMPHASIS_TAU_2,
+
+    DEFAULT_VHS_DEEMPHASIS_TAU_1,
+    DEFAULT_VHS_DEEMPHASIS_TAU_2,
+    DEFAULT_8MM_DEEMPHASIS_TAU_1,
+    DEFAULT_8MM_DEEMPHASIS_TAU_2,
 
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
@@ -101,18 +111,19 @@ class MainUIParameters:
     def __init__(self):
         self.volume: float = 1.0
         self.normalize = False
-        self.expander_gain: float = DEFAULT_EXPANDER_GAIN
-        self.expander_ratio: float = DEFAULT_EXPANDER_RATIO
-        self.expander_attack_tau: float = DEFAULT_EXPANDER_ATTACK_TAU
-        self.expander_release_tau: float = DEFAULT_EXPANDER_RELEASE_TAU
+        self.expander_gain: float = DEFAULT_VHS_EXPANDER_GAIN
+        self.expander_ratio: float = DEFAULT_VHS_EXPANDER_RATIO
+        self.expander_attack_tau: float = DEFAULT_VHS_EXPANDER_ATTACK_TAU
+        self.expander_hold_tau: float = DEFAULT_VHS_EXPANDER_HOLD_TAU
+        self.expander_release_tau: float = DEFAULT_VHS_EXPANDER_RELEASE_TAU
         self.expander_weighting_low_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1
         self.expander_weighting_high_tau: float = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2
-        self.expander_weighting_db_per_octave: float = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE
-        self.expander_weighting_bandwidth: float = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH
+        self.expander_weighting_low_pass: float = DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS
+        self.expander_weighting_low_pass_transition: float = DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION
         self.deemphasis_low_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_1
         self.deemphasis_high_tau: float = DEFAULT_VHS_DEEMPHASIS_TAU_2
-        self.deemphasis_db_per_octave: float = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
-        self.deemphasis_bandwidth: float = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
+        self.nr_deemphasis_low_tau: float = DEFAULT_VHS_NR_DEEMPHASIS_TAU_1
+        self.nr_deemphasis_high_tau: float = DEFAULT_VHS_NR_DEEMPHASIS_TAU_2
         self.afe_vco_deviation = 0
         self.afe_left_carrier = 0
         self.afe_right_carrier = 0
@@ -136,6 +147,17 @@ class MainUIParameters:
 
 
 def decode_options_to_ui_parameters(decode_options):
+    if decode_options["mode"] == "s":
+        mode = "Stereo"
+    elif decode_options["mode"] == "mpx":
+        mode = "Stereo MPX"
+    elif decode_options["mode"] == "l":
+        mode = "L"
+    elif decode_options["mode"] == "r":
+        mode = "R"
+    elif decode_options["mode"] == "sum":
+        mode = "Sum"
+
     values = MainUIParameters()
     values.volume = decode_options["gain"]
     values.normalize = decode_options["normalize"]
@@ -144,15 +166,16 @@ def decode_options_to_ui_parameters(decode_options):
     values.expander_gain = decode_options["expander_gain"]
     values.expander_ratio = decode_options["expander_ratio"]
     values.expander_attack_tau = decode_options["expander_attack_tau"]
+    values.expander_hold_tau = decode_options["expander_hold_tau"]
     values.expander_release_tau = decode_options["expander_release_tau"]
     values.expander_weighting_low_tau = decode_options["expander_weighting_low_tau"]
     values.expander_weighting_high_tau = decode_options["expander_weighting_high_tau"]
-    values.expander_weighting_db_per_octave = decode_options["expander_weighting_db_per_octave"]
-    values.expander_weighting_bandwidth = decode_options["expander_weighting_bandwidth"]
+    values.expander_weighting_low_pass = decode_options["expander_weighting_low_pass"]
+    values.expander_weighting_low_pass_transition = decode_options["expander_weighting_low_pass_transition"]
     values.deemphasis_low_tau = decode_options["deemphasis_low_tau"]
     values.deemphasis_high_tau = decode_options["deemphasis_high_tau"]
-    values.deemphasis_db_per_octave = decode_options["deemphasis_db_per_octave"]
-    values.deemphasis_bandwidth = decode_options["deemphasis_bandwidth"]
+    values.nr_deemphasis_low_tau = decode_options["nr_deemphasis_low_tau"]
+    values.nr_deemphasis_high_tau = decode_options["nr_deemphasis_high_tau"]
     values.afe_vco_deviation = decode_options["afe_vco_deviation"]
     values.afe_left_carrier = decode_options["afe_left_carrier"]
     values.afe_right_carrier = decode_options["afe_right_carrier"]
@@ -162,7 +185,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.audio_sample_rate = decode_options["audio_rate"]
     values.standard = "PAL" if decode_options["standard"] == "p" else "NTSC"
     values.format = "VHS" if decode_options["format"] == "vhs" else "Video8/Hi8"
-    values.audio_mode = "Stereo"
+    values.audio_mode = mode
     values.resampler_quality = decode_options["resampler_quality"]
     values.demod_type = decode_options["demod_type"].capitalize()
     values.input_sample_rate = decode_options["input_rate"]
@@ -174,6 +197,17 @@ def decode_options_to_ui_parameters(decode_options):
 
 
 def ui_parameters_to_decode_options(values: MainUIParameters):
+    if values.audio_mode == "Stereo":
+        mode = "s"
+    elif values.audio_mode == "Stereo MPX":
+        mode = "mpx"
+    elif values.audio_mode == "L":
+        mode = "l"
+    elif values.audio_mode == "R":
+        mode = "r"
+    elif values.audio_mode == "Sum":
+        mode = "sum"
+
     decode_options = {
         "input_rate": float(values.input_sample_rate) * 1e6,
         "standard": "p" if values.standard == "PAL" else "n",
@@ -186,15 +220,16 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "expander_gain": values.expander_gain,
         "expander_ratio": values.expander_ratio,
         "expander_attack_tau": values.expander_attack_tau,
+        "expander_hold_tau": values.expander_hold_tau,
         "expander_release_tau": values.expander_release_tau,
         "expander_weighting_low_tau": values.expander_weighting_low_tau,
         "expander_weighting_high_tau": values.expander_weighting_high_tau,
-        "expander_weighting_db_per_octave": values.expander_weighting_db_per_octave,
-        "expander_weighting_bandwidth": values.expander_weighting_bandwidth,
+        "expander_weighting_low_pass": values.expander_weighting_low_pass,
+        "expander_weighting_low_pass_transition": values.expander_weighting_low_pass_transition,
         "deemphasis_low_tau": values.deemphasis_low_tau,
         "deemphasis_high_tau": values.deemphasis_high_tau,
-        "deemphasis_db_per_octave": values.deemphasis_db_per_octave,
-        "deemphasis_bandwidth": values.deemphasis_bandwidth,
+        "nr_deemphasis_low_tau": values.nr_deemphasis_low_tau,
+        "nr_deemphasis_high_tau": values.nr_deemphasis_high_tau,
         "afe_vco_deviation": values.afe_vco_deviation,
         "afe_left_carrier": values.afe_left_carrier,
         "afe_right_carrier": values.afe_right_carrier,
@@ -208,19 +243,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "resampler_quality": values.resampler_quality,
         "head_switching_interpolation": values.head_switching_interpolation,
         "muting": values.muting,
-        "mode": (
-            "s"
-            if values.audio_mode == "Stereo"
-            else (
-                "l"
-                if values.audio_mode == "L"
-                else (
-                    "r"
-                    if values.audio_mode == "R"
-                    else "mpx" if values.audio_mode == "Stereo MPX" else "sum"
-                )
-            )
-        ),
+        "mode": mode
     }
     return decode_options
 
@@ -689,19 +712,23 @@ class HifiUi(QMainWindow):
         expander_controls_frame.inner_layout.addWidget(self.enable_expander_checkbox)
         expander_controls_layout = QHBoxLayout()
         self.expander_gain_dial_control = DialControl(
-            self, "Gain (db)", QtGui.QDoubleValidator(), 1, 0, 30
+            self, "Gain (db)", QtGui.QDoubleValidator(), 1, 1, 60, width=2
         )
         expander_controls_layout.addWidget(self.expander_gain_dial_control)
         self.expander_ratio_dial_control = DialControl(
-            self, "Ratio", QtGui.QDoubleValidator(), 100, 1, 10
+            self, "Ratio", QtGui.QDoubleValidator(), 10, 1, 10, width=2
         )
         expander_controls_layout.addWidget(self.expander_ratio_dial_control)
         self.expander_attack_tau_dial_control = DialControl(
-            self, "Attack (𝜏)", QtGui.QDoubleValidator(), 10e3, 10e-4, 10e-3
+            self, "Attack (𝜏)", QtGui.QDoubleValidator(), 10e3, 10e-4, 10e-3, width=4
         )
         expander_controls_layout.addWidget(self.expander_attack_tau_dial_control)
+        self.expander_hold_tau_dial_control = DialControl(
+            self, "Hold (𝜏)", QtGui.QDoubleValidator(), 10e3, 10e-4, 10e-3, width=4
+        )
+        expander_controls_layout.addWidget(self.expander_hold_tau_dial_control)
         self.expander_release_tau_dial_control = DialControl(
-            self, "Release (𝜏)", QtGui.QDoubleValidator(), 10e2, 10e-3, 10e-2
+            self, "Release (𝜏)", QtGui.QDoubleValidator(), 10e2, 10e-3, 10e-2, width=4
         )
         expander_controls_layout.addWidget(self.expander_release_tau_dial_control)
         expander_controls_frame.inner_layout.addLayout(expander_controls_layout)
@@ -720,6 +747,7 @@ class HifiUi(QMainWindow):
             10e5,
             DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
             10e-4,
+            width=5
         )
         weighting_layout.addWidget(self.expander_weighting_low_tau_dial_control)
         self.expander_weighting_high_tau_dial_control = DialControl(
@@ -729,16 +757,17 @@ class HifiUi(QMainWindow):
             10e5,
             10e-7,
             DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
+            width=5
         )
         weighting_layout.addWidget(self.expander_weighting_high_tau_dial_control)
-        self.expander_weighting_db_per_octave_dial_control = DialControl(
-            self, "Slope (db/oct)", QtGui.QDoubleValidator(), 10, 0, 12
+        self.expander_weighting_low_pass_dial_control = DialControl(
+            self, "Low Pass (Hz)", QtGui.QDoubleValidator(), 1, 5000, 21000, 100, width=4
         )
-        weighting_layout.addWidget(self.expander_weighting_db_per_octave_dial_control)
-        self.expander_weighting_bandwidth_dial_control = DialControl(
-            self, "Bandwidth", QtGui.QDoubleValidator(), 50, 0, 12
+        weighting_layout.addWidget(self.expander_weighting_low_pass_dial_control)
+        self.expander_weighting_low_pass_transition_dial_control = DialControl(
+            self, "Low Pass Transition (Hz)", QtGui.QDoubleValidator(), 1, 5000, 100000, 100, width=5
         )
-        weighting_layout.addWidget(self.expander_weighting_bandwidth_dial_control)
+        weighting_layout.addWidget(self.expander_weighting_low_pass_transition_dial_control)
         expander_sideband_frame.inner_layout.addLayout(weighting_layout)
 
         show_plot_btn_weighting = QPushButton("Plot")
@@ -760,6 +789,7 @@ class HifiUi(QMainWindow):
             10e5,
             DEFAULT_VHS_DEEMPHASIS_TAU_2,
             10e-4,
+            width=5
         )
         deemphasis_layout.addWidget(self.deemphasis_low_tau_dial_control)
         self.deemphasis_high_tau_dial_control = DialControl(
@@ -769,16 +799,30 @@ class HifiUi(QMainWindow):
             10e5,
             10e-7,
             DEFAULT_VHS_DEEMPHASIS_TAU_1,
+            width=5
         )
         deemphasis_layout.addWidget(self.deemphasis_high_tau_dial_control)
-        self.deemphasis_db_per_octave_dial_control = DialControl(
-            self, "Slope (db/oct)", QtGui.QDoubleValidator(), 10, 0, 12
+
+        self.nr_deemphasis_low_tau_dial_control = DialControl(
+            self,
+            "NR Low Shelf (𝜏)",
+            QtGui.QDoubleValidator(),
+            10e5,
+            DEFAULT_VHS_NR_DEEMPHASIS_TAU_2,
+            10e-4,
+            width=5
         )
-        deemphasis_layout.addWidget(self.deemphasis_db_per_octave_dial_control)
-        self.deemphasis_bandwidth_dial_control = DialControl(
-            self, "Bandwidth", QtGui.QDoubleValidator(), 50, 0, 12
+        deemphasis_layout.addWidget(self.nr_deemphasis_low_tau_dial_control)
+        self.nr_deemphasis_high_tau_dial_control = DialControl(
+            self,
+            "NR High Shelf (𝜏)",
+            QtGui.QDoubleValidator(),
+            10e5,
+            10e-7,
+            DEFAULT_VHS_NR_DEEMPHASIS_TAU_1,
+            width=5
         )
-        deemphasis_layout.addWidget(self.deemphasis_bandwidth_dial_control)
+        deemphasis_layout.addWidget(self.nr_deemphasis_high_tau_dial_control)
 
         show_plot_btn_deemphasis = QPushButton("Plot")
         show_plot_btn_deemphasis.clicked.connect(self.show_plot)
@@ -798,17 +842,25 @@ class HifiUi(QMainWindow):
         self._plot_update_timer.setSingleShot(True)
         self._plot_update_timer.timeout.connect(self.weighting_deemphasis_plot.update_plot)
 
+        self.expander_gain_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_ratio_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_attack_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_hold_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_release_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_ratio_dial_control.valueChanged.connect(self.schedule_plot_update)
+
         self.expander_weighting_low_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
         self.expander_weighting_high_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
-        self.expander_weighting_db_per_octave_dial_control.valueChanged.connect(self.schedule_plot_update)
-        self.expander_weighting_bandwidth_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_weighting_low_pass_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.expander_weighting_low_pass_transition_dial_control.valueChanged.connect(self.schedule_plot_update)
 
         self.deemphasis_low_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
         self.deemphasis_high_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
-        self.deemphasis_db_per_octave_dial_control.valueChanged.connect(self.schedule_plot_update)
-        self.deemphasis_bandwidth_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.nr_deemphasis_low_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
+        self.nr_deemphasis_high_tau_dial_control.valueChanged.connect(self.schedule_plot_update)
 
         self.audio_mode_combo.currentIndexChanged.connect(self.schedule_plot_update)
+        self.sample_rate_combo.currentIndexChanged.connect(self.schedule_plot_update)
     
     def show_plot(self):
         geo = self.geometry()
@@ -839,6 +891,7 @@ class HifiUi(QMainWindow):
         self.expander_gain_dial_control.setValue(values.expander_gain)
         self.expander_ratio_dial_control.setValue(values.expander_ratio)
         self.expander_attack_tau_dial_control.setValue(values.expander_attack_tau)
+        self.expander_hold_tau_dial_control.setValue(values.expander_hold_tau)
         self.expander_release_tau_dial_control.setValue(values.expander_release_tau)
         self.expander_weighting_low_tau_dial_control.setValue(
             values.expander_weighting_low_tau
@@ -846,20 +899,16 @@ class HifiUi(QMainWindow):
         self.expander_weighting_high_tau_dial_control.setValue(
             values.expander_weighting_high_tau
         )
-        self.expander_weighting_db_per_octave_dial_control.setValue(
-            values.expander_weighting_db_per_octave
+        self.expander_weighting_low_pass_dial_control.setValue(
+            values.expander_weighting_low_pass
         )
-        self.expander_weighting_bandwidth_dial_control.setValue(
-            values.expander_weighting_bandwidth
+        self.expander_weighting_low_pass_transition_dial_control.setValue(
+            values.expander_weighting_low_pass_transition
         )
         self.deemphasis_low_tau_dial_control.setValue(values.deemphasis_low_tau)
         self.deemphasis_high_tau_dial_control.setValue(values.deemphasis_high_tau)
-        self.deemphasis_db_per_octave_dial_control.setValue(
-            values.deemphasis_db_per_octave
-        )
-        self.deemphasis_bandwidth_dial_control.setValue(
-            values.deemphasis_bandwidth
-        )
+        self.nr_deemphasis_low_tau_dial_control.setValue(values.nr_deemphasis_low_tau)
+        self.nr_deemphasis_high_tau_dial_control.setValue(values.nr_deemphasis_high_tau)
         self.spectral_nr_amount_dial_control.setValue(values.spectral_nr_amount)
         self.normalize_checkbox.setChecked(values.normalize)
         self.muting_checkbox.setChecked(values.muting)
@@ -924,6 +973,7 @@ class HifiUi(QMainWindow):
         values.expander_gain = self.expander_gain_dial_control.value()
         values.expander_ratio = self.expander_ratio_dial_control.value()
         values.expander_attack_tau = self.expander_attack_tau_dial_control.value()
+        values.expander_hold_tau = self.expander_hold_tau_dial_control.value()
         values.expander_release_tau = self.expander_release_tau_dial_control.value()
         values.expander_weighting_low_tau = (
             self.expander_weighting_low_tau_dial_control.value()
@@ -931,20 +981,16 @@ class HifiUi(QMainWindow):
         values.expander_weighting_high_tau = (
             self.expander_weighting_high_tau_dial_control.value()
         )
-        values.expander_weighting_db_per_octave = (
-            self.expander_weighting_db_per_octave_dial_control.value()
+        values.expander_weighting_low_pass = (
+            self.expander_weighting_low_pass_dial_control.value()
         )
-        values.expander_weighting_bandwidth = (
-            self.expander_weighting_bandwidth_dial_control.value()
+        values.expander_weighting_low_pass_transition = (
+            self.expander_weighting_low_pass_transition_dial_control.value()
         )
         values.deemphasis_low_tau = self.deemphasis_low_tau_dial_control.value()
         values.deemphasis_high_tau = self.deemphasis_high_tau_dial_control.value()
-        values.deemphasis_db_per_octave = (
-            self.deemphasis_db_per_octave_dial_control.value()
-        )
-        values.deemphasis_bandwidth = (
-            self.deemphasis_bandwidth_dial_control.value()
-        )
+        values.nr_deemphasis_low_tau = self.nr_deemphasis_low_tau_dial_control.value()
+        values.nr_deemphasis_high_tau = self.nr_deemphasis_high_tau_dial_control.value()
         values.afe_vco_deviation = self.afe_vco_deviation_spinbox.value()
         values.afe_left_carrier = self.afe_left_carrier_spinbox.value()
         values.afe_right_carrier = self.afe_right_carrier_spinbox.value()
@@ -994,21 +1040,31 @@ class HifiUi(QMainWindow):
         if format == "VHS":
             self.deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_1)
             self.deemphasis_high_tau_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_TAU_2)
-            self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE)
-            self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_VHS_DEEMPHASIS_BANDWIDTH)
+            self.nr_deemphasis_low_tau_dial_control.setValue(DEFAULT_VHS_NR_DEEMPHASIS_TAU_1)
+            self.nr_deemphasis_high_tau_dial_control.setValue(DEFAULT_VHS_NR_DEEMPHASIS_TAU_2)
+            self.expander_gain_dial_control.setValue(DEFAULT_VHS_EXPANDER_GAIN)
+            self.expander_ratio_dial_control.setValue(DEFAULT_VHS_EXPANDER_RATIO)
+            self.expander_attack_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_ATTACK_TAU)
+            self.expander_hold_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_HOLD_TAU)
+            self.expander_release_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_RELEASE_TAU)
             self.expander_weighting_low_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1)
             self.expander_weighting_high_tau_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2)
-            self.expander_weighting_db_per_octave_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE)
-            self.expander_weighting_bandwidth_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH)
+            self.expander_weighting_low_pass_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS)
+            self.expander_weighting_low_pass_transition_dial_control.setValue(DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION)
         else:
             self.deemphasis_low_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_1)
             self.deemphasis_high_tau_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_TAU_2)
-            self.deemphasis_db_per_octave_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE)
-            self.deemphasis_bandwidth_dial_control.setValue(DEFAULT_8MM_DEEMPHASIS_BANDWIDTH)
+            self.nr_deemphasis_low_tau_dial_control.setValue(DEFAULT_8MM_NR_DEEMPHASIS_TAU_1)
+            self.nr_deemphasis_high_tau_dial_control.setValue(DEFAULT_8MM_NR_DEEMPHASIS_TAU_2)
+            self.expander_gain_dial_control.setValue(DEFAULT_8MM_EXPANDER_GAIN)
+            self.expander_ratio_dial_control.setValue(DEFAULT_8MM_EXPANDER_RATIO)
+            self.expander_attack_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_ATTACK_TAU)
+            self.expander_hold_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_HOLD_TAU)
+            self.expander_release_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_RELEASE_TAU)
             self.expander_weighting_low_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1)
             self.expander_weighting_high_tau_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2)
-            self.expander_weighting_db_per_octave_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE)
-            self.expander_weighting_bandwidth_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH)
+            self.expander_weighting_low_pass_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS)
+            self.expander_weighting_low_pass_transition_dial_control.setValue(DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION)
 
     def on_standard_change(self):
         self.update_afe_values(
@@ -1238,6 +1294,7 @@ class DialControl(QWidget):
         min_value=0,
         max_value=1,
         scroll_step_size=1,
+        width=None
     ):
         super(QWidget, self).__init__()
         layout = QHBoxLayout(self)
@@ -1248,7 +1305,7 @@ class DialControl(QWidget):
         label = QLabel(label_text)
         self.scale = scale
 
-        textbox_character_width = max(int(math.log10(self.scale)) + 1, 3)
+        textbox_character_width = max(int(math.log10(self.scale)) + 1, 3) if width is None else width
         self.textbox = QLineEdit(main_window)
         self.textbox.setValidator(validator)
         metrics = QtGui.QFontMetrics(self.textbox.font())
@@ -1524,17 +1581,27 @@ class PlotWindow(QWidget):
             ui_values.audio_sample_rate,
             ui_values.deemphasis_low_tau,
             ui_values.deemphasis_high_tau,
-            ui_values.deemphasis_db_per_octave,
-            ui_values.deemphasis_bandwidth,
         )
         deemphasis_freqs, deemphasis_mag_db = deemphasis.get_response()
 
+        nr_deemphasis = Deemphasis(
+            ui_values.audio_sample_rate,
+            ui_values.nr_deemphasis_low_tau,
+            ui_values.nr_deemphasis_high_tau,
+        )
+        nr_deemphasis_freqs, nr_deemphasis_mag_db = nr_deemphasis.get_response()
+
         expander = Expander(
             ui_values.audio_sample_rate,
-            weighting_low_tau = ui_values.expander_weighting_low_tau,
-            weighting_high_tau = ui_values.expander_weighting_high_tau,
-            weighting_db_per_octave = ui_values.expander_weighting_db_per_octave,
-            weighting_bandwidth = ui_values.expander_weighting_bandwidth
+            ui_values.expander_gain,
+            ui_values.expander_ratio,
+            ui_values.expander_attack_tau,
+            ui_values.expander_hold_tau,
+            ui_values.expander_release_tau,
+            ui_values.expander_weighting_low_tau,
+            ui_values.expander_weighting_high_tau,
+            ui_values.expander_weighting_low_pass,
+            ui_values.expander_weighting_low_pass_transition,
         )
         expander_freqs, expander_mag_db = expander.get_response()
 
@@ -1548,13 +1615,20 @@ class PlotWindow(QWidget):
         )
         self.plot_response(
             "Deemphasis",
-            "blue",
+            "red",
             deemphasis_freqs,
             deemphasis_mag_db,
             ui_values.deemphasis_low_tau,
             ui_values.deemphasis_high_tau,
         )
-
+        self.plot_response(
+            "NR Deemphasis",
+            "blue",
+            nr_deemphasis_freqs,
+            nr_deemphasis_mag_db,
+            ui_values.nr_deemphasis_low_tau,
+            ui_values.nr_deemphasis_high_tau,
+        )
         self.ax.grid(True, which="both")
         self.ax.set_xlabel("Frequency [Hz]")
         self.ax.set_ylabel("Amplitude [dB]")

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -48,26 +48,38 @@ from vhsdecode.hifi.HiFiDecode import (
     DCBlocker,
     Expander,
     Deemphasis,
-    DEFAULT_EXPANDER_GAIN,
-    DEFAULT_EXPANDER_RATIO,
-    DEFAULT_EXPANDER_ATTACK_TAU,
-    DEFAULT_EXPANDER_RELEASE_TAU,
+    DEFAULT_VHS_EXPANDER_GAIN,
+    DEFAULT_VHS_EXPANDER_RATIO,
+    DEFAULT_VHS_EXPANDER_ATTACK_TAU,
+    DEFAULT_VHS_EXPANDER_HOLD_TAU,
+    DEFAULT_VHS_EXPANDER_RELEASE_TAU,
+
+    DEFAULT_8MM_EXPANDER_GAIN,
+    DEFAULT_8MM_EXPANDER_RATIO,
+    DEFAULT_8MM_EXPANDER_ATTACK_TAU,
+    DEFAULT_8MM_EXPANDER_HOLD_TAU,
+    DEFAULT_8MM_EXPANDER_RELEASE_TAU,
+
     DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1,
     DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS,
+    DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION,
+
     DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1,
     DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2,
-    DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE,
-    DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS,
+    DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION,
+
+    DEFAULT_VHS_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_VHS_NR_DEEMPHASIS_TAU_2,
+    DEFAULT_8MM_NR_DEEMPHASIS_TAU_1,
+    DEFAULT_8MM_NR_DEEMPHASIS_TAU_2,
+
     DEFAULT_VHS_DEEMPHASIS_TAU_1,
     DEFAULT_VHS_DEEMPHASIS_TAU_2,
-    DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_VHS_DEEMPHASIS_BANDWIDTH,
     DEFAULT_8MM_DEEMPHASIS_TAU_1,
     DEFAULT_8MM_DEEMPHASIS_TAU_2,
-    DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE,
-    DEFAULT_8MM_DEEMPHASIS_BANDWIDTH,
+
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
     DEFAULT_FINAL_AUDIO_RATE,
@@ -328,36 +340,35 @@ expander_options_group.add_argument(
     default="on",
     help="Set expander block on/off",
 )
-
 expander_options_group.add_argument(
     "--expander_gain",
     dest="expander_gain",
     type=float,
-    default=DEFAULT_EXPANDER_GAIN,
-    help=f"Sets the expander gain (default is {DEFAULT_EXPANDER_GAIN}). "
-    f"Range (0~30): Higher values increase output gain of the expander",
+    help=f"Sets the expander gain (defaults: [VHS: {DEFAULT_VHS_EXPANDER_GAIN}] [8mm: {DEFAULT_8MM_EXPANDER_GAIN}]).",
 )
 expander_options_group.add_argument(
     "--expander_ratio",
     dest="expander_ratio",
     type=float,
-    default=DEFAULT_EXPANDER_RATIO,
-    help=f"Sets the ratio (default is {DEFAULT_EXPANDER_RATIO}). "
-    f"Range (1~2): Higher values increase the ratio of the expander",
+    help=f"Sets the expander ratio (defaults: [VHS: {DEFAULT_VHS_EXPANDER_RATIO}] [8mm: {DEFAULT_8MM_EXPANDER_RATIO}]).",
 )
 expander_options_group.add_argument(
     "--expander_attack_tau",
     dest="expander_attack_tau",
     type=float,
-    default=DEFAULT_EXPANDER_ATTACK_TAU,
-    help=f"Sets the expander attack speed in tau (default is {DEFAULT_EXPANDER_ATTACK_TAU}).",
+    help=f"Sets the expander attack speed in seconds (defaults: [VHS: {DEFAULT_VHS_EXPANDER_ATTACK_TAU}] [8mm: {DEFAULT_8MM_EXPANDER_ATTACK_TAU}]).",
+)
+expander_options_group.add_argument(
+    "--expander_hold_tau",
+    dest="expander_hold_tau",
+    type=float,
+    help=f"Sets the expander hold time in seconds (defaults: [VHS: {DEFAULT_VHS_EXPANDER_HOLD_TAU}] [8mm: {DEFAULT_8MM_EXPANDER_HOLD_TAU}]).",
 )
 expander_options_group.add_argument(
     "--expander_release_tau",
     dest="expander_release_tau",
     type=float,
-    default=DEFAULT_EXPANDER_RELEASE_TAU,
-    help=f"Sets the expander release speed in tau (default is {DEFAULT_EXPANDER_RELEASE_TAU}).",
+    help=f"Sets the expander release speed in seconds (defaults: [VHS: {DEFAULT_VHS_EXPANDER_RELEASE_TAU}] [8mm: {DEFAULT_8MM_EXPANDER_RELEASE_TAU}]).",
 )
 expander_options_group.add_argument(
     "--expander_weighting_low_tau",
@@ -372,16 +383,16 @@ expander_options_group.add_argument(
     help=f"Sets the expander weighting high-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2}]).",
 )
 expander_options_group.add_argument(
-    "--expander_weighting_db_per_octave",
-    dest="expander_weighting_db_per_octave",
+    "--expander_weighting_low_pass",
+    dest="expander_weighting_low_pass",
     type=float,
-    help=f"Sets the expander weighting high-pass shelf filter cutoff rate (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE}]).",
+    help=f"Sets the expander weighting low-pass filter cutoff frequency in Hz (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS}]).",
 )
 expander_options_group.add_argument(
-    "--expander_weighting_bandwidth",
-    dest="expander_weighting_bandwidth",
+    "--expander_weighting_low_pass_transition",
+    dest="expander_weighting_low_pass_transition",
     type=float,
-    help=f"Sets the expander weighting high-pass shelf filter bandwidth (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH}]).",
+    help=f"Sets the expander weighting low-pass filter cutoff rate in Hz (defaults: [VHS: {DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION}] [8mm: {DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION}]).",
 )
 
 deemphasis_options_group = parser.add_argument_group(
@@ -407,16 +418,16 @@ deemphasis_options_group.add_argument(
     help=f"Sets the deemphasis low-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_TAU_2}] [8mm: {DEFAULT_8MM_DEEMPHASIS_TAU_2}])",
 )
 deemphasis_options_group.add_argument(
-    "--deemphasis_db_per_octave",
-    dest="deemphasis_db_per_octave",
+    "--nr_deemphasis_low_tau",
+    dest="nr_deemphasis_low_tau",
     type=float,
-    help=f"Sets the deemphasis low-pass shelf filter cutoff rate (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE}] [8mm: {DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE}])",
+    help=f"Sets the noise reduction deemphasis low-pass shelf filter low point in tau (defaults: [VHS: {DEFAULT_VHS_NR_DEEMPHASIS_TAU_1}] [8mm: {DEFAULT_8MM_NR_DEEMPHASIS_TAU_1}])",
 )
 deemphasis_options_group.add_argument(
-    "--deemphasis_bandwidth",
-    dest="deemphasis_bandwidth",
+    "--nr_deemphasis_high_tau",
+    dest="nr_deemphasis_high_tau",
     type=float,
-    help=f"Sets the deemphasis low-pass shelf filter bandwidth (defaults: [VHS: {DEFAULT_VHS_DEEMPHASIS_BANDWIDTH}] [8mm: {DEFAULT_8MM_DEEMPHASIS_BANDWIDTH}])",
+    help=f"Sets the noise reduction deemphasis low-pass shelf filter high point in tau (defaults: [VHS: {DEFAULT_VHS_NR_DEEMPHASIS_TAU_2}] [8mm: {DEFAULT_8MM_NR_DEEMPHASIS_TAU_2}])",
 )
 
 def test_ld_tools(ld_tool):
@@ -907,6 +918,7 @@ class PostProcessor:
         self.enable_expander = decode_options["enable_expander"]
         self.enable_deemphasis = decode_options["enable_deemphasis"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
+        self.format = decode_options["format"]
         self.peak_gain = peak_gain
 
         # create processes and wire up queues
@@ -1013,28 +1025,31 @@ class PostProcessor:
         atexit.register(self.spectral_nr_worker_r.terminate)
         atexit.register(self.spectral_nr_worker_r.join)
 
+        expander_worker = PostProcessor.expander_8mm_worker if self.format == "8mm" else PostProcessor.expander_vhs_worker
+
         expander_worker_l_out_rx, expander_worker_l_out_tx = Pipe(duplex=False)
         self.expander_worker_l = Process(
-            target=PostProcessor.expander_worker,
+            target=expander_worker,
             name="hifi_expander_l",
             args=(
                 spectral_nr_worker_l_rx,
                 expander_worker_l_out_tx,
-                self.enable_expander,
                 self.enable_deemphasis,
+                self.enable_expander,
                 self.final_audio_rate,
+                decode_options["deemphasis_low_tau"],
+                decode_options["deemphasis_high_tau"],
+                decode_options["nr_deemphasis_low_tau"],
+                decode_options["nr_deemphasis_high_tau"],
                 decode_options["expander_gain"],
                 decode_options["expander_ratio"],
                 decode_options["expander_attack_tau"],
+                decode_options["expander_hold_tau"],
                 decode_options["expander_release_tau"],
                 decode_options["expander_weighting_low_tau"],
                 decode_options["expander_weighting_high_tau"],
-                decode_options["expander_weighting_db_per_octave"],
-                decode_options["expander_weighting_bandwidth"],
-                decode_options["deemphasis_low_tau"],
-                decode_options["deemphasis_high_tau"],
-                decode_options["deemphasis_db_per_octave"],
-                decode_options["deemphasis_bandwidth"],
+                decode_options["expander_weighting_low_pass"],
+                decode_options["expander_weighting_low_pass_transition"]
             ),
         )
         self.expander_worker_l.start()
@@ -1043,26 +1058,27 @@ class PostProcessor:
 
         expander_worker_r_out_rx, expander_worker_r_out_tx = Pipe(duplex=False)
         self.expander_worker_r = Process(
-            target=PostProcessor.expander_worker,
+            target=expander_worker,
             name="hifi_expander_r",
             args=(
                 spectral_nr_worker_r_rx,
                 expander_worker_r_out_tx,
-                self.enable_expander,
                 self.enable_deemphasis,
+                self.enable_expander,
                 self.final_audio_rate,
+                decode_options["deemphasis_low_tau"],
+                decode_options["deemphasis_high_tau"],
+                decode_options["nr_deemphasis_low_tau"],
+                decode_options["nr_deemphasis_high_tau"],
                 decode_options["expander_gain"],
                 decode_options["expander_ratio"],
                 decode_options["expander_attack_tau"],
+                decode_options["expander_hold_tau"],
                 decode_options["expander_release_tau"],
                 decode_options["expander_weighting_low_tau"],
                 decode_options["expander_weighting_high_tau"],
-                decode_options["expander_weighting_db_per_octave"],
-                decode_options["expander_weighting_bandwidth"],
-                decode_options["deemphasis_low_tau"],
-                decode_options["deemphasis_high_tau"],
-                decode_options["deemphasis_db_per_octave"],
-                decode_options["deemphasis_bandwidth"],
+                decode_options["expander_weighting_low_pass"],
+                decode_options["expander_weighting_low_pass_transition"]
             ),
         )
         self.expander_worker_r.start()
@@ -1171,44 +1187,53 @@ class PostProcessor:
             out_conn.send((decoder_state, channel_num))
 
     @staticmethod
-    def expander_worker(
+    def expander_vhs_worker(
         in_conn,
         out_conn,
-        enable_expander,
         enable_deemphasis,
+        enable_expander,
         final_audio_rate,
+        deemphasis_low_tau,
+        deemphasis_high_tau,
+        nr_deemphasis_low_tau,
+        nr_deemphasis_high_tau,
         expander_gain,
         expander_ratio,
         expander_attack_tau,
+        expander_hold_tau,
         expander_release_tau,
         expander_weighting_low_tau,
         expander_weighting_high_tau,
-        expander_weighting_db_per_octave,
-        expander_weighting_bandwidth,
-        deemphasis_low_tau,
-        deemphasis_high_tau,
-        deemphasis_db_per_octave,
-        deemphasis_bandwidth
+        expander_weighting_low_pass,
+        expander_weighting_low_pass_transition,
     ):
         setproctitle(current_process().name)
-        deemphasis = Deemphasis(
+        deemphasis_pre_1 = Deemphasis(
             final_audio_rate,
             deemphasis_low_tau,
             deemphasis_high_tau,
-            deemphasis_db_per_octave,
-            deemphasis_bandwidth
         )
-
+        deemphasis_pre_2 = Deemphasis(
+            final_audio_rate,
+            deemphasis_low_tau,
+            deemphasis_high_tau,
+        )
+        nr_deemphasis = Deemphasis(
+            final_audio_rate,
+            nr_deemphasis_low_tau,
+            nr_deemphasis_high_tau,
+        )
         expander = Expander(
             final_audio_rate,
             expander_gain,
             expander_ratio,
             expander_attack_tau,
+            expander_hold_tau,
             expander_release_tau,
             expander_weighting_low_tau,
             expander_weighting_high_tau,
-            expander_weighting_db_per_octave,
-            expander_weighting_bandwidth
+            expander_weighting_low_pass,
+            expander_weighting_low_pass_transition,
         )
 
         while True:
@@ -1230,13 +1255,101 @@ class PostProcessor:
                 post = buffer.get_post_right()
 
             if enable_deemphasis:
-                deemphasis.process(post)
+                # first deemphasis stage happens before the noise reduction block
+                # IEC 60774-2 Figure 2, pg.15 (pre-emphasis parameters)
+                # IEC 60774-2 Figure 4, pg.17 (pre-emphasis location)
+                deemphasis_pre_1.process(pre)
+                deemphasis_pre_2.process(post)
+
+                # second deemphasis stage only happens on the audio (not the weighted input)
+                # IEC 60774-2 Figure 5, pg.19 (noise reduction layout)
+                nr_deemphasis.process(post)
 
             if enable_expander:
                 if decoder_state.block_num == 0:
                     # prime the expander's gain if this is the first block
                     expander.process(pre, np.copy(post))
                 expander.process(pre, post)
+
+            buffer.close()
+            out_conn.send(decoder_state)
+
+    @staticmethod
+    def expander_8mm_worker(
+        in_conn,
+        out_conn,
+        enable_deemphasis,
+        enable_expander,
+        final_audio_rate,
+        deemphasis_low_tau,
+        deemphasis_high_tau,
+        nr_deemphasis_low_tau,
+        nr_deemphasis_high_tau,
+        expander_gain,
+        expander_ratio,
+        expander_attack_tau,
+        expander_hold_tau,
+        expander_release_tau,
+        expander_weighting_low_tau,
+        expander_weighting_high_tau,
+        expander_weighting_low_pass,
+        expander_weighting_low_pass_transition,
+    ):
+        setproctitle(current_process().name)
+        deemphasis_2 = Deemphasis(
+            final_audio_rate,
+            deemphasis_low_tau,
+            deemphasis_high_tau,
+        )
+        deemphasis_1 = Deemphasis(
+            final_audio_rate,
+            nr_deemphasis_low_tau,
+            nr_deemphasis_high_tau,
+        )
+        expander = Expander(
+            final_audio_rate,
+            expander_gain,
+            expander_ratio,
+            expander_attack_tau,
+            expander_hold_tau,
+            expander_release_tau,
+            expander_weighting_low_tau,
+            expander_weighting_high_tau,
+            expander_weighting_low_pass,
+            expander_weighting_low_pass_transition,
+        )
+
+        while True:
+            while True:
+                try:
+                    decoder_state, channel_num = in_conn.recv()
+                    break
+                except InterruptedError:
+                    pass
+                except EOFError:
+                    return
+
+            buffer = PostProcessorSharedMemory(decoder_state)
+            if channel_num == 0:
+                pre = buffer.get_pre_left()
+                post = buffer.get_post_left()
+            else:
+                pre = buffer.get_pre_right()
+                post = buffer.get_post_right()
+
+            # IEC 60843-1-1993 Figure 34, pg.101
+            if enable_deemphasis:
+                deemphasis_2.process(post)
+
+            if enable_expander:
+                if decoder_state.block_num == 0:
+                    # prime the expander's gain if this is the first block
+                    expander.process(pre, np.copy(post))
+                expander.process(pre, post)
+
+            if enable_deemphasis:
+                # reverse noise reduction pre-emphasis
+                deemphasis_1.process(post)
 
             buffer.close()
             out_conn.send(decoder_state)
@@ -2029,29 +2142,41 @@ def main() -> int:
         resampler_quality = DEFAULT_RESAMPLER_QUALITY
 
     if args.format_8mm:
-        print("using 8mm")
         tape_format = "8mm"
+        default_expander_gain = DEFAULT_8MM_EXPANDER_GAIN
+        default_expander_ratio = DEFAULT_8MM_EXPANDER_RATIO
+        default_expander_attack_tau = DEFAULT_8MM_EXPANDER_ATTACK_TAU
+        default_expander_hold_tau = DEFAULT_8MM_EXPANDER_HOLD_TAU
+        default_expander_release_tau = DEFAULT_8MM_EXPANDER_RELEASE_TAU
+
         default_deemphasis_low_tau = DEFAULT_8MM_DEEMPHASIS_TAU_1
         default_deemphasis_high_tau = DEFAULT_8MM_DEEMPHASIS_TAU_2
-        default_deemphasis_db_per_octave = DEFAULT_8MM_DEEMPHASIS_DB_PER_OCTAVE
-        default_deemphasis_bandwidth = DEFAULT_8MM_DEEMPHASIS_BANDWIDTH
+
+        default_nr_deemphasis_low_tau = DEFAULT_8MM_NR_DEEMPHASIS_TAU_1
+        default_nr_deemphasis_high_tau = DEFAULT_8MM_NR_DEEMPHASIS_TAU_2
 
         default_expander_weighting_low_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_1
         default_expander_weighting_high_tau = DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2
-        default_expander_weighting_db_per_octave = DEFAULT_8MM_EXPANDER_WEIGHTING_DB_PER_OCTAVE
-        default_expander_weighting_bandwidth = DEFAULT_8MM_EXPANDER_WEIGHTING_BANDWIDTH
+        default_expander_weighting_low_pass = DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS
+        default_expander_weighting_low_pass_transition = DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION
     else:
-        print("using vhs")
         tape_format = "vhs"
+        default_expander_gain = DEFAULT_VHS_EXPANDER_GAIN
+        default_expander_ratio = DEFAULT_VHS_EXPANDER_RATIO
+        default_expander_attack_tau = DEFAULT_VHS_EXPANDER_ATTACK_TAU
+        default_expander_hold_tau = DEFAULT_VHS_EXPANDER_HOLD_TAU
+        default_expander_release_tau = DEFAULT_VHS_EXPANDER_RELEASE_TAU
+
         default_deemphasis_low_tau = DEFAULT_VHS_DEEMPHASIS_TAU_1
         default_deemphasis_high_tau = DEFAULT_VHS_DEEMPHASIS_TAU_2
-        default_deemphasis_db_per_octave = DEFAULT_VHS_DEEMPHASIS_DB_PER_OCTAVE
-        default_deemphasis_bandwidth = DEFAULT_VHS_DEEMPHASIS_BANDWIDTH
+
+        default_nr_deemphasis_low_tau = DEFAULT_VHS_NR_DEEMPHASIS_TAU_1
+        default_nr_deemphasis_high_tau = DEFAULT_VHS_NR_DEEMPHASIS_TAU_2
 
         default_expander_weighting_low_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_1
         default_expander_weighting_high_tau = DEFAULT_VHS_EXPANDER_WEIGHTING_TAU_2
-        default_expander_weighting_db_per_octave = DEFAULT_VHS_EXPANDER_WEIGHTING_DB_PER_OCTAVE
-        default_expander_weighting_bandwidth = DEFAULT_VHS_EXPANDER_WEIGHTING_BANDWIDTH
+        default_expander_weighting_low_pass = DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS
+        default_expander_weighting_low_pass_transition = DEFAULT_VHS_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION
 
     decode_options = {
         "input_rate": sample_freq * 1e6,
@@ -2072,18 +2197,19 @@ def main() -> int:
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,
         "bias_guess": args.bias_guess,
         "normalize": args.normalize,
-        "expander_gain": args.expander_gain,
-        "expander_ratio": args.expander_ratio,
-        "expander_attack_tau": args.expander_attack_tau,
-        "expander_release_tau": args.expander_release_tau,
+        "expander_gain": args.expander_gain or default_expander_gain,
+        "expander_ratio": args.expander_ratio or default_expander_ratio,
+        "expander_attack_tau": args.expander_attack_tau or default_expander_attack_tau,
+        "expander_hold_tau": args.expander_hold_tau or default_expander_hold_tau,
+        "expander_release_tau": args.expander_release_tau or default_expander_release_tau,
         "expander_weighting_low_tau": args.expander_weighting_low_tau or default_expander_weighting_low_tau,
         "expander_weighting_high_tau": args.expander_weighting_high_tau or default_expander_weighting_high_tau,
-        "expander_weighting_db_per_octave": args.expander_weighting_db_per_octave or default_expander_weighting_db_per_octave,
-        "expander_weighting_bandwidth": args.expander_weighting_bandwidth or default_expander_weighting_bandwidth,
+        "expander_weighting_low_pass": args.expander_weighting_low_pass or default_expander_weighting_low_pass,
+        "expander_weighting_low_pass_transition": args.expander_weighting_low_pass_transition or default_expander_weighting_low_pass_transition,
+        "nr_deemphasis_low_tau": args.nr_deemphasis_low_tau or default_nr_deemphasis_low_tau,
+        "nr_deemphasis_high_tau": args.nr_deemphasis_high_tau or default_nr_deemphasis_high_tau,
         "deemphasis_low_tau": args.deemphasis_low_tau or default_deemphasis_low_tau,
         "deemphasis_high_tau": args.deemphasis_high_tau or default_deemphasis_high_tau,
-        "deemphasis_db_per_octave": args.deemphasis_db_per_octave or default_deemphasis_db_per_octave,
-        "deemphasis_bandwidth": args.deemphasis_bandwidth or default_deemphasis_bandwidth,
         "grc": args.GRC,
         "audio_rate": args.rate if not args.preview else 44100,
         "gain": args.gain,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -279,9 +279,7 @@ audio_processing_options_group.add_argument(
     dest="mode",
     type=str,
     help=(
-        "Audio mode (s: stereo, mpx: stereo with mpx, l: left channel, r: right channel, sum: mono sum) - "
-        "defaults to s other than on 8mm which defaults to mpx."
-        " 8mm mono is not auto detected currently so has to be manually specified as l."
+        "Audio mode (s: stereo, ms: stereo mid/side, l: left mono, r: right mono, sum: left+right sum) (defaults: [VHS: s] [8mm: ms])."
     ),
 )
 audio_processing_options_group.add_argument(
@@ -2128,7 +2126,7 @@ def main() -> int:
 
     # 8mm AFM uses a mono channel, or L-R/L+R rather than L/R channels
     # The spec defines a dual audio mode but not sure if it was ever used.
-    default_mode = "s" if not args.format_8mm else "mpx"
+    default_mode = "s" if not args.format_8mm else "ms"
 
     real_mode = default_mode if not args.mode else args.mode
 

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1740,7 +1740,12 @@ async def decode_parallel(
         buffer = DecoderSharedMemory(decoder_state)
         # read input data into the shared memory buffer
         block_in = buffer.get_block_in()
-        frames_read = f.buffer_read_into(block_in, "int16")
+        try:
+            frames_read = f.buffer_read_into(block_in, "int16")
+        except sf.LibsndfileError as e:
+            print("Error decoding input rf:", e)
+            print("Stopping decode...")
+            frames_read = 0
         
         decoder_state.block_frames_read = frames_read
         decoder_state.is_last_block = frames_read < len(block_in) or exit_requested or stop_requested.value


### PR DESCRIPTION
* Fix multiple issues with the deemphasis, weighting filters, and the expander section.
* Rename `--audio_mode` `mpx` to `ms` (i.e. mid/side stereo encoding used by 8mm)
* Stop decoding gracefully if soundfile encounters an error decoding the input rf file.