### PR TITLE
NTSC phase detection (allows 3D decoder to be used)

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -197,33 +197,35 @@ def get_phase_rotation_sequence(
 
         phase_rotations.append(current_phase)
 
-    # detect NTSC starting phase
     if color_system == "NTSC":
-        # detect phase quadrant of color bursts
-        quadrant = detect_ntsc_color_burst_phase(bursts, burst_sine, burst_cosine)
+        # detect the correct starting phase using the expected phase quadrant of the color bursts
+        quadrant, burst_detected = detect_ntsc_color_burst_phase(bursts, burst_sine, burst_cosine)
 
         # TODO: mathematical way to do this?
         field_phase_id, ntsc_phase_rotation = {
             # field 1
-            (True,  3): (1, 3), # if isFirstField == True  and quadrant == 3: field_phase_id = 1; ntsc_phase_rotation = 3
-            (False, 2): (4, 2), # if isFirstField == False and quadrant == 2: field_phase_id = 4; ntsc_phase_rotation = 2
+            (True,  3): (1, 3),
+            (False, 2): (4, 2),
             # field 2
-            (True,  2): (3, 0), # if isFirstField == True  and quadrant == 2: field_phase_id = 3; ntsc_phase_rotation = 0
-            (False, 3): (2, 1), # if isFirstField == False and quadrant == 3: field_phase_id = 2; ntsc_phase_rotation = 1
+            (True,  2): (3, 0),
+            (False, 3): (2, 1),
             # field 3
-            (True,  1): (1, 1), # if isFirstField == True  and quadrant == 1: field_phase_id = 1; ntsc_phase_rotation = 1
-            (False, 0): (4, 0), # if isFirstField == False and quadrant == 0: field_phase_id = 4; ntsc_phase_rotation = 0
+            (True,  1): (1, 1),
+            (False, 0): (4, 0),
             # field 4
-            (True,  0): (3, 2), # if isFirstField == True  and quadrant == 0: field_phase_id = 3; ntsc_phase_rotation = 2
-            (False, 1): (2, 3), # if isFirstField == False and quadrant == 1: field_phase_id = 2; ntsc_phase_rotation = 3
+            (True,  0): (3, 2),
+            (False, 1): (2, 3),
         }[is_first_field, quadrant]
 
-        # fix the starting phase
+        # adjust the starting phase
         if ntsc_phase_rotation != 0:
             for i in range(0, len(phase_rotations)):
                 phase_rotations[i] = (phase_rotations[i] + ntsc_phase_rotation) % 4
+    else:
+        field_phase_id = None
+        burst_detected = None
 
-    return phase_rotations, field_phase_id
+    return phase_rotations, field_phase_id, burst_detected
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -232,36 +234,21 @@ def upconvert_chroma(
     linesout,
     outwidth,
     chroma_heterodyne,
-    phase_rotation,
     phase_rotation_sequence
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
-    if phase_rotation == 0:
-        # Track 1 - for PAL, phase doesn't change.
-        start = lineoffset
-        end = lineoffset + (outwidth * linesout)
-        heterodyne = chroma_heterodyne[0][start:end]
-        c = chroma[start:end]
-        # Mixing the chroma signal with a signal at the frequency of colour under + fsc gives us
-        # a signal with frequencies at the difference and sum, the difference is what we want as
-        # it's at the right frequency.
-        uphet[start:end] = heterodyne * c
+    phase_index = 0
 
-    else:
-        #        rotation = [(0,0),(90,-270),(180,-180),(270,-90)]
-        # Track 2 - needs phase rotation or the chroma will be inverted.
-        phase_index = 0
+    for linenumber in range(lineoffset, linesout + lineoffset):
+        current_phase = phase_rotation_sequence[phase_index]
+        phase_index += 1
 
-        for linenumber in range(lineoffset, linesout + lineoffset):
-            linestart = (linenumber - lineoffset) * outwidth
-            lineend = linestart + outwidth
-            c = chroma[linestart:lineend]
+        linestart = (linenumber - lineoffset) * outwidth
+        lineend = linestart + outwidth
 
-            current_phase = phase_rotation_sequence[phase_index]
-            phase_index += 1
-
-            heterodyne = chroma_heterodyne[current_phase][linestart:lineend]
-            uphet[linestart:lineend] = c * heterodyne
+        heterodyne = chroma_heterodyne[current_phase][linestart:lineend]
+        c = chroma[linestart:lineend]
+        uphet[linestart:lineend] = c * heterodyne
 
     return uphet
 
@@ -395,7 +382,7 @@ def process_chroma(
         else field.rf.chroma_heterodyne
     )
 
-    phase_rotation_sequence, field_phase_id = get_phase_rotation_sequence(
+    phase_rotation_sequence, field_phase_id, burst_detected = get_phase_rotation_sequence(
         chroma,
         lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
         lineoffset,
@@ -415,6 +402,9 @@ def process_chroma(
 
     if field.rf.color_system == "NTSC":
         field.fieldPhaseID = field_phase_id
+        # TODO: possibly use this to enable a color killer
+        # if not burst_detected:
+        #     ldd.logger.info("Color burst was not detected.")
 
     uphet = upconvert_chroma(
         chroma,
@@ -422,7 +412,6 @@ def process_chroma(
         linesout,
         outwidth,
         chroma_heterodyne,
-        phase_rotation,
         phase_rotation_sequence,
     )
 
@@ -708,7 +697,10 @@ def detect_burst_pal_line(
 
 @njit(fastmath=True, cache=True, nogil=True)
 def detect_ntsc_color_burst_phase(
-    bursts, sine_wave, cosine_wave
+    bursts,
+    sine_wave,
+    cosine_wave,
+    coherence_threshold=0.3
 ):
     """ Detects the phase rotation quadrant using the color burst phase"""
     # Ignore the first and last 16 lines of the field.
@@ -725,9 +717,15 @@ def detect_ntsc_color_burst_phase(
             I += burst[i] * cosine_wave[i + burst_start]
             Q += burst[i] * sine_wave[i + burst_start]
 
-        magnitude = np.hypot(I, Q) + 1e-12
-        I_total += I / magnitude
-        Q_total += Q / magnitude
+        magnitude = np.hypot(I, Q)
+        if magnitude > 0:
+            I_total += I / magnitude
+            Q_total += Q / magnitude
+
+    # Check that burst phase is consistent
+    # If phase is not consistent, then likely there is no color burst present
+    coherence = np.hypot(I_total, Q_total) / len(bursts)
+    burst_detected = coherence >= coherence_threshold        
 
     # Global field phase
     avg_phase = np.arctan2(Q_total, I_total)
@@ -736,7 +734,7 @@ def detect_ntsc_color_burst_phase(
     # Quantize to nearest 90 degrees
     quadrant = int(np.round(avg_phase_deg / 90)) % 4
 
-    return quadrant
+    return quadrant, burst_detected
 
 
 # Phase comprensation stuff - needs rework.

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -365,7 +365,7 @@ def process_chroma(
 
     if track_phase is not None:
         if chroma_rotation:
-            if field.isFirstField:
+            if field.field_number % 2 == track_phase:
                 phase_rotation = chroma_rotation[0]
             else:
                 phase_rotation = chroma_rotation[1]

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -120,14 +120,17 @@ def get_upconverted_burst(
     chroma_heterodyne,
     chroma_filter,
 ):
-    burst_start = (linenumber - lineoffset) * outwidth + burstarea[0]
-    burst_end = burst_start + burstarea[1]
+    burst_padding = burstarea[1] - burstarea[0] # pad the area being filtered
+    burst_start = max(0, (linenumber - lineoffset) * outwidth + burstarea[0] - burst_padding)
+    burst_end = min(len(chroma), burst_start + burstarea[1] + burst_padding)
 
-    heterodyne = chroma_heterodyne[phase][burst_start:burst_end]
-    burst = heterodyne * chroma[burst_start:burst_end]
+    burst = chroma_heterodyne[phase][burst_start:burst_end] * chroma[burst_start:burst_end]
 
     # filter out noise so only the color burst is present
-    return sosfiltfilt_rust(chroma_filter, burst)
+    filtered = sosfiltfilt_rust(chroma_filter, burst)
+    burst_without_padding = filtered[burst_padding:-burst_padding]
+
+    return burst_without_padding, burst_start + burst_padding, burst_end - burst_padding
 
 def get_phase_rotation_sequence(
     chroma,
@@ -135,10 +138,14 @@ def get_phase_rotation_sequence(
     lineoffset,
     linesout,
     outwidth,
-    phase_rotation_offset,
+    phase_rotation,
+    is_first_field,
+    color_system,
+    burst_sine,
+    burst_cosine,
+    detect_chroma_track_phase,
     chroma_rotation,
     chroma_heterodyne,
-    starting_phase,
     burstarea,
     chroma_filter,
 ):
@@ -146,47 +153,77 @@ def get_phase_rotation_sequence(
     # Gather the phase differences between each color burst
     # Color burst alternates phase between lines in a field
     # *****************************************************    
-    phase_rotation_1 = phase_rotation_offset
-    phase_rotation_2 = chroma_rotation[1] if phase_rotation_offset == chroma_rotation[0] else chroma_rotation[0]
-
-    phase_correlation_threshold = 0.5
+    track_change_threshold = 0.5
     phase_rotations = []
+    bursts = []
+    burst_check_skip_lines = 16
+    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
 
     # rewind to the previous phase (line -1)
-    current_phase = starting_phase
+    current_phase = 0
     for _ in range(3):
-        current_phase = (current_phase + phase_rotation_1) % 4
+        current_phase = (current_phase + phase_rotation) % 4
     
     end = linesout + lineoffset
 
     for linenumber in range(lineoffset, end):
-        current_phase_with_rotation = (current_phase + phase_rotation_2) % 4
-        current_phase = (current_phase + phase_rotation_1) % 4
-        rotate = False
+        current_phase = (current_phase + phase_rotation) % 4
+        current_burst, current_burst_start, current_burst_end = get_upconverted_burst(chroma, current_phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
+        current_burst_norm = np.linalg.norm(current_burst)
 
-        if linenumber >= rotation_check_start_line and linenumber < end - 1:
-            current_burst = get_upconverted_burst(chroma, current_phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
-            current_burst_norm = np.linalg.norm(current_burst)
+        if (
+            burst_check_skip_lines < linenumber and
+            burst_check_skip_lines < end - linenumber
+        ):
+            bursts.append((current_burst, current_burst_start, current_burst_end))
 
+        if (
+            do_phase_rotation_check and
+            linenumber >= rotation_check_start_line and
+            linenumber < end - 1
+        ):
             # get the next burst using the phase rotation for the current track
-            next_phase = (current_phase + phase_rotation_1) % 4
-            next_burst = get_upconverted_burst(chroma, next_phase, linenumber + 1, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
+            next_phase = (current_phase + phase_rotation) % 4
+            next_burst, _, _ = get_upconverted_burst(chroma, next_phase, linenumber + 1, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
             next_burst_norm = np.linalg.norm(next_burst)
 
             phase_correlation = np.dot(current_burst, next_burst) / (current_burst_norm * next_burst_norm)
 
-            if phase_correlation > phase_correlation_threshold:
+            if phase_correlation > track_change_threshold:
                 # positive correlation -> in phase
                 # negative correlation -> out of phase
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
-                old_rotation_1 = phase_rotation_1
-                phase_rotation_1 = phase_rotation_2
-                phase_rotation_2 = old_rotation_1
-                rotate = True
+                phase_rotation = chroma_rotation[1] if phase_rotation == chroma_rotation[0] else chroma_rotation[0]
 
-        phase_rotations.append((current_phase, current_phase_with_rotation, rotate))
+        phase_rotations.append(current_phase)
 
-    return phase_rotations
+    # detect NTSC starting phase
+    if color_system == "NTSC":
+        # detect phase quadrant of color bursts
+        quadrant = detect_ntsc_color_burst_phase(bursts, burst_sine, burst_cosine)
+
+        # TODO: mathematical way to do this?
+        field_phase_id, ntsc_phase_rotation = {
+            # field 1
+            (True,  3): (1, 3), # if isFirstField == True  and quadrant == 3: field_phase_id = 1; ntsc_phase_rotation = 3
+            (False, 2): (4, 2), # if isFirstField == False and quadrant == 2: field_phase_id = 4; ntsc_phase_rotation = 2
+            # field 2
+            (True,  2): (3, 0), # if isFirstField == True  and quadrant == 2: field_phase_id = 3; ntsc_phase_rotation = 0
+            (False, 3): (2, 1), # if isFirstField == False and quadrant == 3: field_phase_id = 2; ntsc_phase_rotation = 1
+            # field 3
+            (True,  1): (1, 1), # if isFirstField == True  and quadrant == 1: field_phase_id = 1; ntsc_phase_rotation = 1
+            (False, 0): (4, 0), # if isFirstField == False and quadrant == 0: field_phase_id = 4; ntsc_phase_rotation = 0
+            # field 4
+            (True,  0): (3, 2), # if isFirstField == True  and quadrant == 0: field_phase_id = 3; ntsc_phase_rotation = 2
+            (False, 1): (2, 3), # if isFirstField == False and quadrant == 1: field_phase_id = 2; ntsc_phase_rotation = 3
+        }[is_first_field, quadrant]
+
+        # fix the starting phase
+        if ntsc_phase_rotation != 0:
+            for i in range(0, len(phase_rotations)):
+                phase_rotations[i] = (phase_rotations[i] + ntsc_phase_rotation) % 4
+
+    return phase_rotations, field_phase_id
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -196,8 +233,7 @@ def upconvert_chroma(
     outwidth,
     chroma_heterodyne,
     phase_rotation,
-    starting_phase,
-    phase_rotation_sequence=None
+    phase_rotation_sequence
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
     if phase_rotation == 0:
@@ -214,7 +250,6 @@ def upconvert_chroma(
     else:
         #        rotation = [(0,0),(90,-270),(180,-180),(270,-90)]
         # Track 2 - needs phase rotation or the chroma will be inverted.
-        current_phase = int(starting_phase)
         phase_index = 0
 
         for linenumber in range(lineoffset, linesout + lineoffset):
@@ -222,14 +257,11 @@ def upconvert_chroma(
             lineend = linestart + outwidth
             c = chroma[linestart:lineend]
 
-            if phase_rotation_sequence is not None:
-                # override calculated phase rotation with the passed in rotation
-                current_phase, _, _ = phase_rotation_sequence[phase_index]
-                phase_index += 1
+            current_phase = phase_rotation_sequence[phase_index]
+            phase_index += 1
 
             heterodyne = chroma_heterodyne[current_phase][linestart:lineend]
             uphet[linestart:lineend] = c * heterodyne
-            current_phase = (current_phase + phase_rotation) % 4
 
     return uphet
 
@@ -336,9 +368,6 @@ def process_chroma(
     if field.rf.color_system == "NTSC" and not disable_deemph:
         chroma = burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea)
 
-    # What phase we start on. (Needed for NTSC to get the color phase correct)
-    ntsc_starting_phase = field.field_number % 2 # should this persist on the field so phase order doesn't need to be re-detected?
-
     # Rotation per track
     # VHS PAL: Track1 0, Track2 -90
     # VHS NTSC: Track1 +90, Track2 -90
@@ -349,8 +378,7 @@ def process_chroma(
 
     if track_phase is not None:
         if chroma_rotation:
-            # if field.rf.field_number % 2 == track_phase:
-            if field.field_number % 2 == track_phase:
+            if field.isFirstField:
                 phase_rotation = chroma_rotation[0]
             else:
                 phase_rotation = chroma_rotation[1]
@@ -367,23 +395,26 @@ def process_chroma(
         else field.rf.chroma_heterodyne
     )
 
+    phase_rotation_sequence, field_phase_id = get_phase_rotation_sequence(
+        chroma,
+        lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
+        lineoffset,
+        linesout,
+        outwidth,
+        phase_rotation,
+        field.isFirstField,
+        field.rf.color_system,
+        field.rf.fsc_wave,
+        field.rf.fsc_cos_wave,
+        detect_chroma_track_phase,
+        chroma_rotation,
+        chroma_heterodyne,
+        burstarea,
+        field.rf.Filters["FChromaFinal"],
+    )
 
-    if detect_chroma_track_phase and chroma_rotation is not None:
-        phase_rotation_sequence = get_phase_rotation_sequence(
-            chroma,
-            16, # check for track phase rotation around the headswitching area (bottom of field)
-            lineoffset,
-            linesout,
-            outwidth,
-            phase_rotation,
-            chroma_rotation,
-            chroma_heterodyne,
-            ntsc_starting_phase, 
-            burstarea,
-            field.rf.Filters["FChromaFinal"],
-        )
-    else:
-        phase_rotation_sequence = None
+    if field.rf.color_system == "NTSC":
+        field.fieldPhaseID = field_phase_id
 
     uphet = upconvert_chroma(
         chroma,
@@ -392,7 +423,6 @@ def process_chroma(
         outwidth,
         chroma_heterodyne,
         phase_rotation,
-        ntsc_starting_phase,
         phase_rotation_sequence,
     )
 
@@ -676,98 +706,37 @@ def detect_burst_pal_line(
 
     return LineInfo(line_number, line_bp, line_bq, line_vsw, line_burst_norm)
 
-
-@njit(cache=True, nogil=True)
-def detect_burst_ntsc(
-    chroma_data, sine_wave, cosine_wave, burst_area, line_length, lines
+@njit(fastmath=True, cache=True, nogil=True)
+def detect_ntsc_color_burst_phase(
+    bursts, sine_wave, cosine_wave
 ):
-    """Check the phase of the color burst."""
-
+    """ Detects the phase rotation quadrant using the color burst phase"""
     # Ignore the first and last 16 lines of the field.
     # first ones contain sync and often doesn't have color burst,
     # while the last lines of the field will contain the head switch and may be distorted.
-    IGNORED_LINES = 16
-    odd_i_acc = 0
-    even_i_acc = 0
+    I_total = 0
+    Q_total = 0
 
-    for linenumber in range(IGNORED_LINES, lines - IGNORED_LINES):
-        bi, _, _ = detect_burst_ntsc_line(
-            chroma_data, sine_wave, cosine_wave, burst_area, line_length, linenumber
-        )
-        #        line_data.append((bi, bq, linenumber))
-        if linenumber % 2 == 0:
-            even_i_acc += bi
-        else:
-            odd_i_acc += bi
+    for burst, burst_start, burst_end in bursts:
+        I = 0
+        Q = 0
 
-    num_lines = lines - (IGNORED_LINES * 2)
+        for i in range(burst_end - burst_start):
+            I += burst[i] * cosine_wave[i + burst_start]
+            Q += burst[i] * sine_wave[i + burst_start]
 
-    return even_i_acc / num_lines, odd_i_acc / num_lines
+        magnitude = np.hypot(I, Q) + 1e-12
+        I_total += I / magnitude
+        Q_total += Q / magnitude
 
+    # Global field phase
+    avg_phase = np.arctan2(Q_total, I_total)
+    avg_phase_deg = np.degrees(avg_phase) % 360
 
-@njit(cache=True, nogil=True)
-def detect_burst_ntsc_line(
-    chroma_data, sine, cosine, burst_area, line_length, line_number
-):
-    bi = 0
-    bq = 0
-    # TODO:
-    sine = sine[burst_area[0] :]
-    cosine = cosine[burst_area[0] :]
-    line = get_line(chroma_data, line_length, line_number)
-    for i in range(burst_area[0], burst_area[1]):
-        bi += line[i] * sine[i]
-        bq += line[i] * cosine[i]
+    # Quantize to nearest 90 degrees
+    quadrant = int(np.round(avg_phase_deg / 90)) % 4
 
-    burst_length = burst_area[1] - burst_area[0]
-
-    bi /= burst_length
-    bq /= burst_length
-
-    burst_norm = max(math.sqrt(bi * bi + bq * bq), 130000.0 / 128)
-    bi /= burst_norm
-    bq /= burst_norm
-    return bi, bq, burst_norm
-
-
-def get_field_phase_id(field):
-    """Try to determine which of the 4 NTSC phase cycles the field is.
-    For tapes the result seem to not be cyclical at all, not sure if that's normal
-    or if something is off.
-    The most relevant thing is which lines the burst phase is positive or negative on.
-    TODO: Current code does not give the correct result!!!!
-    """
-    burst_area = get_burst_area(field)
-
-    sine_wave = field.rf.fsc_wave
-    cosine_wave = field.rf.fsc_cos_wave
-
-    # Try to detect the average burst phase of odd and even lines.
-    even, odd = detect_burst_ntsc(
-        field.uphet_temp,
-        sine_wave,
-        cosine_wave,
-        burst_area,
-        field.outlinelen,
-        field.outlinecount,
-    )
-
-    # This map is based on (first field, field14)
-    map4 = {
-        (True, True): 1,
-        (False, False): 2,
-        (True, False): 3,
-        (False, True): 4,
-    }
-
-    phase_id = (
-        map4[(field.isFirstField, even < odd)] if field.isFirstField is not None else 0
-    )
-
-    # ldd.logger.info("Field: %i, Odd I %f , Even I %f, phase id %i, field first %i",
-    #                field.rf.field_number, even, odd, phase_id, field.isFirstField)
-
-    return phase_id
+    return quadrant
 
 
 # Phase comprensation stuff - needs rework.

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -145,21 +145,33 @@ def get_phase_rotation_sequence(
     # *****************************************************
     # Gather the phase differences between each color burst
     # Color burst alternates phase between lines in a field
-    # *****************************************************
-    phase = starting_phase
+    # *****************************************************    
+    phase_rotation_1 = phase_rotation_offset
+    phase_rotation_2 = chroma_rotation[1] if phase_rotation_offset == chroma_rotation[0] else chroma_rotation[0]
+
     phase_correlation_threshold = 0.5
     phase_rotations = []
-    phase_rotations.append(phase)
 
-    for linenumber in range(lineoffset, linesout + lineoffset - 1):
-        next_phase = (phase + phase_rotation_offset) % 4
+    # rewind to the previous phase (line -1)
+    current_phase = starting_phase
+    for _ in range(3):
+        current_phase = (current_phase + phase_rotation_1) % 4
+    
+    end = linesout + lineoffset
 
-        if linenumber >= rotation_check_start_line:
-            current_burst = get_upconverted_burst(chroma, phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
+    for linenumber in range(lineoffset, end):
+        current_phase_with_rotation = (current_phase + phase_rotation_2) % 4
+        current_phase = (current_phase + phase_rotation_1) % 4
+        rotate = False
+
+        if linenumber >= rotation_check_start_line and linenumber < end - 1:
+            current_burst = get_upconverted_burst(chroma, current_phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
             current_burst_norm = np.linalg.norm(current_burst)
 
+            # get the next burst using the phase rotation for the current track
+            next_phase = (current_phase + phase_rotation_1) % 4
             next_burst = get_upconverted_burst(chroma, next_phase, linenumber + 1, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
-            next_burst_norm = np.linalg.norm(current_burst)
+            next_burst_norm = np.linalg.norm(next_burst)
 
             phase_correlation = np.dot(current_burst, next_burst) / (current_burst_norm * next_burst_norm)
 
@@ -167,11 +179,12 @@ def get_phase_rotation_sequence(
                 # positive correlation -> in phase
                 # negative correlation -> out of phase
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
-                phase_rotation_offset = chroma_rotation[1] if phase_rotation_offset == chroma_rotation[0] else chroma_rotation[0]
-                next_phase = (phase + phase_rotation_offset) % 4
+                old_rotation_1 = phase_rotation_1
+                phase_rotation_1 = phase_rotation_2
+                phase_rotation_2 = old_rotation_1
+                rotate = True
 
-        phase_rotations.append(next_phase)
-        phase = next_phase
+        phase_rotations.append((current_phase, current_phase_with_rotation, rotate))
 
     return phase_rotations
     
@@ -201,25 +214,22 @@ def upconvert_chroma(
     else:
         #        rotation = [(0,0),(90,-270),(180,-180),(270,-90)]
         # Track 2 - needs phase rotation or the chroma will be inverted.
-        phase = starting_phase
+        current_phase = int(starting_phase)
         phase_index = 0
+
         for linenumber in range(lineoffset, linesout + lineoffset):
             linestart = (linenumber - lineoffset) * outwidth
             lineend = linestart + outwidth
-            
-            if phase_rotation_sequence is not None:
-                # override calculated phase rotation with the passed in rotation
-                phase = phase_rotation_sequence[phase_index]
-                phase_index += 1
-
-            heterodyne = chroma_heterodyne[phase][linestart:lineend]
-
             c = chroma[linestart:lineend]
 
-            line = heterodyne * c
+            if phase_rotation_sequence is not None:
+                # override calculated phase rotation with the passed in rotation
+                current_phase, _, _ = phase_rotation_sequence[phase_index]
+                phase_index += 1
 
-            uphet[linestart:lineend] = line
-            phase = (phase + phase_rotation) % 4
+            heterodyne = chroma_heterodyne[current_phase][linestart:lineend]
+            uphet[linestart:lineend] = c * heterodyne
+            current_phase = (current_phase + phase_rotation) % 4
 
     return uphet
 
@@ -326,11 +336,8 @@ def process_chroma(
     if field.rf.color_system == "NTSC" and not disable_deemph:
         chroma = burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea)
 
-    # Track 2 is rotated ccw in both NTSC and PAL for VHS
-    # u-matic has no phase rotation.
-    phase_rotation = -1 if track_phase is not None else 0
     # What phase we start on. (Needed for NTSC to get the color phase correct)
-    starting_phase = 0
+    ntsc_starting_phase = field.field_number % 2 # should this persist on the field so phase order doesn't need to be re-detected?
 
     # Rotation per track
     # VHS PAL: Track1 0, Track2 -90
@@ -340,12 +347,19 @@ def process_chroma(
     # Video8 NTSC: Track1 0, Track2 180
     # Video8 PAL: Track1 0, Track2 -90
 
-    if track_phase is not None and chroma_rotation:
-        # if field.rf.field_number % 2 == track_phase:
-        if field.field_number % 2 == track_phase:
-            phase_rotation = chroma_rotation[0]
+    if track_phase is not None:
+        if chroma_rotation:
+            # if field.rf.field_number % 2 == track_phase:
+            if field.field_number % 2 == track_phase:
+                phase_rotation = chroma_rotation[0]
+            else:
+                phase_rotation = chroma_rotation[1]
         else:
-            phase_rotation = chroma_rotation[1]
+            phase_rotation = track_phase
+    else:
+        # Track 2 is rotated ccw in both NTSC and PAL for VHS
+        # u-matic has no phase rotation.
+        phase_rotation = 0
 
     chroma_heterodyne = (
         field.rf.chroma_afc.getChromaHet()
@@ -353,19 +367,18 @@ def process_chroma(
         else field.rf.chroma_heterodyne
     )
 
-    starting_phase = 0 # should this persist on the field so phase order doesn't need to be re-detected?
 
     if detect_chroma_track_phase and chroma_rotation is not None:
         phase_rotation_sequence = get_phase_rotation_sequence(
             chroma,
-            16, # TODO: start after the vbi (system dependent)
+            16, # check for track phase rotation around the headswitching area (bottom of field)
             lineoffset,
             linesout,
             outwidth,
             phase_rotation,
             chroma_rotation,
             chroma_heterodyne,
-            starting_phase, 
+            ntsc_starting_phase, 
             burstarea,
             field.rf.Filters["FChromaFinal"],
         )
@@ -379,7 +392,7 @@ def process_chroma(
         outwidth,
         chroma_heterodyne,
         phase_rotation,
-        starting_phase,
+        ntsc_starting_phase,
         phase_rotation_sequence,
     )
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -12,7 +12,6 @@ from vhsdecode.addons.resync import Pulse
 from vhsdecode.chroma import (
     decode_chroma_simple,
     decode_chroma,
-    get_field_phase_id,
     try_detect_track_vhs_pal,
     try_detect_track_ntsc,
     try_detect_track_betamax_pal,
@@ -1951,8 +1950,6 @@ class FieldNTSCVHS(FieldNTSCShared):
 
         dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
 
-        self.fieldPhaseID = get_field_phase_id(self)
-
         return (dsout, dschroma), dsaudio, dsefm
 
 
@@ -1998,8 +1995,6 @@ class FieldNTSCUMatic(FieldNTSCShared):
         )
         dschroma = decode_chroma_simple(self)
 
-        self.fieldPhaseID = get_field_phase_id(self)
-
         return (dsout, dschroma), dsaudio, dsefm
 
 
@@ -2012,7 +2007,7 @@ class FieldNTSCTypeC(FieldShared, ldd.FieldNTSC):
             final=final, *args, **kwargs
         )
 
-        # self.fieldPhaseID = get_field_phase_id(self)
+        self.fieldPhaseID = 0
 
         return (dsout, None), dsaudio, dsefm
 
@@ -2033,8 +2028,6 @@ class FieldNTSCVideo8(FieldNTSCShared):
         dschroma = decode_chroma(
             self, self.rf.DecoderParams["chroma_rotation"], do_chroma_deemphasis=True, detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
-
-        self.fieldPhaseID = get_field_phase_id(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 


### PR DESCRIPTION
### Fixes
* Correctly detect NTSC chroma phase rotation sequence. This enables the use of the NTSC 3D chroma decoder for VHS and other color under sources.
  * The color burst phase is detected by converting each burst area into a complex signal (i.e. I/Q) and summing each burst's I/Q together for the entire field. The phase of the complex signal is measured and mapped to a quadrant which is used along with the `isFirstField` to select the correct NTSC phase rotation and field phase id.
* Limit track phase switching to the last 16 lines of a field.
  * False positives were very infrequently appearing in the middle of the field for noisy EP VHS recordings.