### PR TITLE
Fix macOS ARM + Intel GitHub Actions app builds

### DIFF
--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -7,11 +7,11 @@ jobs:
   build-decode:
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15-intel, macos-latest]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
 
     name: Build vhs-decode (${{ matrix.arch }})

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install LLVM (Intel only)
         if: matrix.arch == 'x86_64'
-        run: brew install llvm
+        run: brew install llvm@20
 
       - name: Build Python module
         shell: bash
@@ -52,8 +52,8 @@ jobs:
 
           # llvmlite may fall back to source builds on Intel macOS; ensure it can find Homebrew LLVM
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            export LLVM_CONFIG="$(brew --prefix llvm)/bin/llvm-config"
-            export CMAKE_PREFIX_PATH="$(brew --prefix llvm)"
+            export LLVM_CONFIG="$(brew --prefix llvm@20)/bin/llvm-config"
+            export CMAKE_PREFIX_PATH="$(brew --prefix llvm@20)"
           fi
 
           python3 -m pip install -r ./requirements.txt

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -57,6 +57,11 @@ jobs:
           fi
 
           python3 -m pip install -r ./requirements.txt
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            # Keep Intel on a numba version that resolves to prebuilt llvmlite wheels.
+            # This avoids llvmlite source builds failing under current setuptools internals.
+            python3 -m pip install "numba==0.62.1"
+          fi
           python3 -m pip install pyinstaller
           python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"
 

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-decode:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, macos-15-intel]
         include:
@@ -38,10 +39,23 @@ jobs:
       - name: Install dependencies
         run: brew install create-dmg libsndfile
 
+      - name: Install LLVM (Intel only)
+        if: matrix.arch == 'x86_64'
+        run: brew install llvm
+
       - name: Build Python module
+        shell: bash
         env:
           SETUPTOOLS_RUST_CARGO_PROFILE: release
         run: |
+          set -euxo pipefail
+
+          # llvmlite may fall back to source builds on Intel macOS; ensure it can find Homebrew LLVM
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            export LLVM_CONFIG="$(brew --prefix llvm)/bin/llvm-config"
+            export CMAKE_PREFIX_PATH="$(brew --prefix llvm)"
+          fi
+
           python3 -m pip install -r ./requirements.txt
           python3 -m pip install pyinstaller
           python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -7,10 +7,8 @@ jobs:
   build-decode:
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: [macos-latest]
         include:
-          - os: macos-15-intel
-            arch: x86_64
           - os: macos-latest
             arch: arm64
 

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
-        run: brew install create-dmg
+        run: brew install create-dmg libsndfile
 
       - name: Build Python module
         env:

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Upgrade pip tooling
+        run: python3 -m pip install --upgrade pip setuptools wheel
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
@@ -36,8 +39,9 @@ jobs:
         env:
           SETUPTOOLS_RUST_CARGO_PROFILE: release
         run: |
-          pip3 install ".[hifi_gui_qt6,hifi_gnuradio]" setuptools Cython pyinstaller -r ./requirements.txt
-          pip3 install -e .
+          python3 -m pip install -r ./requirements.txt
+          python3 -m pip install pyinstaller
+          python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"
 
       - name: Build binary
         run: |

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -7,10 +7,15 @@ jobs:
   build-decode:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, macos-15-intel]
         include:
           - os: macos-latest
             arch: arm64
+            python: "3.12"
+          - os: macos-15-intel
+            arch: x86_64
+            # Use a Python version with reliable wheels for llvmlite/numba on Intel macOS
+            python: "3.11"
 
     name: Build vhs-decode (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
@@ -23,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "${{ matrix.python }}"
 
       - name: Upgrade pip tooling
         run: python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -54,14 +54,12 @@ jobs:
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             export LLVM_CONFIG="$(brew --prefix llvm@20)/bin/llvm-config"
             export CMAKE_PREFIX_PATH="$(brew --prefix llvm@20)"
+            # Keep Intel on a numba/llvmlite pair with published x86_64 wheels.
+            # Installing this first avoids llvmlite source builds with setuptools API incompatibilities.
+            python3 -m pip install "numba==0.60.0"
           fi
 
           python3 -m pip install -r ./requirements.txt
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            # Keep Intel on a numba version that resolves to prebuilt llvmlite wheels.
-            # This avoids llvmlite source builds failing under current setuptools internals.
-            python3 -m pip install "numba==0.62.1"
-          fi
           python3 -m pip install pyinstaller
           python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"
 

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -11,11 +11,11 @@ jobs:
   build-tbc-tools:
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15-intel, macos-latest]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
 
     name: Build tbc-tools (${{ matrix.arch }})

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -11,10 +11,8 @@ jobs:
   build-tbc-tools:
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: [macos-latest]
         include:
