### PR TITLE
add `--detect_chroma_track_phase`

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -110,7 +110,72 @@ def comb_c_ntsc(data, line_len):
         ) / 4
     return data
 
+def get_track_transition(
+    chroma,
+    first_visible_line,
+    lineoffset,
+    linesout,
+    outwidth,
+    phase_rotation_offset,
+    chroma_heterodyne,
+    starting_phase,
+    burstarea,
+    chroma_filter,
+):
+    # *****************************************************
+    # Gather the phase differences between each color burst
+    # *****************************************************
+    phase = starting_phase
+    previous_burst = None
+    current_burst = None
+    phase_differences = []
 
+    for linenumber in range(lineoffset + first_visible_line, linesout + lineoffset):
+        burst_start = (linenumber - lineoffset) * outwidth + burstarea[0]
+        burst_end = burst_start + burstarea[1]
+
+        heterodyne = chroma_heterodyne[phase][burst_start:burst_end]
+        current_burst = heterodyne * chroma[burst_start:burst_end]
+
+        # filter out noise so only the color burst is present
+        current_burst = sosfiltfilt_rust(chroma_filter, current_burst)
+        current_burst_norm = np.linalg.norm(current_burst)
+
+        if previous_burst is not None:
+            phase_difference = np.dot(previous_burst, current_burst) / (previous_burst_norm * current_burst_norm)
+            phase_differences.append((linenumber - 1, phase_difference))
+
+        previous_burst = current_burst
+        previous_burst_norm = current_burst_norm
+
+        phase = (phase + phase_rotation_offset) % 4
+
+    # *******************************************
+    # Find the transition point where color burst
+    # phase transition pattern changes
+    # *******************************************
+    threshold = 0.8 # +- difference
+    track_transition_candidates = []
+    
+    prev_diff = phase_differences[0][1]
+    for (linenumber, cur_diff) in phase_differences:
+        if (
+            (prev_diff < -threshold and cur_diff > threshold) or
+            (cur_diff < -threshold and prev_diff > threshold)
+        ):
+            track_transition_candidates.append(
+                (linenumber, abs(prev_diff-cur_diff))
+            )
+        prev_diff = cur_diff
+
+    if len(track_transition_candidates) == 0:
+        return None
+
+    best_candidate = max(track_transition_candidates, key=lambda x: x[1])
+    transition_line, transition_diff = best_candidate
+    
+    return transition_line
+    
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
     chroma,
