### PR TITLE
hifi-decode: better padding for last block

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -2600,10 +2600,7 @@ class HiFiDecode:
                     return
 
             buffer = DecoderSharedMemory(decoder_state)
-            if decoder_state.is_last_block:
-                raw_data = buffer.get_last_block()
-            else:
-                raw_data = buffer.get_block()
+            raw_data = buffer.get_block()
 
             audioL, audioR = decoder.block_decode(
                 raw_data,
@@ -2616,8 +2613,12 @@ class HiFiDecode:
             l_out = buffer.get_pre_left()
             r_out = buffer.get_pre_right()
 
-            # shift the audio left to remove the block overlap
-            overlap_to_trim = max(0, round((len(audioL) - decoder_state.block_audio_final_len) / 2))
+            if decoder_state.is_last_block:
+                # only copy the last part of the data
+                overlap_to_trim = len(audioL) - (decoder_state.block_audio_final_len + decoder_state.block_audio_final_overlap)
+            else:
+                # shift the audio left to remove the block overlap
+                overlap_to_trim = max(0, round((len(audioL) - decoder_state.block_audio_final_len) / 2))
 
             DecoderSharedMemory.copy_data_src_offset_float32(
                 audioL, l_out, overlap_to_trim, decoder_state.block_audio_final_len

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -32,6 +32,7 @@ from vhsdecode.hifi.utils import (
     DecoderState,
     PostProcessorSharedMemory,
     NumbaAudioArray,
+    PeakGain,
     BLOCK_DTYPE
 )
 
@@ -952,16 +953,14 @@ class PostProcessor:
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
         out_conn,
-        peak_gain_left,
-        peak_gain_right,
+        peak_gain
     ):
         self.final_audio_rate = decode_options["audio_rate"]
         self.enable_expander = decode_options["enable_expander"]
         self.enable_deemphasis = decode_options["enable_deemphasis"]
         self.spectral_nr_amount = decode_options["spectral_nr_amount"]
         self.format = decode_options["format"]
-        self.peak_gain_left = peak_gain_left
-        self.peak_gain_right = peak_gain_right
+        self.peak_gain = peak_gain
 
         # create processes and wire up queues
         #
@@ -1134,8 +1133,7 @@ class PostProcessor:
                 expander_worker_l_out_rx,
                 expander_worker_r_out_rx,
                 self.mix_to_stereo_worker_output,
-                self.peak_gain_left,
-                self.peak_gain_right,
+                self.peak_gain,
                 self.final_audio_rate,
             ),
         )
@@ -1399,7 +1397,7 @@ class PostProcessor:
 
     @staticmethod
     def mix_to_stereo_worker(
-        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain_left, peak_gain_right, sample_rate
+        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
     ):
         setproctitle(current_process().name)
         while True:
@@ -1435,12 +1433,12 @@ class PostProcessor:
                 l, r, stereo, sample_rate, decoder_state.block_num == 0
             )
 
-            with peak_gain_left.get_lock(), peak_gain_right.get_lock():
-                if peak_gain_left.value < max_gain_left:
-                    peak_gain_left.value = max_gain_left
+            with peak_gain.get_lock():
+                if peak_gain.left < max_gain_left:
+                    peak_gain.left = max_gain_left
 
-                if peak_gain_right.value < max_gain_right:
-                    peak_gain_right.value = max_gain_right
+                if peak_gain.right < max_gain_right:
+                    peak_gain.right = max_gain_right
 
             buffer.close()
             out_conn.send(decoder_state)
