### PR TITLE
hifi-decode: use other channel as dropout compensation data when muting

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -45,12 +45,16 @@ import matplotlib.pyplot as plt
 
 AUDIO_MODE_STEREO = "s"
 AUDIO_MODE_STEREO_MS = "ms"
+AUDIO_MODE_DUAL_MONO = "d"
+AUDIO_MODE_DUAL_MONO_MS = "dms"
 AUDIO_MODE_MONO_L = "l"
 AUDIO_MODE_MONO_R = "r"
 AUDIO_MODE_MONO_SUM = "sum"
 
 UI_STEREO = "Stereo (L, R)"
 UI_STEREO_MS = "Stereo (L+R, L-R)"
+UI_DUAL_MONO = "Dual Mono (L) (R)"
+UI_DUAL_MONO_MS = "Dual Mono (L+R) (L-R)"
 UI_MONO_L = "Mono (L)"
 UI_MONO_R = "Mono (R)"
 UI_MONO_SUM = "Mono Sum (L+R)"
@@ -58,6 +62,8 @@ UI_MONO_SUM = "Mono Sum (L+R)"
 audio_mode_to_ui = {
     AUDIO_MODE_STEREO: UI_STEREO,
     AUDIO_MODE_STEREO_MS: UI_STEREO_MS,
+    AUDIO_MODE_DUAL_MONO: UI_DUAL_MONO,
+    AUDIO_MODE_DUAL_MONO_MS: UI_DUAL_MONO_MS,
     AUDIO_MODE_MONO_L: UI_MONO_L,
     AUDIO_MODE_MONO_R: UI_MONO_R,
     AUDIO_MODE_MONO_SUM: UI_MONO_SUM,
@@ -66,6 +72,8 @@ audio_mode_to_ui = {
 ui_to_audio_mode = {
     UI_STEREO: AUDIO_MODE_STEREO,
     UI_STEREO_MS: AUDIO_MODE_STEREO_MS,
+    UI_DUAL_MONO: AUDIO_MODE_DUAL_MONO,
+    UI_DUAL_MONO_MS: AUDIO_MODE_DUAL_MONO_MS,
     UI_MONO_L: AUDIO_MODE_MONO_L,
     UI_MONO_R: AUDIO_MODE_MONO_R,
     UI_MONO_SUM: AUDIO_MODE_MONO_SUM,
@@ -2158,6 +2166,11 @@ class HiFiDecode:
 
     @staticmethod
     def mute(audioL: np.array, audioR: np.array, audio_process_params: HiFiAudioParams) -> np.array:
+        dual_mono = (
+            audio_process_params.decode_mode == AUDIO_MODE_DUAL_MONO or
+            audio_process_params.decode_mode == AUDIO_MODE_DUAL_MONO_MS
+        )
+
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
             mute_point_boundaries_l = HiFiDecode._detect_dropouts(audioL, audio_process_params)
         else:
@@ -2171,11 +2184,22 @@ class HiFiDecode:
             mute_point_boundaries_r = [(0, len(audioL))]
 
         # check each other channel for any data that can be used as dropout compensation
-        if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
-            mute_points_left = HiFiDecode._check_other_channel(mute_point_boundaries_l, mute_point_boundaries_r)
-
-        if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
-            mute_points_right = HiFiDecode._check_other_channel(mute_point_boundaries_r, mute_point_boundaries_l)
+        if dual_mono:
+            # don't fill from other channel
+            mute_points_right = [(None, (start,end)) for start,end in mute_point_boundaries_r]
+            mute_points_left = [(None, (start,end)) for start,end in mute_point_boundaries_l]
+        else:
+            if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
+                mute_points_left = HiFiDecode._check_other_channel(mute_point_boundaries_l, mute_point_boundaries_r)
+            else:
+                # don't fill from other channel
+                mute_points_right = [(None, (start,end)) for start,end in mute_point_boundaries_r]
+    
+            if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
+                mute_points_right = HiFiDecode._check_other_channel(mute_point_boundaries_r, mute_point_boundaries_l)
+            else:
+                # don't fill from other channel
+                mute_points_left = [(None, (start,end)) for start,end in mute_point_boundaries_l]
 
         # apply muting / filling with dropout compensation data
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
@@ -2199,7 +2223,10 @@ class HiFiDecode:
     def mix_for_mode_stereo(
         l_raw: np.array, r_raw: np.array, decode_mode: str
     ) -> Tuple[np.array, np.array]:
-        if decode_mode == AUDIO_MODE_STEREO_MS:
+        if (
+            decode_mode == AUDIO_MODE_STEREO_MS or 
+            decode_mode == AUDIO_MODE_DUAL_MONO_MS
+        ):
             l = np.multiply(np.add(l_raw, r_raw), 0.5)
             r = np.multiply(np.subtract(l_raw, r_raw), 0.5)
         elif decode_mode == AUDIO_MODE_MONO_L:
@@ -2211,7 +2238,9 @@ class HiFiDecode:
         elif decode_mode == AUDIO_MODE_MONO_SUM:
             l = np.multiply(np.add(l_raw, r_raw), 0.5)
             r = np.multiply(np.add(l_raw, r_raw), 0.5)
-        else: # AUDIO_MODE_STEREO
+        else:
+            # AUDIO_MODE_STEREO
+            # AUDIO_MODE_DUAL_MONO_STEREO
             l = l_raw
             r = r_raw
 

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -2125,72 +2125,131 @@ class HiFiDecode:
         return result
 
     @staticmethod
+    @njit(
+        numba.types.void(
+            numba.types.int64,
+            numba.types.int64,
+            NumbaAudioArray,
+            NumbaAudioArray,
+            numba.types.int64,
+            numba.types.int64,
+            numba.types.boolean,
+            numba.types.float32
+        ),
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def _fill(start, end, outer, inner, fade_samples, dc_window, mute, epsilon):
+        # ------- calculate the start of the fade --------
+        fade_start = max(0, start - fade_samples)
+        fade_start_duration = start - fade_start
+
+        dc_before_start = max(0, fade_start - dc_window)
+        dc_before_end = start
+        if dc_before_start < dc_before_end:
+            dc_before = np.mean(outer[dc_before_start:dc_before_end])
+        else:
+            dc_before = 0
+
+        # ------- calculate the end of the fade --------
+        fade_end = min(len(outer), end + fade_samples)
+        fade_end_duration = fade_end - end
+
+        dc_after_start = end
+        dc_after_end = min(len(outer), fade_end + dc_window)
+        if dc_after_start < dc_after_end:
+            dc_after = np.mean(outer[dc_after_start:dc_after_end])
+        else:
+            dc_after = 0
+
+        # DC of inner data over the gap
+        dc_inner = 0 if mute else np.mean(inner[fade_start:fade_end])
+
+        # interpolate DC across the gap
+        # prevents artifacts introduced with dc offset difference between the channels
+        dc_total_len = fade_end - fade_start
+        dc_interp_full = np.zeros(dc_total_len, dtype=REAL_DTYPE)
+
+        if dc_total_len > 1:
+            denom = float(dc_total_len - 1)
+            delta = dc_after - dc_before
+        
+            for i in range(dc_total_len):
+                t = i / denom
+                smooth = 0.5 * (1.0 - np.cos(np.pi * t))
+                dc_interp_full[i] = dc_before + delta * smooth
+        else:
+            dc_interp_full[0] = dc_before
+
+        # -------- cross fade outer -> inner (before gap) --------
+        for i in range(fade_start_duration):
+            idx = fade_start + i
+            dc_idx = idx - fade_start
+
+            fade_in_factor = i / fade_start_duration
+            fade_out_factor = 1 - fade_in_factor
+
+            outer_sample = outer[idx] * fade_out_factor
+            inner_sample = (epsilon if mute else inner[idx] - dc_inner + dc_interp_full[dc_idx]) * fade_in_factor
+
+            outer[idx] = outer_sample + inner_sample
+
+        # -------- copy inner (gap) --------
+        for i in range(start, end):
+            dc_idx = i - fade_start
+
+            inner_sample = epsilon if mute else inner[i]
+            outer[i] = (
+                inner_sample
+                - dc_inner # subtract current dc offset
+                + dc_interp_full[dc_idx] # add interpolated dc offset
+            )
+
+        # -------- cross fade inner -> outer (after gap) --------
+        for i in range(fade_end_duration):
+            idx = end + i
+            dc_idx = idx - fade_start
+
+            fade_in_factor = (i + 1) / fade_end_duration
+            fade_out_factor = 1 - fade_in_factor
+
+            outer_sample = outer[idx] * fade_in_factor
+            inner_sample = (epsilon if mute else inner[idx] - dc_inner + dc_interp_full[dc_idx]) * fade_out_factor
+
+            outer[idx] = outer_sample + inner_sample
+
+
+    @staticmethod
     def _mute_or_fill(dropouts, current_channel, other_channel, fade_samples, dc_window):
-        eps = np.finfo(np.float16).eps
-        n = len(current_channel)
+        epsilon = np.finfo(np.float16).eps
 
         for fill_range, mute_range in dropouts:
             # cross fade from other channel
             if fill_range is not None:
-                start, end = map(int, fill_range)
-
-                length = end - start
-                if length <= 0:
-                    continue
-
-                fade_len = min(fade_samples, length // 2)
-                middle_len = max(0, length - 2 * fade_len)
-
-                # DC before and after the gap
-                dc_before = np.mean(current_channel[max(0, start - dc_window):start])
-                dc_after = np.mean(current_channel[end:min(n, end + dc_window)])
-                dc_other = np.mean(other_channel[start:end])
-
-                # Smooth DC interpolation across the gap
-                t = np.linspace(0.0, 1.0, length)
-                smooth_interp = 0.5 * (1 - np.cos(np.pi * t))  # smooth ramp
-                dc_interp = dc_before + (dc_after - dc_before) * smooth_interp - dc_other
-
-                # Apply the crossfade with DC correction
-                fade_curve = np.concatenate([
-                    np.linspace(0.0, 1.0, fade_len, endpoint=False),
-                    np.ones(middle_len),
-                    np.linspace(1.0, 0.0, length - fade_len - middle_len, endpoint=False)
-                ])
-
-                current_channel[start:end] = (
-                    current_channel[start:end] * (1 - fade_curve) +
-                    other_channel[start:end] * fade_curve +
-                    dc_interp
+                HiFiDecode._fill(
+                    fill_range[0],
+                    fill_range[1],
+                    current_channel,
+                    other_channel,
+                    fade_samples,
+                    dc_window,
+                    False,
+                    epsilon
                 )
 
             # fade to silence
             if mute_range is not None:
-                start, end = map(int, mute_range)
-
-                fade_start = max(0, start - fade_samples)
-                fade_start_duration = start - fade_start
-                if fade_start_duration > 0:
-                    fade_start_rate = log1p(fade_start_duration)
-
-                fade_end = min(n, end + fade_samples)
-                fade_end_duration = fade_end - end
-                if fade_end_duration > 0:
-                    fade_end_rate = log1p(fade_end_duration)
-
-                # fade out
-                for i in range(fade_start_duration):
-                    current_channel[fade_start + i] = (
-                        current_channel[fade_start + i]
-                        * log1p(fade_start_duration - i)
-                        / fade_start_rate
-                    )
-                # mute
-                for i in range(start, end):
-                    current_channel[i] = eps  # not quite zero to prevent issues with noise reduction
-                # fade in
-                for i in range(fade_end_duration):
-                    current_channel[end + i] = current_channel[end + i] * log1p(i) / fade_end_rate
+                HiFiDecode._fill(
+                    mute_range[0],
+                    mute_range[1],
+                    current_channel,
+                    other_channel,
+                    fade_samples,
+                    dc_window,
+                    True,
+                    epsilon
+                )
 
     @staticmethod
     def dropout_compensate(audioL: np.array, audioR: np.array, audio_process_params: HiFiAudioParams) -> np.array:

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -1181,6 +1181,7 @@ class HiFiAudioParams:
     muting_window_size: int
     muting_window_hop_size: int
     muting_fade_samples: int
+    muting_dc_offset_samples: int
     muting_amplitude_threshold: int
     muting_std_threshold: int
     muting_fft_start: int
@@ -1295,6 +1296,8 @@ class HiFiDecode:
         self.muting_audio_rate = self.audio_rate
         # number of samples to fade out before muting, and fade in after muting
         self.muting_fade_samples = 128
+        # number of samples to compensate for dc offset 
+        self.muting_dc_offset_samples = 256
         # muting detection thresholds
         self.muting_window_size = 128
         self.muting_window_hop_size = 128
@@ -1368,6 +1371,7 @@ class HiFiDecode:
             muting_window_size=self.muting_window_size,
             muting_window_hop_size=self.muting_window_hop_size,
             muting_fade_samples=self.muting_fade_samples,
+            muting_dc_offset_samples=self.muting_dc_offset_samples,
             muting_amplitude_threshold=self.muting_amplitude_threshold,
             muting_std_threshold=self.muting_std_threshold,
             muting_fft_start=self.muting_fft_start,
@@ -2011,7 +2015,7 @@ class HiFiDecode:
         return dc
 
     @staticmethod
-    def mute(audio: np.array, audio_process_params: HiFiAudioParams) -> np.array:
+    def _detect_dropouts(audio: np.array, audio_process_params: HiFiAudioParams):
         # Parameters for the sliding window
         window_size = (
             audio_process_params.muting_window_size
@@ -2056,36 +2060,140 @@ class HiFiDecode:
                     full_spectrum_ranges_count += 1
 
         # sort and merge any overlapping boundaries
-        mute_point_boundaries = HiFiDecode.merge_boundaries(mute_point_ranges)
+        return HiFiDecode.merge_boundaries(mute_point_ranges)
+    
+    @staticmethod
+    def _check_other_channel(gaps_to_fill, source_gaps):
+        result = []
 
-        for boundary in mute_point_boundaries:
-            start = boundary[0]
-            fade_start = max(0, start - audio_process_params.muting_fade_samples)
-            fade_start_duration = start - fade_start
-            if fade_start_duration > 0:
-                fade_start_rate = log1p(fade_start_duration)
+        for start, end in gaps_to_fill:
+            # Check overlap with source gaps
+            overlap_found = False
+            for s_start, s_end in source_gaps:
+                # If no overlap, skip
+                if end <= s_start or start >= s_end:
+                    continue
+                overlap_found = True
+                # Safe copy = part of gap outside overlap
+                if start < s_start:
+                    result.append(((start, s_start), None))
+                # Missing in both = overlap
+                overlap_start = max(start, s_start)
+                overlap_end = min(end, s_end)
+                result.append((None, (overlap_start, overlap_end)))
+                start = overlap_end
+            # Remaining part after last overlap
+            if not overlap_found or start < end:
+                result.append(((start, end), None))
 
-            end = boundary[1]
-            fade_end = min(len(audio), end + audio_process_params.muting_fade_samples)
-            fade_end_duration = fade_end - end
-            if fade_end_duration > 0:
-                fade_end_rate = log1p(fade_end_duration)
+        return result
 
-            # fade out
-            for i in range(fade_start_duration):
-                audio[fade_start + i] = (
-                    audio[fade_start + i]
-                    * log1p(fade_start_duration - i)
-                    / fade_start_rate
+    @staticmethod
+    def _mute_or_fill(mute_points, current_channel, other_channel, fade_samples, dc_window):
+        eps = np.finfo(np.float16).eps
+        n = len(current_channel)
+
+        for copy_range, mute_range in mute_points:
+            # cross fade from other channel
+            if copy_range is not None:
+                start, end = map(int, copy_range)
+
+                length = end - start
+                if length <= 0:
+                    continue
+
+                fade_len = min(fade_samples, length // 2)
+                middle_len = max(0, length - 2 * fade_len)
+
+                # DC before and after the gap
+                dc_before = np.mean(current_channel[max(0, start - dc_window):start])
+                dc_after = np.mean(current_channel[end:min(n, end + dc_window)])
+                dc_other = np.mean(other_channel[start:end])
+
+                # Smooth DC interpolation across the gap
+                t = np.linspace(0.0, 1.0, length)
+                smooth_interp = 0.5 * (1 - np.cos(np.pi * t))  # smooth ramp
+                dc_interp = dc_before + (dc_after - dc_before) * smooth_interp - dc_other
+
+                # Apply the crossfade with DC correction
+                fade_curve = np.concatenate([
+                    np.linspace(0.0, 1.0, fade_len, endpoint=False),
+                    np.ones(middle_len),
+                    np.linspace(1.0, 0.0, length - fade_len - middle_len, endpoint=False)
+                ])
+
+                current_channel[start:end] = (
+                    current_channel[start:end] * (1 - fade_curve) +
+                    other_channel[start:end] * fade_curve +
+                    dc_interp
                 )
-            # mute
-            for i in range(start, end):
-                audio[i] = np.finfo(
-                    np.float16
-                ).eps  # not quite zero to prevent issues with noise reduction
-            # fade in
-            for i in range(fade_end_duration):
-                audio[end + i] = audio[end + i] * log1p(i) / fade_end_rate
+
+            # fade to silence
+            if mute_range is not None:
+                start, end = map(int, mute_range)
+
+                fade_start = max(0, start - fade_samples)
+                fade_start_duration = start - fade_start
+                if fade_start_duration > 0:
+                    fade_start_rate = log1p(fade_start_duration)
+
+                fade_end = min(n, end + fade_samples)
+                fade_end_duration = fade_end - end
+                if fade_end_duration > 0:
+                    fade_end_rate = log1p(fade_end_duration)
+
+                # fade out
+                for i in range(fade_start_duration):
+                    current_channel[fade_start + i] = (
+                        current_channel[fade_start + i]
+                        * log1p(fade_start_duration - i)
+                        / fade_start_rate
+                    )
+                # mute
+                for i in range(start, end):
+                    current_channel[i] = eps  # not quite zero to prevent issues with noise reduction
+                # fade in
+                for i in range(fade_end_duration):
+                    current_channel[end + i] = current_channel[end + i] * log1p(i) / fade_end_rate
+
+    @staticmethod
+    def mute(audioL: np.array, audioR: np.array, audio_process_params: HiFiAudioParams) -> np.array:
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
+            mute_point_boundaries_l = HiFiDecode._detect_dropouts(audioL, audio_process_params)
+        else:
+            # fully muted since this is right channel only
+            mute_point_boundaries_l = [(0, len(audioR))]
+
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
+            mute_point_boundaries_r = HiFiDecode._detect_dropouts(audioR, audio_process_params)
+        else:
+            # fully muted since this is left channel only
+            mute_point_boundaries_r = [(0, len(audioL))]
+
+        # check each other channel for any data that can be used as dropout compensation
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
+            mute_points_left = HiFiDecode._check_other_channel(mute_point_boundaries_l, mute_point_boundaries_r)
+
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
+            mute_points_right = HiFiDecode._check_other_channel(mute_point_boundaries_r, mute_point_boundaries_l)
+
+        # apply muting / filling with dropout compensation data
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
+            HiFiDecode._mute_or_fill(
+                mute_points_left,
+                audioL,
+                audioR,
+                audio_process_params.muting_fade_samples,
+                audio_process_params.muting_dc_offset_samples
+            )
+        if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
+            HiFiDecode._mute_or_fill(
+                mute_points_right,
+                audioR,
+                audioL,
+                audio_process_params.muting_fade_samples,
+                audio_process_params.muting_dc_offset_samples
+            )
 
     @staticmethod
     def mix_for_mode_stereo(
@@ -2122,7 +2230,7 @@ class HiFiDecode:
 
     @staticmethod
     def demod_process_audio(
-        filtered: np.array, fm: FMdemod, audio_process_params: dict, audio_resampler, audio_final_resampler, measure_perf: bool
+        filtered: np.array, fm: FMdemod, audio_process_params: HiFiAudioParams, audio_resampler, measure_perf: bool
     ) -> Tuple[np.array, float, dict]:
         perf_measurements = {
             "start_demod": 0,
@@ -2160,14 +2268,16 @@ class HiFiDecode:
         if measure_perf:
             perf_measurements["end_dc_trim"] = perf_counter()
 
-        # mute audio when carrier loss occurs
-        if measure_perf:
-            perf_measurements["start_mute"] = perf_counter()
-        if audio_process_params.muting_enabled:
-            HiFiDecode.mute(audio, audio_process_params)
-        if measure_perf:
-            perf_measurements["end_mute"] = perf_counter()
+        return audio, dc, perf_measurements
 
+    @staticmethod
+    def head_switch_resample(
+        audio: np.array,
+        audio_process_params: HiFiAudioParams,
+        audio_final_resampler,
+        perf_measurements: dict,
+        measure_perf: bool
+    ) -> Tuple[np.array, float, dict]:
         # do head switching noise cancellation if enabled
         if measure_perf:
             perf_measurements["start_headswitch"] = perf_counter()
@@ -2185,7 +2295,7 @@ class HiFiDecode:
         if measure_perf:
             perf_measurements["end_audio_final_resample"] = perf_counter()
 
-        return audio, dc, perf_measurements
+        return audio, perf_measurements
 
     def block_decode(
         self,
@@ -2237,22 +2347,42 @@ class HiFiDecode:
         if self.options["grc"] and ZMQ_AVAILABLE:
             self.grc.send(filterL + filterR)
 
+        # demodulate, resample to audio rate
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_R: 
             preL, dcL, perf_measurements_l = HiFiDecode.demod_process_audio(
-                filterL, self.fmL, self.audio_process_params, self.audio_resampler_l, self.audio_final_resampler_l, measure_perf
+                filterL, self.fmL, self.audio_process_params, self.audio_resampler_l, measure_perf
             )
         else:
             preL = None
             dcL = 0
             perf_measurements_l = 0
+
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_L: 
             preR, dcR, perf_measurements_r = HiFiDecode.demod_process_audio(
-                filterR, self.fmR, self.audio_process_params, self.audio_resampler_r, self.audio_final_resampler_r, measure_perf
+                filterR, self.fmR, self.audio_process_params, self.audio_resampler_r, measure_perf
             )
         else:
             preR = None
             dcR = 0
             perf_measurements_r = 0
+
+        # dropout compensation
+        # mute audio when carrier loss occurs
+        if measure_perf:
+            perf_measurements_l["start_mute"] = perf_counter()
+            perf_measurements_r["start_mute"] = perf_measurements_l["start_mute"]
+        if self.audio_process_params.muting_enabled:
+            HiFiDecode.mute(preL, preR, self.audio_process_params)
+        if measure_perf:
+            perf_measurements_l["end_mute"] = perf_counter()
+            perf_measurements_r["end_mute"] = perf_measurements_l["end_mute"]
+
+        # headswitch interpolation, resample to final rate
+        if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
+            preL, perf_measurements_l = HiFiDecode.head_switch_resample(preL, self.audio_process_params, self.audio_final_resampler_l, perf_measurements_l, measure_perf)
+
+        if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
+            preR, perf_measurements_r = HiFiDecode.head_switch_resample(preR, self.audio_process_params, self.audio_final_resampler_r, perf_measurements_r, measure_perf)
 
         # fine tune carrier frequency
         if measure_perf:

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -43,6 +43,9 @@ from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray
 
 import matplotlib.pyplot as plt
 
+# ******************
+# Audio mode options
+# ******************
 AUDIO_MODE_STEREO = "s"
 AUDIO_MODE_STEREO_MS = "ms"
 AUDIO_MODE_DUAL_MONO = "d"
@@ -58,6 +61,9 @@ UI_DUAL_MONO_MS = "Dual Mono (L+R) (L-R)"
 UI_MONO_L = "Mono (L)"
 UI_MONO_R = "Mono (R)"
 UI_MONO_SUM = "Mono Sum (L+R)"
+
+DEFAULT_VHS_AUDIO_MODE = AUDIO_MODE_STEREO
+DEFAULT_8MM_AUDIO_MODE = AUDIO_MODE_STEREO_MS
 
 audio_mode_to_ui = {
     AUDIO_MODE_STEREO: UI_STEREO,
@@ -79,6 +85,31 @@ ui_to_audio_mode = {
     UI_MONO_SUM: AUDIO_MODE_MONO_SUM,
 }
 
+# ****************************
+# Dropout Compensation Options
+# ****************************
+DOC_MODE_FULL = "full"
+DOC_MODE_MUTE = "mute"
+DOC_MODE_DISABLED = "off"
+
+UI_DOC_MODE_FULL = "Full"
+UI_DOC_MODE_MUTE = "Muting Only"
+UI_DOC_MODE_DISABLED = "Off"
+
+DEFAULT_DOC_MODE = DOC_MODE_FULL
+
+doc_mode_to_ui = {
+    DOC_MODE_FULL: UI_DOC_MODE_FULL,
+    DOC_MODE_MUTE: UI_DOC_MODE_MUTE,
+    DOC_MODE_DISABLED: UI_DOC_MODE_DISABLED,
+}
+
+ui_to_doc_mode = {
+    UI_DOC_MODE_FULL: DOC_MODE_FULL,
+    UI_DOC_MODE_MUTE: DOC_MODE_MUTE,
+    UI_DOC_MODE_DISABLED: DOC_MODE_DISABLED,
+}
+
 # TAU_1         low end of shelf curve
 # TAU_2         high end of shelf curve
 
@@ -88,7 +119,7 @@ ui_to_audio_mode = {
 DEFAULT_VHS_EXPANDER_GAIN = 30
 # IEC 60774-2 5.1: Noise Reduction
 DEFAULT_VHS_EXPANDER_RATIO = 2 #           2:1 logarithmic
-DEFAULT_VHS_EXPANDER_ATTACK_TAU = 6.5e-3 #   3ms to 10ms
+DEFAULT_VHS_EXPANDER_ATTACK_TAU = 6.5e-3 # 3ms to 10ms
 DEFAULT_VHS_EXPANDER_HOLD_TAU = 0 #        None (only used for 8mm)
 DEFAULT_VHS_EXPANDER_RELEASE_TAU = 70e-3 # 70ms +-20%
 
@@ -144,9 +175,6 @@ DEFAULT_8MM_EXPANDER_WEIGHTING_TAU_2 = 27e-6
 # this may help to remove any high frequency noise interfering with the expander envelope
 DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS = 20000
 DEFAULT_8MM_EXPANDER_WEIGHTING_LOW_PASS_TRANSITION = 100000
-
-DEFAULT_VHS_AUDIO_MODE = AUDIO_MODE_STEREO
-DEFAULT_8MM_AUDIO_MODE = AUDIO_MODE_STEREO_MS
 
 # set the amount of spectral noise reduction to apply to the signal before deemphasis
 DEFAULT_SPECTRAL_NR_AMOUNT = 0.4
@@ -1184,16 +1212,16 @@ class HiFiAudioParams:
     headswitch_interpolation_neighbor_range: int
     hs_b: float
     hs_a: float
-    muting_enabled: bool
-    muting_cutoff_freq: int
-    muting_window_size: int
-    muting_window_hop_size: int
-    muting_fade_samples: int
-    muting_dc_offset_samples: int
-    muting_amplitude_threshold: int
-    muting_std_threshold: int
-    muting_fft_start: int
-    muting_fft_end: int
+    doc_mode: bool
+    doc_cutoff_freq: int
+    doc_window_size: int
+    doc_window_hop_size: int
+    doc_fade_samples: int
+    doc_dc_offset_samples: int
+    doc_amplitude_threshold: int
+    doc_std_threshold: int
+    doc_fft_start: int
+    doc_fft_end: int
 
 
 class HiFiDecode:
@@ -1300,30 +1328,30 @@ class HiFiDecode:
 
         # hifi carrier loss results in broadband noise
         # mute the audio when this broadband noise exists above the audible frequencies
-        self.muting_enabled = self.options["muting"]
-        self.muting_audio_rate = self.audio_rate
-        # number of samples to fade out before muting, and fade in after muting
-        self.muting_fade_samples = 128
+        self.doc_mode = self.options["doc"]
+        self.doc_audio_rate = self.audio_rate
+        # number of samples to fade out before doc, and fade in after doc
+        self.doc_fade_samples = 128
         # number of samples to compensate for dc offset 
-        self.muting_dc_offset_samples = 256
-        # muting detection thresholds
-        self.muting_window_size = 128
-        self.muting_window_hop_size = 128
-        self.muting_amplitude_threshold = 1  # 1 is 100% gain
-        self.muting_std_threshold = 1  # +- standard deviation of fft before muting
+        self.doc_dc_offset_samples = 256
+        # dropout detection thresholds
+        self.doc_window_size = 128
+        self.doc_window_hop_size = 128
+        self.doc_amplitude_threshold = 1  # 1 is 100% gain
+        self.doc_std_threshold = 1  # +- standard deviation of fft before dropout correction
 
         # remove signals that may be from the recorded audio
-        self.muting_cutoff_freq = 40000
-        muting_fft_freqs = np.fft.fftfreq(
-            self.muting_window_size, d=1 / self.muting_audio_rate
+        self.doc_cutoff_freq = 40000
+        doc_fft_freqs = np.fft.fftfreq(
+            self.doc_window_size, d=1 / self.doc_audio_rate
         )
-        for i in range(len(muting_fft_freqs)):
-            freq = muting_fft_freqs[i]
+        for i in range(len(doc_fft_freqs)):
+            freq = doc_fft_freqs[i]
             if freq < 0:
-                self.muting_fft_end = i - 1
+                self.doc_fft_end = i - 1
                 break
-            if freq <= self.muting_cutoff_freq:
-                self.muting_fft_start = i
+            if freq <= self.doc_cutoff_freq:
+                self.doc_fft_start = i
 
         if not bias_guess:
             # defer until carriers can be determined
@@ -1374,16 +1402,16 @@ class HiFiDecode:
             headswitch_interpolation_neighbor_range=self.headswitch_interpolation_neighbor_range,
             hs_b=hs_b,
             hs_a=hs_a,
-            muting_enabled=self.muting_enabled,
-            muting_cutoff_freq=self.muting_cutoff_freq,
-            muting_window_size=self.muting_window_size,
-            muting_window_hop_size=self.muting_window_hop_size,
-            muting_fade_samples=self.muting_fade_samples,
-            muting_dc_offset_samples=self.muting_dc_offset_samples,
-            muting_amplitude_threshold=self.muting_amplitude_threshold,
-            muting_std_threshold=self.muting_std_threshold,
-            muting_fft_start=self.muting_fft_start,
-            muting_fft_end=self.muting_fft_end,
+            doc_mode=self.doc_mode,
+            doc_cutoff_freq=self.doc_cutoff_freq,
+            doc_window_size=self.doc_window_size,
+            doc_window_hop_size=self.doc_window_hop_size,
+            doc_fade_samples=self.doc_fade_samples,
+            doc_dc_offset_samples=self.doc_dc_offset_samples,
+            doc_amplitude_threshold=self.doc_amplitude_threshold,
+            doc_std_threshold=self.doc_std_threshold,
+            doc_fft_start=self.doc_fft_start,
+            doc_fft_end=self.doc_fft_end,
         )
 
     @staticmethod
@@ -2026,17 +2054,17 @@ class HiFiDecode:
     def _detect_dropouts(audio: np.array, audio_process_params: HiFiAudioParams):
         # Parameters for the sliding window
         window_size = (
-            audio_process_params.muting_window_size
+            audio_process_params.doc_window_size
         )  # Size of each window (in samples)
         hop_size = (
-            audio_process_params.muting_window_hop_size
+            audio_process_params.doc_window_hop_size
         )  # Hop size (how much to move the window each time)
 
-        mute_point_ranges = []
+        dropout_ranges = []
         full_spectrum_ranges_count = 0
 
-        fft_start = audio_process_params.muting_fft_start
-        fft_end = audio_process_params.muting_fft_end
+        fft_start = audio_process_params.doc_fft_start
+        fft_end = audio_process_params.doc_fft_end
 
         # Loop through the audio in overlapping windows
         for start in range(0, len(audio) - window_size, hop_size):
@@ -2053,22 +2081,22 @@ class HiFiDecode:
             magnitude_mean, magnitude_std = HiFiDecode.mean_stddev(magnitude)
 
             if (
-                magnitude_mean > audio_process_params.muting_amplitude_threshold
-                and magnitude_std > audio_process_params.muting_std_threshold
+                magnitude_mean > audio_process_params.doc_amplitude_threshold
+                and magnitude_std > audio_process_params.doc_std_threshold
             ):
-                # start the mute point, if not currently muted
-                if len(mute_point_ranges) == full_spectrum_ranges_count:
-                    mute_point_ranges.append(
+                # start the dropout, if not currently in a dropout
+                if len(dropout_ranges) == full_spectrum_ranges_count:
+                    dropout_ranges.append(
                         [start, len(audio)]
-                    )  # default to end muting at the end of the audio
+                    )  # default to end doc at the end of the audio
             else:
-                # end the mute point, if currently muted
-                if len(mute_point_ranges) > full_spectrum_ranges_count:
-                    mute_point_ranges[full_spectrum_ranges_count][1] = end
+                # end the dropout, if currently in a dropout
+                if len(dropout_ranges) > full_spectrum_ranges_count:
+                    dropout_ranges[full_spectrum_ranges_count][1] = end
                     full_spectrum_ranges_count += 1
 
         # sort and merge any overlapping boundaries
-        return HiFiDecode.merge_boundaries(mute_point_ranges)
+        return HiFiDecode.merge_boundaries(dropout_ranges)
     
     @staticmethod
     def _check_other_channel(gaps_to_fill, source_gaps):
@@ -2097,14 +2125,14 @@ class HiFiDecode:
         return result
 
     @staticmethod
-    def _mute_or_fill(mute_points, current_channel, other_channel, fade_samples, dc_window):
+    def _mute_or_fill(dropouts, current_channel, other_channel, fade_samples, dc_window):
         eps = np.finfo(np.float16).eps
         n = len(current_channel)
 
-        for copy_range, mute_range in mute_points:
+        for fill_range, mute_range in dropouts:
             # cross fade from other channel
-            if copy_range is not None:
-                start, end = map(int, copy_range)
+            if fill_range is not None:
+                start, end = map(int, fill_range)
 
                 length = end - start
                 if length <= 0:
@@ -2165,58 +2193,58 @@ class HiFiDecode:
                     current_channel[end + i] = current_channel[end + i] * log1p(i) / fade_end_rate
 
     @staticmethod
-    def mute(audioL: np.array, audioR: np.array, audio_process_params: HiFiAudioParams) -> np.array:
+    def dropout_compensate(audioL: np.array, audioR: np.array, audio_process_params: HiFiAudioParams) -> np.array:
         dual_mono = (
             audio_process_params.decode_mode == AUDIO_MODE_DUAL_MONO or
             audio_process_params.decode_mode == AUDIO_MODE_DUAL_MONO_MS
         )
 
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
-            mute_point_boundaries_l = HiFiDecode._detect_dropouts(audioL, audio_process_params)
+            dropout_boundaries_l = HiFiDecode._detect_dropouts(audioL, audio_process_params)
         else:
             # fully muted since this is right channel only
-            mute_point_boundaries_l = [(0, len(audioR))]
+            dropout_boundaries_l = [(0, len(audioR))]
 
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
-            mute_point_boundaries_r = HiFiDecode._detect_dropouts(audioR, audio_process_params)
+            dropout_boundaries_r = HiFiDecode._detect_dropouts(audioR, audio_process_params)
         else:
             # fully muted since this is left channel only
-            mute_point_boundaries_r = [(0, len(audioL))]
+            dropout_boundaries_r = [(0, len(audioL))]
 
         # check each other channel for any data that can be used as dropout compensation
-        if dual_mono:
+        if dual_mono or audio_process_params.doc_mode == DOC_MODE_MUTE:
             # don't fill from other channel
-            mute_points_right = [(None, (start,end)) for start,end in mute_point_boundaries_r]
-            mute_points_left = [(None, (start,end)) for start,end in mute_point_boundaries_l]
+            dropouts_right = [(None, (start,end)) for start,end in dropout_boundaries_r]
+            dropouts_left = [(None, (start,end)) for start,end in dropout_boundaries_l]
         else:
             if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
-                mute_points_left = HiFiDecode._check_other_channel(mute_point_boundaries_l, mute_point_boundaries_r)
+                dropouts_left = HiFiDecode._check_other_channel(dropout_boundaries_l, dropout_boundaries_r)
             else:
                 # don't fill from other channel
-                mute_points_right = [(None, (start,end)) for start,end in mute_point_boundaries_r]
+                dropouts_right = [(None, (start,end)) for start,end in dropout_boundaries_r]
     
             if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
-                mute_points_right = HiFiDecode._check_other_channel(mute_point_boundaries_r, mute_point_boundaries_l)
+                dropouts_right = HiFiDecode._check_other_channel(dropout_boundaries_r, dropout_boundaries_l)
             else:
                 # don't fill from other channel
-                mute_points_left = [(None, (start,end)) for start,end in mute_point_boundaries_l]
+                dropouts_left = [(None, (start,end)) for start,end in dropout_boundaries_l]
 
-        # apply muting / filling with dropout compensation data
+        # apply doc / filling with dropout compensation data
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
             HiFiDecode._mute_or_fill(
-                mute_points_left,
+                dropouts_left,
                 audioL,
                 audioR,
-                audio_process_params.muting_fade_samples,
-                audio_process_params.muting_dc_offset_samples
+                audio_process_params.doc_fade_samples,
+                audio_process_params.doc_dc_offset_samples
             )
         if audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
             HiFiDecode._mute_or_fill(
-                mute_points_right,
+                dropouts_right,
                 audioR,
                 audioL,
-                audio_process_params.muting_fade_samples,
-                audio_process_params.muting_dc_offset_samples
+                audio_process_params.doc_fade_samples,
+                audio_process_params.doc_dc_offset_samples
             )
 
     @staticmethod
@@ -2396,15 +2424,16 @@ class HiFiDecode:
             perf_measurements_r = 0
 
         # dropout compensation
+        # try to copy from the other channel otherwise
         # mute audio when carrier loss occurs
         if measure_perf:
-            perf_measurements_l["start_mute"] = perf_counter()
-            perf_measurements_r["start_mute"] = perf_measurements_l["start_mute"]
-        if self.audio_process_params.muting_enabled:
-            HiFiDecode.mute(preL, preR, self.audio_process_params)
+            perf_measurements_l["start_doc"] = perf_counter()
+            perf_measurements_r["start_doc"] = perf_measurements_l["start_doc"]
+        if self.audio_process_params.doc_mode != DOC_MODE_DISABLED:
+            HiFiDecode.dropout_compensate(preL, preR, self.audio_process_params)
         if measure_perf:
-            perf_measurements_l["end_mute"] = perf_counter()
-            perf_measurements_r["end_mute"] = perf_measurements_l["end_mute"]
+            perf_measurements_l["end_doc"] = perf_counter()
+            perf_measurements_r["end_doc"] = perf_measurements_l["end_doc"]
 
         # headswitch interpolation, resample to final rate
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
@@ -2462,8 +2491,8 @@ class HiFiDecode:
                 perf_measurements_l["end_dc_trim"]
                 - perf_measurements_l["start_dc_trim"]
             )
-            duration_mute_l = (
-                perf_measurements_l["end_mute"] - perf_measurements_l["start_mute"]
+            duration_doc_l = (
+                perf_measurements_l["end_doc"] - perf_measurements_l["start_doc"]
             )
             duration_headswitch_l = (
                 perf_measurements_l["end_headswitch"]
@@ -2485,8 +2514,8 @@ class HiFiDecode:
                 perf_measurements_r["end_dc_trim"]
                 - perf_measurements_r["start_dc_trim"]
             )
-            duration_mute_r = (
-                perf_measurements_r["end_mute"] - perf_measurements_r["start_mute"]
+            duration_doc_r = (
+                perf_measurements_r["end_doc"] - perf_measurements_r["start_doc"]
             )
             duration_headswitch_r = (
                 perf_measurements_r["end_headswitch"]
@@ -2507,13 +2536,13 @@ class HiFiDecode:
                 ("duration_demod_l", duration_demod_l),
                 ("duration_audio_resample_l", duration_audio_resample_l),
                 ("duration_dc_trim_l", duration_dc_trim_l),
-                ("duration_mute_l", duration_mute_l),
+                ("duration_doc_l", duration_doc_l),
                 ("duration_headswitch_l", duration_headswitch_l),
                 ("duration_audio_final_resample_l", duration_audio_final_resample_l),
                 ("duration_demod_r", duration_demod_r),
                 ("duration_audio_resample_r", duration_audio_resample_r),
                 ("duration_dc_trim_r", duration_dc_trim_r),
-                ("duration_mute_r", duration_mute_r),
+                ("duration_doc_r", duration_doc_r),
                 ("duration_headswitch_r", duration_headswitch_r),
                 ("duration_audio_final_resample_r", duration_audio_final_resample_r),
                 ("duration_auto_fine_tune", duration_auto_fine_tune),

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -96,6 +96,9 @@ from vhsdecode.hifi.HiFiDecode import (
     DEFAULT_8MM_AUDIO_MODE,
     audio_mode_to_ui,
     ui_to_audio_mode,
+    DEFAULT_DOC_MODE,
+    doc_mode_to_ui,
+    ui_to_doc_mode,
     DEMOD_QUADRATURE,
     DEMOD_HILBERT,
     DEFAULT_DEMOD,
@@ -147,7 +150,7 @@ class MainUIParameters:
         self.input_file: str = ""
         self.output_file: str = ""
         self.head_switching_interpolation = "on"
-        self.muting = "on"
+        self.doc = DEFAULT_DOC_MODE
 
 
 def decode_options_to_ui_parameters(decode_options):
@@ -185,7 +188,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.input_file = decode_options["input_file"]
     values.output_file = decode_options["output_file"]
     values.head_switching_interpolation = decode_options["head_switching_interpolation"]
-    values.muting = decode_options["muting"]
+    values.doc = doc_mode_to_ui[decode_options["doc"]]
     return values
 
 
@@ -224,7 +227,7 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "output_file": values.output_file,
         "resampler_quality": values.resampler_quality,
         "head_switching_interpolation": values.head_switching_interpolation,
-        "muting": values.muting,
+        "doc": ui_to_doc_mode[values.doc],
         "mode": ui_to_audio_mode[values.audio_mode]
     }
     return decode_options
@@ -614,9 +617,16 @@ class HifiUi(QMainWindow):
         noise_reduction_checkboxes_layout.addWidget(
             self.head_switching_interpolation_checkbox
         )
-        # Muting checkbox
-        self.muting_checkbox = QCheckBox("Muting")
-        noise_reduction_checkboxes_layout.addWidget(self.muting_checkbox)
+
+        # Dropout compensation combo
+        doc_layout = QHBoxLayout()
+        doc_label = QLabel("Dropout Compensation")
+
+        self.doc_combo = QComboBox(self)
+        self.doc_combo.addItems(ui_to_doc_mode.keys())
+        doc_layout.addWidget(doc_label)
+        doc_layout.addWidget(self.doc_combo)
+        noise_reduction_checkboxes_layout.addLayout(doc_layout)
 
         noise_reduction_options_layout.addWidget(
             self.spectral_nr_amount_dial_control, 1
@@ -893,7 +903,10 @@ class HifiUi(QMainWindow):
         self.nr_deemphasis_high_tau_dial_control.setValue(values.nr_deemphasis_high_tau)
         self.spectral_nr_amount_dial_control.setValue(values.spectral_nr_amount)
         self.normalize_checkbox.setChecked(values.normalize)
-        self.muting_checkbox.setChecked(values.muting)
+        self.doc_combo.setCurrentText(values.doc)
+        self.doc_combo.setCurrentIndex(
+            self.doc_combo.findText(values.doc)
+        )
         self.enable_expander_checkbox.setChecked(values.enable_expander)
         self.enable_deemphasis_checkbox.setChecked(values.enable_deemphasis)
         self.head_switching_interpolation_checkbox.setChecked(
@@ -980,7 +993,7 @@ class HifiUi(QMainWindow):
             self.spectral_nr_amount_dial_control.textbox.text()
         )
         values.normalize = self.normalize_checkbox.isChecked()
-        values.muting = self.muting_checkbox.isChecked()
+        values.doc = self.doc_combo.currentText()
         values.enable_expander = self.enable_expander_checkbox.isChecked()
         values.enable_deemphasis = self.enable_deemphasis_checkbox.isChecked()
         values.head_switching_interpolation = (

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -947,14 +947,16 @@ class PostProcessor:
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
         out_conn,
-        peak_gain,
+        peak_gain_left,
+        peak_gain_right,
     ):
         self.final_audio_rate = decode_options["audio_rate"]
         self.enable_expander = decode_options["enable_expander"]
         self.enable_deemphasis = decode_options["enable_deemphasis"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
         self.format = decode_options["format"]
-        self.peak_gain = peak_gain
+        self.peak_gain_left = peak_gain_left
+        self.peak_gain_right = peak_gain_right
 
         # create processes and wire up queues
         #
@@ -1127,7 +1129,8 @@ class PostProcessor:
                 expander_worker_l_out_rx,
                 expander_worker_r_out_rx,
                 self.mix_to_stereo_worker_output,
-                self.peak_gain,
+                self.peak_gain_left,
+                self.peak_gain_right,
                 self.final_audio_rate,
             ),
         )
@@ -1391,7 +1394,7 @@ class PostProcessor:
 
     @staticmethod
     def mix_to_stereo_worker(
-        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
+        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain_left, peak_gain_right, sample_rate
     ):
         setproctitle(current_process().name)
         while True:
@@ -1423,20 +1426,24 @@ class PostProcessor:
             r = buffer.get_post_right()
             stereo = buffer.get_stereo()
 
-            max_gain = PostProcessor.stereo_interleave(
+            max_gain_left, max_gain_right = PostProcessor.stereo_interleave(
                 l, r, stereo, sample_rate, decoder_state.block_num == 0
             )
 
-            if peak_gain.value < max_gain:
-                with peak_gain.get_lock():
-                    peak_gain.value = max_gain
+            if peak_gain_left.value < max_gain_left:
+                with peak_gain_left.get_lock():
+                    peak_gain_left.value = max_gain_left
+
+            if peak_gain_right.value < max_gain_right:
+                with peak_gain_right.get_lock():
+                    peak_gain_right.value = max_gain_right
 
             buffer.close()
             out_conn.send(decoder_state)
 
     @staticmethod
     @njit(
-        numba.types.float32(
+        numba.types.UniTuple(numba.types.float32, 2)(
             NumbaAudioArray,
             NumbaAudioArray,
             NumbaAudioArray,
@@ -1454,7 +1461,8 @@ class PostProcessor:
         sample_rate: int,
         is_first_block: bool,
     ) -> int:
-        max_gain = 0
+        max_gain_left = 0
+        max_gain_right = 0
         start_sample = 0
 
         # mute the spike that occurs during noise reduction
@@ -1470,16 +1478,16 @@ class PostProcessor:
             audioLSample = audioL[i]
             stereo[i * 2] = audioLSample
             gain = abs(audioLSample)
-            if gain > max_gain:
-                max_gain = gain
+            if gain > max_gain_left:
+                max_gain_left = gain
 
             audioRSample = audioR[i]
             stereo[i * 2 + 1] = audioRSample
             gain = abs(audioRSample)
-            if gain > max_gain:
-                max_gain = gain
+            if gain > max_gain_right:
+                max_gain_right = gain
 
-        return max_gain
+        return max_gain_left, max_gain_right
 
     @staticmethod
     def block_sorter_worker(
@@ -1799,7 +1807,7 @@ def write_soundfile_process_worker(
             channel_1_output.flush()
             channel_2_output.flush()
         else:
-            stereo.flush()
+            stereo_output.flush()
         decode_done.set()
 
 
@@ -1824,7 +1832,8 @@ async def decode_parallel(
     blocks_enqueued = Value("d", 0)
     input_position = Value("d", 0)
     total_samples_decoded = Value("d", 0)
-    peak_gain = Value("d", 0)
+    peak_gain_left = Value("d", 0)
+    peak_gain_right = Value("d", 0)
     stop_requested = Value("d", STOP_NOT_REQUESTED)
     start_time = datetime.now()
 
@@ -1893,7 +1902,8 @@ async def decode_parallel(
         shared_memory_idle_queue,
         blocks_enqueued,
         post_processor_out_tx_conn,
-        peak_gain,
+        peak_gain_left,
+        peak_gain_right,
     )
     atexit.register(post_processor.close)
 
@@ -2098,36 +2108,38 @@ async def decode_parallel(
         atexit.unregister(shared_memory.close)
         atexit.unregister(shared_memory.unlink)
     
-    with peak_gain.get_lock():
-        print(f"\nPeak gain is {(peak_gain.value * 100):.2f}%.", end="")
+    with peak_gain_left.get_lock(), peak_gain_right.get_lock():
+        audio_rate = decode_options["audio_rate"]
 
-        if decode_options["normalize"]:
-            # TODO calculate peak gain per channel for dual mono
-            gain_adjust = (
-                1 / peak_gain.value - np.finfo(np.float16).eps
-            )  # subtract epsilon error to prevent appearance of "clipping" in editing tools
-            print(f" Adjusting to {(gain_adjust * 100):.2f}%, please wait...")
-
-            audio_rate = decode_options["audio_rate"]
-            dual_mono = decode_options["mode"] == AUDIO_MODE_DUAL_MONO or decode_options["mode"] == AUDIO_MODE_DUAL_MONO_MS
-
-            if dual_mono:
+        if (
+            decode_options["mode"] == AUDIO_MODE_DUAL_MONO or
+            decode_options["mode"] == AUDIO_MODE_DUAL_MONO_MS
+        ):
+            # Normalize channels independently for dual mono
+            print(f"\nChannel 1: Peak gain is {(peak_gain_left.value * 100):.2f}%.", end="")
+            if decode_options["normalize"]:
                 channel_1_output_file = get_dual_mono_filename(output_file, channel_1_suffix)
                 channel_1_input_file_post_gain = get_normalize_filename(channel_1_output_file, audio_rate)
-                normalize(channel_1_input_file_post_gain, channel_1_output_file, gain_adjust, 1, audio_rate)
+                normalize(channel_1_input_file_post_gain, channel_1_output_file, peak_gain_left.value, 1, audio_rate)
 
+            print(f"\nChannel 2: Peak gain is {(peak_gain_right.value * 100):.2f}%.", end="")
+            if decode_options["normalize"]:
                 channel_2_output_file = get_dual_mono_filename(output_file, channel_2_suffix)
                 channel_2_input_file_post_gain = get_normalize_filename(channel_2_output_file, audio_rate)
-                normalize(channel_2_input_file_post_gain, channel_2_output_file, gain_adjust, 1, audio_rate)
-            else:
+                normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain_right.value, 1, audio_rate)
+
+        else:
+            peak_gain_stereo = max(peak_gain_left.value, peak_gain_right.value)
+            print(f"\nPeak gain is {(peak_gain_stereo * 100):.2f}%.", end="")
+            if decode_options["normalize"]:
                 input_file_post_gain = get_normalize_filename(output_file, audio_rate)
-                normalize(input_file_post_gain, output_file, gain_adjust, 2, audio_rate)
+                normalize(input_file_post_gain, output_file, peak_gain_stereo, 2, audio_rate)
 
     elapsed_time = datetime.now() - start_time
     dt_string = elapsed_time.total_seconds()
     print(f"\nDecode finished, seconds elapsed: {round(dt_string)}")
 
-def normalize(input_file_post_gain, output_file, gain_adjust, channels, audio_rate):
+def normalize(input_file_post_gain, output_file, peak_gain, channels, audio_rate):
     try:
         total_frames_read = 0
         buffer = np.empty(2**20, dtype=np.float32)
@@ -2139,11 +2151,16 @@ def normalize(input_file_post_gain, output_file, gain_adjust, channels, audio_ra
             channels=channels,
             **normalize_parameters,
         ) as f, as_outputfile(output_file, channels, audio_rate, False) as w:
+            gain_adjust = (
+                1 / peak_gain - np.finfo(np.float16).eps
+            )  # subtract epsilon error to prevent appearance of "clipping" in editing tools
+            print(f" Adjusting to {(gain_adjust * 100):.2f}%, please wait...")
+
             progressB = TimeProgressBar(f.frames, f.frames)
             done = False
             while not done:
                 frames_read = f.buffer_read_into(buffer, dtype="float32")
-                samples_read = frames_read * 2
+                samples_read = frames_read * channels
 
                 if samples_read < len(buffer):
                     buffer = buffer[0:samples_read]

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -82,6 +82,10 @@ from vhsdecode.hifi.HiFiDecode import (
 
     DEFAULT_VHS_AUDIO_MODE,
     DEFAULT_8MM_AUDIO_MODE,
+    DEFAULT_DOC_MODE,
+    DOC_MODE_FULL,
+    DOC_MODE_MUTE,
+    DOC_MODE_DISABLED,
     AUDIO_MODE_DUAL_MONO,
     AUDIO_MODE_DUAL_MONO_MS,
     audio_mode_to_ui,
@@ -332,12 +336,12 @@ noise_reduction_options_group.add_argument(
     help='Enables head switching noise interpolation. \n  on \tenabled [default]\n  off \tdisabled'
 )
 noise_reduction_options_group.add_argument(
-    "--muting",
-    dest="muting",
+    "--doc",
+    dest="doc",
     type=str.lower,
-    default="on",
+    default=DEFAULT_DOC_MODE,
     metavar='',
-    help='Mutes the audio when there is no hifi carrier. \n  on \tenabled [default]\n  off \tdisabled'
+    help=f'Dropout compensation method (what happens when there is no hifi carrier) \n  {DOC_MODE_FULL} \tcopies audio from the other channel, or mutes if both channels have a dropout [default]\n  {DOC_MODE_MUTE} \talways mute dropouts\n  {DOC_MODE_DISABLED} \tdisabled'
 )
 noise_reduction_options_group.add_argument(
     "--NR_spectral_amount",
@@ -2127,7 +2131,6 @@ async def decode_parallel(
                 channel_2_output_file = get_dual_mono_filename(output_file, channel_2_suffix)
                 channel_2_input_file_post_gain = get_normalize_filename(channel_2_output_file, audio_rate)
                 normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain_right.value, 1, audio_rate)
-
         else:
             peak_gain_stereo = max(peak_gain_left.value, peak_gain_right.value)
             print(f"\nPeak gain is {(peak_gain_stereo * 100):.2f}%.", end="")
@@ -2234,7 +2237,7 @@ def main() -> int:
 
     # 8mm AFM uses a mono channel, or L-R/L+R rather than L/R channels
     # The spec defines a dual audio mode but not sure if it was ever used.
-    default_mode = "s" if not args.format_8mm else "ms"
+    default_mode = DEFAULT_VHS_AUDIO_MODE if not args.format_8mm else DEFAULT_8MM_AUDIO_MODE
 
     real_mode = default_mode if not args.mode else args.mode
 
@@ -2297,7 +2300,7 @@ def main() -> int:
         "resampler_quality": resampler_quality if not args.preview else "low",
         "spectral_nr_amount": args.spectral_nr_amount if not args.preview else 0,
         "head_switching_interpolation": args.head_switching_interpolation == "on",
-        "muting": args.muting == "on",
+        "doc": args.doc,
         "enable_expander": args.enable_expander == "on",
         "enable_deemphasis": args.enable_deemphasis == "on",
         "auto_fine_tune": args.auto_fine_tune == "on" if not args.preview else False,

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -82,6 +82,8 @@ from vhsdecode.hifi.HiFiDecode import (
 
     DEFAULT_VHS_AUDIO_MODE,
     DEFAULT_8MM_AUDIO_MODE,
+    AUDIO_MODE_DUAL_MONO,
+    AUDIO_MODE_DUAL_MONO_MS,
     audio_mode_to_ui,
     DEFAULT_SPECTRAL_NR_AMOUNT,
     DEFAULT_RESAMPLER_QUALITY,
@@ -128,6 +130,7 @@ STOP_NOT_REQUESTED = 0
 STOP_REQUESTED = 1
 STOP_IMMEDIATE_REQUESTED = 2
 
+DEFAULT_CHANNEL_SUFFIX = "channel"
 NORMALIZE_FILE_SUFFIX = "tmp_normalize.raw"
 
 
@@ -848,27 +851,30 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
 def get_normalize_filename(path, sample_rate):
     return f"{path}_{int(sample_rate)}_f32_{NORMALIZE_FILE_SUFFIX}"
 
+def get_dual_mono_filename(path, channel_suffix):
+    root, extension = os.path.splitext(path)
+    return f"{root}_{channel_suffix}{extension}"
 
 normalize_parameters = {
-    "channels": 2,
     "format": "RAW",  # TODO: update to FLAC 32 bit when supported by soundfile
     "subtype": "FLOAT",
 }
 
 
-def as_outputfile(path, sample_rate, normalize):
+def as_outputfile(path, channels, sample_rate, normalize):
     if normalize:
         return sf.SoundFile(
             get_normalize_filename(path, sample_rate),
             "w",
             samplerate=int(sample_rate),
+            channels=channels,
             **normalize_parameters,
         )
     elif ".wav" in path.lower():
         return sf.SoundFile(
             path,
             "w",
-            channels=2,
+            channels=channels,
             samplerate=int(sample_rate),
             format="WAV",
             subtype="PCM_16",
@@ -877,7 +883,7 @@ def as_outputfile(path, sample_rate, normalize):
         return sf.SoundFile(
             path,
             "w",
-            channels=2,
+            channels=channels,
             samplerate=int(sample_rate),
             format="FLAC",
             subtype="PCM_24",
@@ -1691,6 +1697,8 @@ def write_soundfile_process_worker(
     total_samples_decoded,
     decode_options,
     output_file: str,
+    channel_1_suffix: str,
+    channel_2_suffix: str,
     stop_requested,
     decode_done,
 ):
@@ -1699,13 +1707,34 @@ def write_soundfile_process_worker(
     input_rate = decode_options["input_rate"]
     preview_mode = decode_options["preview"]
     normalize = decode_options["normalize"]
+    dual_mono = decode_options["mode"] == AUDIO_MODE_DUAL_MONO or decode_options["mode"] == AUDIO_MODE_DUAL_MONO_MS
 
     if preview_mode:
         player = SoundDeviceProcess(audio_rate, stop_requested)
     else:
         player = nullcontext()
 
-    with player, as_outputfile(output_file, audio_rate, normalize) as w:
+    if dual_mono:
+        stereo_output = nullcontext()
+        channel_1_output = as_outputfile(
+            get_dual_mono_filename(output_file, channel_1_suffix),
+            1,
+            audio_rate,
+            normalize
+        )
+
+        channel_2_output = as_outputfile(
+            get_dual_mono_filename(output_file, channel_2_suffix),
+            1,
+            audio_rate,
+            normalize
+        )
+    else:
+        stereo_output = as_outputfile(output_file, 2, audio_rate, normalize)
+        channel_1_output = nullcontext()
+        channel_2_output = nullcontext()
+
+    with player, stereo_output, channel_1_output, channel_2_output:
         done = False
         while not done:
             while True:
@@ -1724,9 +1753,20 @@ def write_soundfile_process_worker(
             # pad the start of the audio due to beginning gap
             if decoder_state.block_num == 0:
                 padding = round(decoder_state.block_audio_final_overlap / 2) * 2 * 4 # 2 channels, 4 bytes per channel
-                w.buffer_write(bytes(padding), dtype="float32")
+                
+                if dual_mono:
+                    channel_1_output.buffer_write(bytes(padding), dtype="float32")
+                    channel_2_output.buffer_write(bytes(padding), dtype="float32")
+                else:
+                    stereo_output.buffer_write(bytes(padding), dtype="float32")
 
-            w.buffer_write(stereo, dtype="float32")
+            if dual_mono:
+                channel_1, channel_2 = stereo[::2], stereo[1::2]
+                channel_1_output.write(channel_1)
+                channel_2_output.write(channel_2)
+            else:
+                stereo_output.buffer_write(stereo, dtype="float32")
+
             if preview_mode:
                 if SOUNDDEVICE_AVAILABLE:
                     stereo_copy = np.empty_like(stereo)
@@ -1755,7 +1795,11 @@ def write_soundfile_process_worker(
 
             done = decoder_state.is_last_block
 
-        w.flush()
+        if dual_mono:
+            channel_1_output.flush()
+            channel_2_output.flush()
+        else:
+            stereo.flush()
         decode_done.set()
 
 
@@ -1771,6 +1815,9 @@ async def decode_parallel(
 
     input_file = decode_options["input_file"]
     output_file = decode_options["output_file"]
+
+    channel_1_suffix = DEFAULT_CHANNEL_SUFFIX + "_1"
+    channel_2_suffix = DEFAULT_CHANNEL_SUFFIX + "_2"
 
     block_size = decoder.initialBlockSize
 
@@ -1863,6 +1910,8 @@ async def decode_parallel(
             total_samples_decoded,
             decode_options,
             output_file,
+            channel_1_suffix,
+            channel_2_suffix,
             stop_requested,
             decode_done,
         ),
@@ -2053,50 +2102,61 @@ async def decode_parallel(
         print(f"\nPeak gain is {(peak_gain.value * 100):.2f}%.", end="")
 
         if decode_options["normalize"]:
+            # TODO calculate peak gain per channel for dual mono
             gain_adjust = (
                 1 / peak_gain.value - np.finfo(np.float16).eps
             )  # subtract epsilon error to prevent appearance of "clipping" in editing tools
             print(f" Adjusting to {(gain_adjust * 100):.2f}%, please wait...")
 
-            input_file_post_gain = get_normalize_filename(
-                output_file, decode_options["audio_rate"]
-            )
-            output_file = decode_options["output_file"]
             audio_rate = decode_options["audio_rate"]
+            dual_mono = decode_options["mode"] == AUDIO_MODE_DUAL_MONO or decode_options["mode"] == AUDIO_MODE_DUAL_MONO_MS
 
-            try:
-                total_frames_read = 0
-                buffer = np.empty(2**20, dtype=np.float32)
+            if dual_mono:
+                channel_1_output_file = get_dual_mono_filename(output_file, channel_1_suffix)
+                channel_1_input_file_post_gain = get_normalize_filename(channel_1_output_file, audio_rate)
+                normalize(channel_1_input_file_post_gain, channel_1_output_file, gain_adjust, 1, audio_rate)
 
-                with sf.SoundFile(
-                    input_file_post_gain,
-                    "r",
-                    samplerate=int(decode_options["audio_rate"]),
-                    **normalize_parameters,
-                ) as f, as_outputfile(output_file, audio_rate, False) as w:
-                    progressB = TimeProgressBar(f.frames, f.frames)
-                    done = False
-                    while not done:
-                        frames_read = f.buffer_read_into(buffer, dtype="float32")
-                        samples_read = frames_read * 2
-
-                        if samples_read < len(buffer):
-                            buffer = buffer[0:samples_read]
-                            done = True
-
-                        PostProcessor.normalize(gain_adjust, buffer, buffer)
-                        w.buffer_write(buffer, "float32")
-
-                        total_frames_read += frames_read
-                        progressB.print(total_frames_read, False)
-                print("")
-            finally:
-                os.remove(input_file_post_gain)
+                channel_2_output_file = get_dual_mono_filename(output_file, channel_2_suffix)
+                channel_2_input_file_post_gain = get_normalize_filename(channel_2_output_file, audio_rate)
+                normalize(channel_2_input_file_post_gain, channel_2_output_file, gain_adjust, 1, audio_rate)
+            else:
+                input_file_post_gain = get_normalize_filename(output_file, audio_rate)
+                normalize(input_file_post_gain, output_file, gain_adjust, 2, audio_rate)
 
     elapsed_time = datetime.now() - start_time
     dt_string = elapsed_time.total_seconds()
     print(f"\nDecode finished, seconds elapsed: {round(dt_string)}")
 
+def normalize(input_file_post_gain, output_file, gain_adjust, channels, audio_rate):
+    try:
+        total_frames_read = 0
+        buffer = np.empty(2**20, dtype=np.float32)
+
+        with sf.SoundFile(
+            input_file_post_gain,
+            "r",
+            samplerate=int(audio_rate),
+            channels=channels,
+            **normalize_parameters,
+        ) as f, as_outputfile(output_file, channels, audio_rate, False) as w:
+            progressB = TimeProgressBar(f.frames, f.frames)
+            done = False
+            while not done:
+                frames_read = f.buffer_read_into(buffer, dtype="float32")
+                samples_read = frames_read * 2
+
+                if samples_read < len(buffer):
+                    buffer = buffer[0:samples_read]
+                    done = True
+
+                PostProcessor.normalize(gain_adjust, buffer, buffer)
+                w.buffer_write(buffer, "float32")
+
+                total_frames_read += frames_read
+                progressB.print(total_frames_read, False)
+        print("")
+    finally:
+        os.remove(input_file_post_gain)
 
 def guess_bias(decoder, input_file, block_size, blocks_limits=10):
     print("Measuring carrier bias ... ")


### PR DESCRIPTION
### Changes
* Rename `--muting` to `--doc` and add options to control the level of dropout compensation.
  ```
    --doc                 Dropout compensation method (what happens when there is no hifi carrier) 
                          full 	copies audio from the other channel, or mutes if both channels have a dropout [default]
                          mute 	always mute dropouts
                          off 	disabled
  ```
  * `--doc full` -> (default) Use L channel audio for R dropout compensation and vice versa. Mute if there is also a dropout in the other channel
  * `--doc mute` -> Only mute the dropouts
  * `--doc off` -> No dropout compensation
* Add dual mono audio modes which saves each channel to a separate file.
   ```
   --audio_mode          Audio modes 
                          s 	Stereo (L, R) [VHS default]
                          ms 	Stereo (L+R, L-R) [8mm default]
                          d 	Dual Mono (L) (R) 
                          dms 	Dual Mono (L+R) (L-R) 
                          l 	Mono (L) 
                          r 	Mono (R) 
                          sum 	Mono Sum (L+R)
  ```
  * Useful for tapes that have two different audio tracks on each channel, i.e. over dubs
  * Channels are normalized independently
  * dropout compensation is limited `--doc mute` for dual audio, since the two channels do not relate to each other

### Dropout compensation example
<img width="1547" height="1061" alt="image" src="https://github.com/user-attachments/assets/5a5f7635-94ab-4765-8a4d-b7853563d5dd" />

* Top: New behavior, copies from other channel for dropout compensation
  <video src='https://github.com/user-attachments/assets/d68c5efc-261d-4945-b565-8395cfeebd6e'>
* Middle: Original behavior, mutes dropouts
  <video src='https://github.com/user-attachments/assets/1ae52d63-6103-46d4-9079-053176058a16'>
* Bottom: No dropout compensation
  <video src='https://github.com/user-attachments/assets/2e33dc5d-844a-40b8-aaae-9124f4325901'>