### PR TITLE
add option to smooth out wow brightness compensation

### DIFF
--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -83,6 +83,16 @@ def main(args=None):
         default=False,
         help="Additionally use right hand side of hsync for line start detection. Improves accuracy on tape sources but might cause issues on high bandwidth stable ones",
     )
+    parser.add_argument(
+        "--wow_adjust_smoothing_lines",
+        type=float,
+        default=0,
+        help=(
+            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
+            "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\nSet to `0` to disable smoothing (only recommended for low noise video)",
+        )
+    )
 
     args = parser.parse_args(args)
     try:
@@ -159,6 +169,7 @@ def main(args=None):
         # level_adjust=args.level_adjust,
         rf_options=rf_options,
         extra_options=extra_options,
+        level_smoothing_lines=args.wow_adjust_smoothing_lines
     )
 
     signal.signal(signal.SIGINT, original_sigint_handler)

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -526,6 +526,7 @@ class CVBSDecode(ldd.LDdecode):
         level_adjust=0.2,
         rf_options={},
         extra_options={},
+        level_smoothing_lines=0,
     ):
         # monkey patch init with a dummy to prevent calling set_start_method twice on macos
         # and not create extra threads.
@@ -572,6 +573,8 @@ class CVBSDecode(ldd.LDdecode):
         self.demodcache = ldd.DemodCache(
             self.rf, self.infile, self.freader, None, num_worker_threads=self.numthreads
         )
+
+        self.level_smoothing_lines = level_smoothing_lines
 
     # Override to avoid NaN in JSON.
     def calcsnr(self, f, snrslice):

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -1459,7 +1459,8 @@ class Field:
         initphase=False,
         fields_written=0,
         readloc=0,
-        use_threads=True
+        use_threads=True,
+        level_smoothing_lines=0
     ):
         self.rawdata = decode["input"]
         self.data = decode
@@ -1493,6 +1494,8 @@ class Field:
         self.linecount = None
 
         self.use_threads = use_threads
+
+        self.level_smoothing_lines = level_smoothing_lines
 
     @profile
     def process(self):
@@ -2559,6 +2562,7 @@ class Field:
             wowfactors,
             self.lineoffset,
             outwidth,
+            level_smoothing_lines=self.level_smoothing_lines
         )
 
         if self.rf.decode_digital_audio:
@@ -3692,6 +3696,7 @@ class LDdecode:
             initphase=initphase,
             fields_written=self.fields_written,
             readloc=rawdecode["startloc"],
+            level_smoothing_lines=self.level_smoothing_lines
         )
 
         # set an object-level variable to make notebook debugging easier

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -130,10 +130,11 @@ def main(args=None, use_gui=False):
     luma_group.add_argument(
         "--wow_adjust_smoothing_lines",
         type=float,
-        default=30,
+        default=None,
         help=(
             "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
             "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\nDefault is (video system lines / 2) i.e. NTSC=525/2, PAL=625/2, etc.",
             "\nSet to `0` to disable smoothing (only recommended for low noise video)",
         )
     )

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -128,6 +128,16 @@ def main(args=None, use_gui=False):
         ),
     )
     luma_group.add_argument(
+        "--wow_adjust_smoothing_lines",
+        type=float,
+        default=6,
+        help=(
+            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
+            "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\nSet to `0` to disable smoothing (only recommended for low noise video)",
+        )
+    )
+    luma_group.add_argument(
         "--nodd",
         "--no_diff_demod",
         dest="disable_diff_demod",
@@ -533,7 +543,8 @@ def main(args=None, use_gui=False):
         rf_options=rf_options,
         extra_options=extra_options,
         debug_plot=debug_plot,
-        field_order_action=args.field_order_action
+        field_order_action=args.field_order_action,
+        level_smoothing_lines=args.wow_adjust_smoothing_lines
     )
 
     if check_debug():

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -130,7 +130,7 @@ def main(args=None, use_gui=False):
     luma_group.add_argument(
         "--wow_adjust_smoothing_lines",
         type=float,
-        default=6,
+        default=30,
         help=(
             "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
             "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -91,6 +91,7 @@ class VHSDecode(ldd.LDdecode):
         extra_options={},
         debug_plot=None,
         field_order_action="detect",
+        level_smoothing_lines=0,
     ):
 
         # monkey patch init with a dummy to prevent calling set_start_method twice on macos
@@ -170,6 +171,8 @@ class VHSDecode(ldd.LDdecode):
             # Since typec usually lacks vsync set this to none to avoid dropping fields.
             self.field_order_action = "none"
         self.duplicate_prev_field = True
+
+        self.level_smoothing_lines = level_smoothing_lines
 
         # Needs to be overridden since this is overwritten for 405-line.
         # self.output_lines = (self.rf.SysParams["frame_lines"] // 2) + 1

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -91,7 +91,7 @@ class VHSDecode(ldd.LDdecode):
         extra_options={},
         debug_plot=None,
         field_order_action="detect",
-        level_smoothing_lines=0,
+        level_smoothing_lines=None,
     ):
 
         # monkey patch init with a dummy to prevent calling set_start_method twice on macos
@@ -172,7 +172,7 @@ class VHSDecode(ldd.LDdecode):
             self.field_order_action = "none"
         self.duplicate_prev_field = True
 
-        self.level_smoothing_lines = level_smoothing_lines
+        self.level_smoothing_lines = level_smoothing_lines if level_smoothing_lines is not None else self.rf.SysParams["frame_lines"] / 2
 
         # Needs to be overridden since this is overwritten for 405-line.
         # self.output_lines = (self.rf.SysParams["frame_lines"] // 2) + 1


### PR DESCRIPTION
* Adds `--wow_adjust_smoothing_lines` which allows the brightness adjustment for wow to be smoothed out. This fixes the horizontal brightness striping that occurs on noisy tapes, especially EP.
  * This can be set to `--wow_adjust_smoothing_lines 0` to disable the smoothing and use the original wow brightness compensation.
  * Defaults to `--wow_adjust_smoothing_lines 6` so that brightness adjustment is averaged over a rolling window of 6 lines

ld-decode changes added here: https://github.com/happycube/ld-decode/pull/1014

https://imgsli.com/NDQ3MjQx

### `--wow_adjust_smoothing_lines 6` (new default)
* brightness bars are no longer visible, since the wow calculation is being smoothed to remove noise
<img width="760" height="525" alt="frame_ntsc_source_ar43_1_test_mean tbc" src="https://github.com/user-attachments/assets/363c0ee7-33a4-466c-8a4a-1684699ce5bc" />

### `--wow_adjust_smoothing_lines 0` (i.e. behavior before this fix)
* brightness bars show up since wow calculation is noisy due to noisy video
<img width="760" height="525" alt="frame_ntsc_source_ar43_1_test_none tbc" src="https://github.com/user-attachments/assets/90072641-8970-4245-a837-1a34054675ad" />