@@ -1836,8 +1834,7 @@ async def decode_parallel(
     blocks_enqueued = Value("d", 0)
     input_position = Value("d", 0)
     total_samples_decoded = Value("d", 0)
-    peak_gain_left = Value("d", 0)
-    peak_gain_right = Value("d", 0)
+    peak_gain = Value(PeakGain, 0.0, 0.0)
     stop_requested = Value("d", STOP_NOT_REQUESTED)
     start_time = datetime.now()
 
@@ -1906,8 +1903,7 @@ async def decode_parallel(
         shared_memory_idle_queue,
         blocks_enqueued,
         post_processor_out_tx_conn,
-        peak_gain_left,
-        peak_gain_right,
+        peak_gain,
     )
     atexit.register(post_processor.close)
 
@@ -2139,7 +2135,7 @@ async def decode_parallel(
         atexit.unregister(shared_memory.close)
         atexit.unregister(shared_memory.unlink)
     
-    with peak_gain_left.get_lock(), peak_gain_right.get_lock():
+    with peak_gain.get_lock():
         audio_rate = decode_options["audio_rate"]
 
         if (
@@ -2147,19 +2143,19 @@ async def decode_parallel(
             decode_options["mode"] == AUDIO_MODE_DUAL_MONO_MS
         ):
             # Normalize channels independently for dual mono
-            print(f"\nChannel 1: Peak gain is {(peak_gain_left.value * 100):.2f}%.", end="")
+            print(f"\nChannel 1: Peak gain is {(peak_gain.left * 100):.2f}%.", end="")
             if decode_options["normalize"]:
                 channel_1_output_file = get_dual_mono_filename(output_file, channel_1_suffix)
                 channel_1_input_file_post_gain = get_normalize_filename(channel_1_output_file, audio_rate)
-                normalize(channel_1_input_file_post_gain, channel_1_output_file, peak_gain_left.value, 1, audio_rate)
+                normalize(channel_1_input_file_post_gain, channel_1_output_file, peak_gain.left, 1, audio_rate)
 
-            print(f"\nChannel 2: Peak gain is {(peak_gain_right.value * 100):.2f}%.", end="")
+            print(f"\nChannel 2: Peak gain is {(peak_gain.right * 100):.2f}%.", end="")
             if decode_options["normalize"]:
                 channel_2_output_file = get_dual_mono_filename(output_file, channel_2_suffix)
                 channel_2_input_file_post_gain = get_normalize_filename(channel_2_output_file, audio_rate)
-                normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain_right.value, 1, audio_rate)
+                normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain.right, 1, audio_rate)
         else:
-            peak_gain_stereo = max(peak_gain_left.value, peak_gain_right.value)
+            peak_gain_stereo = max(peak_gain.left, peak_gain.right)
             print(f"\nPeak gain is {(peak_gain_stereo * 100):.2f}%.", end="")
             if decode_options["normalize"]:
                 input_file_post_gain = get_normalize_filename(output_file, audio_rate)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -32,6 +32,7 @@ from vhsdecode.hifi.utils import (
     DecoderState,
     PostProcessorSharedMemory,
     NumbaAudioArray,
+    BLOCK_DTYPE
 )
 
 import argparse
@@ -1434,12 +1435,11 @@ class PostProcessor:
                 l, r, stereo, sample_rate, decoder_state.block_num == 0
             )
 
-            if peak_gain_left.value < max_gain_left:
-                with peak_gain_left.get_lock():
+            with peak_gain_left.get_lock(), peak_gain_right.get_lock():
+                if peak_gain_left.value < max_gain_left:
                     peak_gain_left.value = max_gain_left
 
-            if peak_gain_right.value < max_gain_right:
-                with peak_gain_right.get_lock():
+                if peak_gain_right.value < max_gain_right:
                     peak_gain_right.value = max_gain_right
 
             buffer.close()
@@ -1941,6 +1941,7 @@ async def decode_parallel(
         input_position,
         exit_requested,
         previous_overlap,
+        previous_block
     ):
         buffer = DecoderSharedMemory(decoder_state)
         # read input data into the shared memory buffer