@@ -120,6 +185,8 @@ def upconvert_chroma(
     chroma_heterodyne,
     phase_rotation,
     starting_phase,
+    track_transition_line=None,
+    chroma_rotation=None,
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
     if phase_rotation == 0:
@@ -149,7 +216,12 @@ def upconvert_chroma(
 
             uphet[linestart:lineend] = line
 
+            if linenumber == track_transition_line and chroma_rotation is not None:
+                # switch the track for the next line
+                phase_rotation = chroma_rotation[1] if phase_rotation == chroma_rotation[0] else chroma_rotation[0]
+
             phase = (phase + phase_rotation) % 4
+
     return uphet
 
 
@@ -204,6 +276,7 @@ def process_chroma(
     disable_tracking_cafc=False,
     chroma_rotation=None,
     do_chroma_deemphasis=False,
+    detect_chroma_track_phase=True,
 ):
     # Run TBC/downscale on chroma (if new field, else uses cache)
     # Cached if chroma process is run multiple times on one field due to track detection.
@@ -275,18 +348,40 @@ def process_chroma(
         else:
             phase_rotation = chroma_rotation[1]
 
+    chroma_heterodyne = (
+        field.rf.chroma_afc.getChromaHet()
+        if (field.rf.do_cafc and not disable_tracking_cafc)
+        else field.rf.chroma_heterodyne
+    )
+
+    starting_phase = 0 # should this persist on the field so phase order doesn't need to be re-detected?
+
+    if detect_chroma_track_phase:
+        transition_line = get_track_transition(
+            chroma,
+            0, # TODO: start after the vsync?
+            lineoffset,
+            linesout,
+            outwidth,
+            phase_rotation,
+            chroma_heterodyne,
+            starting_phase, 
+            burstarea,
+            field.rf.Filters["FChromaFinal"],
+        )
+    else:
+        transition_line = None
+
     uphet = upconvert_chroma(
         chroma,
         lineoffset,
         linesout,
         outwidth,
-        (
-            field.rf.chroma_afc.getChromaHet()
-            if (field.rf.do_cafc and not disable_tracking_cafc)
-            else field.rf.chroma_heterodyne
-        ),
+        chroma_heterodyne,
         phase_rotation,
         starting_phase,
+        transition_line,
+        chroma_rotation,
     )
 
     # Filter out unwanted frequencies from the final chroma signal.

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -276,7 +276,7 @@ def process_chroma(
     disable_tracking_cafc=False,
     chroma_rotation=None,
     do_chroma_deemphasis=False,
-    detect_chroma_track_phase=True,
+    detect_chroma_track_phase=False,
 ):
     # Run TBC/downscale on chroma (if new field, else uses cache)
     # Cached if chroma process is run multiple times on one field due to track detection.
@@ -359,7 +359,7 @@ def process_chroma(
     if detect_chroma_track_phase:
         transition_line = get_track_transition(
             chroma,
-            0, # TODO: start after the vsync?
+            16, # TODO: start after the vbi (system dependent)
             lineoffset,
             linesout,
             outwidth,
@@ -468,7 +468,7 @@ def decode_chroma_simple(field):
     return chroma_to_u16(uphet)
 
 
-def decode_chroma(field, chroma_rotation=None, do_chroma_deemphasis=False):
+def decode_chroma(field, chroma_rotation=None, do_chroma_deemphasis=False, detect_chroma_track_phase=False):
     """Do track detection if needed and upconvert the chroma signal"""
     rf = field.rf
     field.chroma_tbc_buffer = None
@@ -503,6 +503,7 @@ def decode_chroma(field, chroma_rotation=None, do_chroma_deemphasis=False):
         disable_tracking_cafc=False,
         chroma_rotation=chroma_rotation,
         do_chroma_deemphasis=do_chroma_deemphasis,
+        detect_chroma_track_phase=detect_chroma_track_phase
     )
     field.uphet_temp = uphet
     # Release to avoid keeping this im memory - should do this in a cleaner manner.

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -110,13 +110,33 @@ def comb_c_ntsc(data, line_len):
         ) / 4
     return data
 
-def get_track_transition(
+def get_upconverted_burst(
     chroma,
-    first_visible_line,
+    phase,
+    linenumber,
+    lineoffset,
+    outwidth,
+    burstarea,
+    chroma_heterodyne,
+    chroma_filter,
+):
+    burst_start = (linenumber - lineoffset) * outwidth + burstarea[0]
+    burst_end = burst_start + burstarea[1]
+
+    heterodyne = chroma_heterodyne[phase][burst_start:burst_end]
+    burst = heterodyne * chroma[burst_start:burst_end]
+
+    # filter out noise so only the color burst is present
+    return sosfiltfilt_rust(chroma_filter, burst)
+
+def get_phase_rotation_sequence(
+    chroma,
+    rotation_check_start_line,
     lineoffset,
     linesout,
     outwidth,
     phase_rotation_offset,
+    chroma_rotation,
     chroma_heterodyne,
     starting_phase,
     burstarea,
@@ -124,57 +144,36 @@ def get_track_transition(
 ):
     # *****************************************************
     # Gather the phase differences between each color burst
+    # Color burst alternates phase between lines in a field
     # *****************************************************
     phase = starting_phase
-    previous_burst = None
-    current_burst = None
-    phase_differences = []
+    phase_correlation_threshold = 0.5
+    phase_rotations = []
+    phase_rotations.append(phase)
 
-    for linenumber in range(lineoffset + first_visible_line, linesout + lineoffset):
-        burst_start = (linenumber - lineoffset) * outwidth + burstarea[0]
-        burst_end = burst_start + burstarea[1]
+    for linenumber in range(lineoffset, linesout + lineoffset - 1):
+        next_phase = (phase + phase_rotation_offset) % 4
 
-        heterodyne = chroma_heterodyne[phase][burst_start:burst_end]
-        current_burst = heterodyne * chroma[burst_start:burst_end]
+        if linenumber >= rotation_check_start_line:
+            current_burst = get_upconverted_burst(chroma, phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
+            current_burst_norm = np.linalg.norm(current_burst)
 
-        # filter out noise so only the color burst is present
-        current_burst = sosfiltfilt_rust(chroma_filter, current_burst)
-        current_burst_norm = np.linalg.norm(current_burst)
+            next_burst = get_upconverted_burst(chroma, next_phase, linenumber + 1, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
+            next_burst_norm = np.linalg.norm(current_burst)
 
-        if previous_burst is not None:
-            phase_difference = np.dot(previous_burst, current_burst) / (previous_burst_norm * current_burst_norm)
-            phase_differences.append((linenumber - 1, phase_difference))
+            phase_correlation = np.dot(current_burst, next_burst) / (current_burst_norm * next_burst_norm)
 
-        previous_burst = current_burst
-        previous_burst_norm = current_burst_norm
+            if phase_correlation > phase_correlation_threshold:
+                # positive correlation -> in phase
+                # negative correlation -> out of phase
+                # burst is more in phase than out of phase, flip rotation so it remains out of phase
+                phase_rotation_offset = chroma_rotation[1] if phase_rotation_offset == chroma_rotation[0] else chroma_rotation[0]
+                next_phase = (phase + phase_rotation_offset) % 4
 
-        phase = (phase + phase_rotation_offset) % 4
+        phase_rotations.append(next_phase)
+        phase = next_phase
 
-    # *******************************************
-    # Find the transition point where color burst
-    # phase transition pattern changes
-    # *******************************************
-    threshold = 0.8 # +- difference
-    track_transition_candidates = []
-    
-    prev_diff = phase_differences[0][1]
-    for (linenumber, cur_diff) in phase_differences:
-        if (
-            (prev_diff < -threshold and cur_diff > threshold) or
-            (cur_diff < -threshold and prev_diff > threshold)
-        ):
-            track_transition_candidates.append(
-                (linenumber, abs(prev_diff-cur_diff))
-            )
-        prev_diff = cur_diff
-
-    if len(track_transition_candidates) == 0:
-        return None
-
-    best_candidate = max(track_transition_candidates, key=lambda x: x[1])
-    transition_line, transition_diff = best_candidate
-    
-    return transition_line
+    return phase_rotations
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -185,8 +184,7 @@ def upconvert_chroma(
     chroma_heterodyne,
     phase_rotation,
     starting_phase,
-    track_transition_line=None,
-    chroma_rotation=None,
+    phase_rotation_sequence=None
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
     if phase_rotation == 0:
@@ -204,9 +202,15 @@ def upconvert_chroma(
         #        rotation = [(0,0),(90,-270),(180,-180),(270,-90)]
         # Track 2 - needs phase rotation or the chroma will be inverted.
         phase = starting_phase
+        phase_index = 0
         for linenumber in range(lineoffset, linesout + lineoffset):
             linestart = (linenumber - lineoffset) * outwidth
             lineend = linestart + outwidth
+            
+            if phase_rotation_sequence is not None:
+                # override calculated phase rotation with the passed in rotation
+                phase = phase_rotation_sequence[phase_index]
+                phase_index += 1
 
             heterodyne = chroma_heterodyne[phase][linestart:lineend]
 
@@ -215,11 +219,6 @@ def upconvert_chroma(
             line = heterodyne * c
 
             uphet[linestart:lineend] = line
-
-            if linenumber == track_transition_line and chroma_rotation is not None:
-                # switch the track for the next line
-                phase_rotation = chroma_rotation[1] if phase_rotation == chroma_rotation[0] else chroma_rotation[0]
-
             phase = (phase + phase_rotation) % 4
 
     return uphet
@@ -356,21 +355,22 @@ def process_chroma(
 
     starting_phase = 0 # should this persist on the field so phase order doesn't need to be re-detected?
 
-    if detect_chroma_track_phase:
-        transition_line = get_track_transition(
+    if detect_chroma_track_phase and chroma_rotation is not None:
+        phase_rotation_sequence = get_phase_rotation_sequence(
             chroma,
             16, # TODO: start after the vbi (system dependent)
             lineoffset,
             linesout,
             outwidth,
             phase_rotation,
+            chroma_rotation,
             chroma_heterodyne,
             starting_phase, 
             burstarea,
             field.rf.Filters["FChromaFinal"],
         )
     else:
-        transition_line = None
+        phase_rotation_sequence = None
 
     uphet = upconvert_chroma(
         chroma,
@@ -380,8 +380,7 @@ def process_chroma(
         chroma_heterodyne,
         phase_rotation,
         starting_phase,
-        transition_line,
-        chroma_rotation,
+        phase_rotation_sequence,
     )
 
     # Filter out unwanted frequencies from the final chroma signal.

--- a/vhsdecode/compute_video_filters.py
+++ b/vhsdecode/compute_video_filters.py
@@ -163,7 +163,7 @@ def gen_nonlinear_bandpass_params(rf_params, nyquist_hz, block_len):
 
 
 def gen_nonlinear_amplitude_lpf(corner_freq, nyquist_hz, order=1):
-    return sps.butter(1, [corner_freq / nyquist_hz], btype="lowpass", output="sos")
+    return sps.butter(1, corner_freq / nyquist_hz, btype="lowpass", output="sos")
 
 
 def gen_nonlinear_bandpass(upper_freq, lower_freq, order, nyquist_hz, block_len):
@@ -187,7 +187,7 @@ def gen_nonlinear_bandpass(upper_freq, lower_freq, order, nyquist_hz, block_len)
         nl_highpass_filter = filtfft(
             sps.butter(
                 order,
-                [lower_freq / nyquist_hz],
+                lower_freq / nyquist_hz,
                 btype="highpass",
             ),
             block_len,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1853,7 +1853,7 @@ class FieldPALVHS(FieldPALShared):
         dsout, dsaudio, dsefm = super(FieldPALVHS, self).downscale(
             final=final, *args, **kwargs
         )
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"])
+        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -1895,7 +1895,7 @@ class FieldPALBetamax(FieldPALShared):
         )
 
         dschroma = decode_chroma(
-            self, chroma_rotation=self.rf.DecoderParams["chroma_rotation"]
+            self, chroma_rotation=self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
 
         return (dsout, dschroma), dsaudio, dsefm
@@ -1918,6 +1918,7 @@ class FieldPALVideo8(FieldPALShared):
             self,
             chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
             do_chroma_deemphasis=True,
+            detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
 
         return (dsout, dschroma), dsaudio, dsefm
@@ -1948,7 +1949,7 @@ class FieldNTSCVHS(FieldNTSCShared):
             final=final, *args, **kwargs
         )
 
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"])
+        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
 
         self.fieldPhaseID = get_field_phase_id(self)
 
@@ -1974,7 +1975,7 @@ class FieldNTSCBetamax(FieldNTSCShared):
             final=final, *args, **kwargs
         )
 
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"])
+        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -2030,7 +2031,7 @@ class FieldNTSCVideo8(FieldNTSCShared):
         )
 
         dschroma = decode_chroma(
-            self, self.rf.DecoderParams["chroma_rotation"], do_chroma_deemphasis=True
+            self, self.rf.DecoderParams["chroma_rotation"], do_chroma_deemphasis=True, detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
 
         self.fieldPhaseID = get_field_phase_id(self)

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -230,6 +230,14 @@ def main(args=None, use_gui=False):
         help="If set to 0 or 1, force use of video track phase. (No effect on U-matic)",
     )
     chroma_group.add_argument(
+        "-dctp",
+        "--detect_chroma_track_phase",
+        dest="detect_chroma_track_phase",
+        action="store_true",
+        default=False,
+        help="Detect and correct chroma phase consistency for each track / field. Corrects chroma artifacts around head-switching area for VHS. (Experimental feature)",
+    )
+    chroma_group.add_argument(
         "--recheck_phase",
         dest="recheck_phase",
         action="store_true",
@@ -506,6 +514,7 @@ def main(args=None, use_gui=False):
     rf_options["export_raw_tbc"] = args.export_raw_tbc
     rf_options["tape_speed"] = args.tape_speed
     rf_options["ire0_adjust"] = args.ire0_adjust
+    rf_options["detect_chroma_track_phase"] = args.detect_chroma_track_phase
     rf_options["gnrc_afe"] = args.gnrc_afe
 
     extra_options = get_extra_options(args, not use_gui)

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -697,6 +697,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "ire0_adjust",
                 "gnrc_afe",
                 "relaxed_line0",
+                "detect_chroma_track_phase"
             ],
         )(
             self.iretohz(100) * 2,
@@ -732,6 +733,7 @@ class VHSRFDecode(ldd.RFDecode):
             ire0_adjust,
             rf_options.get("gnrc_afe", False),
             rf_options.get("relaxed_line0", False),
+            rf_options.get("detect_chroma_track_phase", False)
         )
 
         # As agc can alter these sysParams values, store a copy to then

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -999,7 +999,7 @@ class VHSRFDecode(ldd.RFDecode):
             y_fm_lowpass = sosfiltfft(
                 sps.butter(
                     DP["video_lpf_extra_order"],
-                    [DP["video_lpf_extra"] / self.freq_hz_half],
+                    DP["video_lpf_extra"] / self.freq_hz_half,
                     btype="lowpass",
                     output="sos",
                 ),
@@ -1009,7 +1009,7 @@ class VHSRFDecode(ldd.RFDecode):
             y_fm_highpass = sosfiltfft(
                 sps.butter(
                     DP["video_hpf_extra_order"],
-                    [DP["video_hpf_extra"] / self.freq_hz_half],
+                    DP["video_hpf_extra"] / self.freq_hz_half,
                     btype="highpass",
                     output="sos",
                 ),
@@ -1122,7 +1122,7 @@ class VHSRFDecode(ldd.RFDecode):
         # sections and thus do the filtering in sngle precision.
         # On higher order filters this is not viable as it tends to alter the filter too much.
         self.Filters["FEnvPost"] = sps.butter(
-            1, [700000 / self.freq_hz_half], btype="lowpass", output="sos"
+            1, 700000 / self.freq_hz_half, btype="lowpass", output="sos"
         )
 
         self.Filters["NLAmplitudeLPF"] = gen_nonlinear_amplitude_lpf(
@@ -1145,9 +1145,7 @@ class VHSRFDecode(ldd.RFDecode):
 
         # SF["YNRHighPass"] = sps.butter(
         #     1,
-        #     [
-        #         (0.5e6) / self.freq_hz_half,
-        #     ],
+        #     (0.5e6) / self.freq_hz_half,
         #     btype="highpass",
         #     output="sos",
         # )


### PR DESCRIPTION
* Add `--detect_chroma_track_phase` option that corrects chroma artifacts around the head switching point.
  * These artifacts are caused when the recording VCR switches the chroma phase offset to the next track's configuration too soon (within the visible video). The change in chroma phase shows up as rainbowing at the bottom of the picture. This feature checks the consistency of the color burst phase, and if it is changed +- ~90 degrees within the visible picture, and flips the chroma phase configuration to the next track.

## with `--detect_chroma_track_phase`
<img width="760" height="525" alt="chroma_issue_yc_auto_fixed" src="https://github.com/user-attachments/assets/be7aa8ea-1222-408e-87af-91c73acd23e4" />

## without `--detect_chroma_track_phase`
  <img width="760" height="525" alt="chroma_issue_yc" src="https://github.com/user-attachments/assets/c1e04b03-a7c7-40e1-8e84-ba4bb69b4705" />