-          - os: macos-15-intel
-            arch: x86_64
           - os: macos-latest
             arch: arm64
 

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -11,10 +11,12 @@ jobs:
   build-tbc-tools:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, macos-15-intel]
         include:
           - os: macos-latest
             arch: arm64
+          - os: macos-15-intel
+            arch: x86_64
 
     name: Build tbc-tools (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   build-tbc-tools:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, macos-15-intel]
         include:

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -57,10 +57,21 @@ jobs:
           cp flaldf dist/tbc-tools.app/Contents/MacOS/
 
       - name: Copy scripts
-        run: find scripts scripts/linux -maxdepth 1 -perm +111 -type f -exec cp {} dist/tbc-tools.app/Contents/MacOS/ \;
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for f in scripts/* scripts/linux/*; do
+            if [[ -f "$f" && -x "$f" ]]; then
+              cp "$f" dist/tbc-tools.app/Contents/MacOS/
+            fi
+          done
 
       - name: Copy dependencies
-        run: macdeployqt dist/tbc-tools.app -libpath=/usr/local/lib/
+        shell: bash
+        run: |
+          BREW_PREFIX="$(brew --prefix)"
+          QT_PREFIX="$(brew --prefix qt)"
+          "$QT_PREFIX/bin/macdeployqt" dist/tbc-tools.app -libpath="$BREW_PREFIX/lib"
 
       - name: Build DMG file
         run: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Homepage = "https://www.domesday86.com"
 [tool.setuptools_scm]
 write_to = "vhsdecode/_version.py"
 local_scheme = "no-local-version"
+# Restrict git describe/version parsing to real version tags (avoid tags like "rev4.0" breaking builds)
+git_describe_command = "git describe --dirty --tags --long --match [0-9]* --match v[0-9]*"
+tag_regex = '^(?:v)?(?P<version>\d+(?:\.\d+)*(?:rc\d+)?)$'
 
 [tool.setuptools.package-data]
 vhs_decode = ["*.txt"]

--- a/tools/ld-analyse/CMakeLists.txt
+++ b/tools/ld-analyse/CMakeLists.txt
@@ -39,13 +39,27 @@ target_include_directories(ld-analyse PRIVATE
 )
 
 
-# Include homebrew folders manually for qwt on macos
-# as it seems the find scripts don't handle it
-# properly.
+# Include Homebrew folders manually for qwt on macOS.
+# (Some setups expose Qwt as a framework under the Homebrew prefix.)
 if(APPLE)
-    target_include_directories(ld-analyse PRIVATE
-    /opt/homebrew/lib/qwt.framework/Headers
-    )
+    if(EXISTS "/opt/homebrew/lib/qwt.framework/Headers")
+        target_include_directories(ld-analyse PRIVATE
+            /opt/homebrew/lib/qwt.framework/Headers
+        )
+    endif()
+
+    if(EXISTS "/usr/local/lib/qwt.framework/Headers")
+        target_include_directories(ld-analyse PRIVATE
+            /usr/local/lib/qwt.framework/Headers
+        )
+    endif()
+
+    # Fallback: some installations keep the framework under the qwt keg.
+    if(EXISTS "/usr/local/opt/qwt/lib/qwt.framework/Headers")
+        target_include_directories(ld-analyse PRIVATE
+            /usr/local/opt/qwt/lib/qwt.framework/Headers
+        )
+    endif()
 endif()
 
 target_link_libraries(ld-analyse PRIVATE


### PR DESCRIPTION
This PR fixes macOS GitHub Actions app builds for both Apple Silicon and Intel.

## What this changes
- Updates the macOS workflow matrix to use active runner labels (`macos-latest`, `macos-15-intel`) and disables `fail-fast`.
- Fixes `setuptools_scm` version parsing for repositories with non-version tags.
- Makes macOS tools packaging portable:
  - Uses `brew --prefix` / `brew --prefix qt` for `macdeployqt` and lib path.
  - Replaces GNU-only `find -perm +111` usage with portable bash logic.
- Fixes Intel decode dependency path:
  - Installs `llvm@20` and exports `LLVM_CONFIG` + `CMAKE_PREFIX_PATH`.
  - Preinstalls `numba==0.60.0` on Intel to force wheel-based llvmlite resolution and avoid sdist build breakage.
- Fixes Intel tools build include path for Qwt framework headers in `tools/ld-analyse/CMakeLists.txt`.

## Verification
Triggered and validated on branch `MacOS_Build_Fixes`:
- Build macOS decode: https://github.com/harrypm/ld-decode/actions/runs/22731848017
  - Artifacts: `vhs-decode_macos_arm64`, `vhs-decode_macos_x86_64`
- Build macOS tools: https://github.com/harrypm/ld-decode/actions/runs/22731849030
  - Artifacts: `tbc-tools_macos_arm64`, `tbc-tools_macos_x86_64`

Co-Authored-By: Oz <oz-agent@warp.dev>