@@ -1989,6 +1990,23 @@ async def decode_parallel(
             DecoderSharedMemory.copy_data_int16(
                 block_data_read, block, start_overlap_end
             )
+        elif decoder_state.is_last_block and frames_read > 0:
+            # shift the read in data to (end - discard overlap)
+            block = buffer.get_block()
+
+            frames_read_with_overlap = frames_read + decoder_state.block_overlap
+            block_in_offset = len(block) - frames_read_with_overlap
+            block_data_read = block_in[0:frames_read].copy()
+            DecoderSharedMemory.copy_data_dst_offset_int16(
+                block_data_read, block, block_in_offset, frames_read
+            )
+
+            # copy in the entire previous block to use as overlap
+            # at the end of this decode worker, only the new audio will be returned
+            previous_block_in_offset = len(previous_block) - block_in_offset
+            DecoderSharedMemory.copy_data_src_offset_int16(
+                previous_block, block, previous_block_in_offset, block_in_offset
+            )
         else:
             # copy the overlapping data from the previous read
             block_in_overlap = buffer.get_block_in_start_overlap()
@@ -1996,11 +2014,18 @@ async def decode_parallel(
                 previous_overlap, block_in_overlap, len(block_in_overlap)
             )
 
-        if not decoder_state.is_last_block:
             # copy the the current overlap to use in the next iteration
             current_overlap = buffer.get_block_in_end_overlap()
             DecoderSharedMemory.copy_data_int16(
                 current_overlap, previous_overlap, len(current_overlap)
+            )
+
+        if not decoder_state.is_last_block:
+            # save the full block for the next iteration, including previous overlap
+            # will be used if the next block is the last block
+            block = buffer.get_block()
+            DecoderSharedMemory.copy_data_int16(
+                block, previous_block, len(previous_block)
             )
 
         buffer.close()
@@ -2039,6 +2064,7 @@ async def decode_parallel(
     with as_soundfile(input_file) as f:
         loop = asyncio.get_event_loop()
         previous_overlap = np.empty(0)
+        previous_block = np.empty(block_size, dtype=BLOCK_DTYPE)
         progressB = TimeProgressBar(f.frames, f.frames)
         block_num = 0
 
@@ -2073,6 +2099,7 @@ async def decode_parallel(
                 input_position,
                 exit_requested,
                 previous_overlap,
+                previous_block
             )
             
             with blocks_enqueued.get_lock():

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -286,16 +286,6 @@ class DecoderSharedMemory:
             buffer=self.buf,
             order="C"
         )
-    
-    # block data only including the data that was read
-    def get_last_block(self) -> np.array:
-        return np.ndarray(
-            self.block_start_overlap_len + self.block_frames_read,
-            dtype=self.block_dtype,
-            offset=self.block_start_overlap_offset,
-            buffer=self.buf,
-            order="C"
-        )
 
     # block starts after first overlap, goes until the end of the last overlap
     # first part of the block is copied from the previous read
@@ -390,6 +380,24 @@ class DecoderSharedMemory:
     ):
         for i in range(length):
             dst[i + dst_offset] = src[i]
+
+    @staticmethod
+    @njit(
+        numba.types.void(
+            numba.types.Array(numba.int16, 1, "C"),
+            numba.types.Array(numba.int16, 1, "C"),
+            numba.types.int64,
+            numba.types.int64,
+        ),
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def copy_data_src_offset_int16(
+        src: np.array, dst: np.array, src_offset: int, length: int
+    ):
+        for i in range(length):
+            dst[i] = src[i + src_offset]
 
     @staticmethod
     @njit(

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -8,6 +8,7 @@ import string
 from random import SystemRandom
 
 from cProfile import Profile
+import ctypes
 from pstats import SortKey, Stats
 
 BLOCK_DTYPE = np.int16
@@ -432,6 +433,11 @@ class DecoderSharedMemory:
         for i in range(length):
             dst[i] = src[i + src_offset]
 
+class PeakGain(ctypes.Structure):
+    _fields_ = [
+        ("left", ctypes.c_float),
+        ("right", ctypes.c_float),
+    ]
 
 def profile(function) -> int:
     def run_profiler(*args, **kwarg):


### PR DESCRIPTION
Fixes the scenario where the last block is too small to fit within the overlap logic. Instead, this forces all blocks to be the same size, and prepends the last block with the previous block's data if it's smaller than the block size.