### PR TITLE
NTSC Color Burst TBC

### DIFF
--- a/cvbsdecode/main.py
+++ b/cvbsdecode/main.py
@@ -84,13 +84,25 @@ def main(args=None):
         help="Additionally use right hand side of hsync for line start detection. Improves accuracy on tape sources but might cause issues on high bandwidth stable ones",
     )
     parser.add_argument(
-        "--wow_adjust_smoothing_lines",
+        "--wow_level_adjust_smoothing",
         type=float,
         default=0,
         help=(
-            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
-            "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
-            "\nSet to `0` to disable smoothing (only recommended for low noise video)"
+            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. (default 0)"
+            "\n  Wow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\n  If you see vertical brightness variations (banding), setting to a value larger than 0 will smooth the wow adjustment."
+        )
+    )
+    parser.add_argument(
+        "--wow_interpolation_method",
+        type=str,
+        default="linear",
+        choices=["linear", "quadratic", "cubic"],
+        help=(
+            "Sets the type of interpolation spline used to correct wow."
+            "\n  linear     [default]"
+            "\n  quadratic"
+            "\n  cubic"
         )
     )
 
@@ -169,7 +181,6 @@ def main(args=None):
         # level_adjust=args.level_adjust,
         rf_options=rf_options,
         extra_options=extra_options,
-        level_smoothing_lines=args.wow_adjust_smoothing_lines
     )
 
     signal.signal(signal.SIGINT, original_sigint_handler)

--- a/cvbsdecode/process.py
+++ b/cvbsdecode/process.py
@@ -526,7 +526,6 @@ class CVBSDecode(ldd.LDdecode):
         level_adjust=0.2,
         rf_options={},
         extra_options={},
-        level_smoothing_lines=0,
     ):
         # monkey patch init with a dummy to prevent calling set_start_method twice on macos
         # and not create extra threads.
@@ -573,8 +572,6 @@ class CVBSDecode(ldd.LDdecode):
         self.demodcache = ldd.DemodCache(
             self.rf, self.infile, self.freader, None, num_worker_threads=self.numthreads
         )
-
-        self.level_smoothing_lines = level_smoothing_lines
 
     # Override to avoid NaN in JSON.
     def calcsnr(self, f, snrslice):

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -1460,7 +1460,8 @@ class Field:
         fields_written=0,
         readloc=0,
         use_threads=True,
-        level_smoothing_lines=0
+        wow_level_adjust_smoothing=0,
+        wow_interpolation_method="linear"
     ):
         self.rawdata = decode["input"]
         self.data = decode
@@ -1495,7 +1496,8 @@ class Field:
 
         self.use_threads = use_threads
 
-        self.level_smoothing_lines = level_smoothing_lines
+        self.wow_level_adjust_smoothing = wow_level_adjust_smoothing
+        self.wow_interpolation_method = wow_interpolation_method
 
     @profile
     def process(self):
@@ -2452,7 +2454,7 @@ class Field:
 
         return linelocs
 
-    def computewow_scaled(self, kind='linear'):
+    def computewow_scaled(self):
         """Compute how much the line deviates fron expected,
            and scale input samples to output samples
         """
@@ -2463,13 +2465,13 @@ class Field:
         outsamples = self.outlinecount * self.outlinelen
         outline_offset = (self.lineoffset + 1) * self.outlinelen
 
-        if kind == 'linear':
+        if self.wow_interpolation_method == 'linear':
             k=1
             bc_type=None
-        elif kind == 'quadratic':
+        elif self.wow_interpolation_method == 'quadratic':
             k=2
             bc_type=None
-        elif kind == 'cubic':
+        elif self.wow_interpolation_method == 'cubic':
             k=3
             bc_type='natural'
 
@@ -2561,7 +2563,7 @@ class Field:
             wowfactors,
             self.lineoffset,
             outwidth,
-            level_smoothing_lines=self.level_smoothing_lines
+            wow_level_adjust_smoothing=self.wow_level_adjust_smoothing
         )
 
         if self.rf.decode_digital_audio:
@@ -3504,7 +3506,8 @@ class LDdecode:
 
         self.autoMTF = True
         self.useAGC = extra_options.get("useAGC", True)
-        self.level_smoothing_lines = extra_options.get("level_smoothing_lines", 0)
+        self.wow_level_adjust_smoothing = extra_options.get("wow_level_adjust_smoothing", 0)
+        self.wow_interpolation_method = extra_options.get("wow_interpolation_method", "linear")
 
         self.verboseVITS = False
 
@@ -3696,7 +3699,8 @@ class LDdecode:
             initphase=initphase,
             fields_written=self.fields_written,
             readloc=rawdecode["startloc"],
-            level_smoothing_lines=self.level_smoothing_lines
+            wow_level_adjust_smoothing=self.wow_level_adjust_smoothing,
+            wow_interpolation_method=self.wow_interpolation_method
         )
 
         # set an object-level variable to make notebook debugging easier

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2456,34 +2456,33 @@ class Field:
         """Compute how much the line deviates fron expected,
            and scale input samples to output samples
         """
-        if self.interpolated_pixel_locs is None:
-            actual_linelocs = np.array(self.linelocs, dtype=np.float64)
-            expected_linelocs = np.array([i * self.inlinelen for i in range(len(actual_linelocs))], dtype=np.float64)
+        actual_linelocs = np.array(self.linelocs, dtype=np.float64)
+        expected_linelocs = np.array([i * self.inlinelen for i in range(len(actual_linelocs))], dtype=np.float64)
 
-            outscale = self.inlinelen / self.outlinelen
-            outsamples = self.outlinecount * self.outlinelen
-            outline_offset = (self.lineoffset + 1) * self.outlinelen
+        outscale = self.inlinelen / self.outlinelen
+        outsamples = self.outlinecount * self.outlinelen
+        outline_offset = (self.lineoffset + 1) * self.outlinelen
 
-            if kind == 'linear':
-                k=1
-                bc_type=None
-            elif kind == 'quadratic':
-                k=2
-                bc_type=None
-            elif kind == 'cubic':
-                k=3
-                bc_type='natural'
+        if kind == 'linear':
+            k=1
+            bc_type=None
+        elif kind == 'quadratic':
+            k=2
+            bc_type=None
+        elif kind == 'cubic':
+            k=3
+            bc_type='natural'
 
-            # create a spline that interpolates the exact sample value based on expected vs. actual line locations
-            spl = interpolate.make_interp_spline(expected_linelocs, actual_linelocs, k=k, bc_type=bc_type, check_finite=False)
+        # create a spline that interpolates the exact sample value based on expected vs. actual line locations
+        spl = interpolate.make_interp_spline(expected_linelocs, actual_linelocs, k=k, bc_type=bc_type, check_finite=False)
 
-            # scale up to compute where the output pixel would fall on the interpolated line loc
-            scaled_pixel_locs = np.arange(outsamples + outline_offset) * outscale
+        # scale up to compute where the output pixel would fall on the interpolated line loc
+        scaled_pixel_locs = np.arange(outsamples + outline_offset) * outscale
 
-            # interpolate the expected pixel location
-            self.interpolated_pixel_locs = spl(scaled_pixel_locs)
-            # amount of wow for each scaled pixel
-            self.wowfactors = spl(scaled_pixel_locs, 1)
+        # interpolate the expected pixel location
+        self.interpolated_pixel_locs = spl(scaled_pixel_locs)
+        # amount of wow for each scaled pixel
+        self.wowfactors = spl(scaled_pixel_locs, 1)
 
         return self.interpolated_pixel_locs, self.wowfactors
 

--- a/lddecode/main.py
+++ b/lddecode/main.py
@@ -14,6 +14,7 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description="Extracts audio and video from raw RF laserdisc captures",
         epilog=options_epilog,
+        formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument("infile", metavar="infile", type=str, help="source file")
     parser.add_argument(
@@ -203,6 +204,29 @@ def main(args=None):
     )
 
     parser.add_argument(
+        "--wow_level_adjust_smoothing",
+        type=float,
+        default=0,
+        help=(
+            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. (default 0)"
+            "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\nIf you see vertical brightness variations (banding), setting to a value larger than 0 will smooth the wow adjustment."
+        )
+    )
+    parser.add_argument(
+        "--wow_interpolation_method",
+        type=str,
+        default="linear",
+        choices=["linear", "quadratic", "cubic"],
+        help=(
+            "Sets the type of interpolation spline used to correct wow."
+            "\n  linear     [default]"
+            "\n  quadratic"
+            "\n  cubic"
+        )
+    )
+
+    parser.add_argument(
         "-t",
         "--threads",
         metavar="threads",
@@ -303,6 +327,8 @@ def main(args=None):
         "audio_filterwidth": args.audio_filterwidth,
         "AC3": args.AC3,
         "use_profiler": args.use_profiler,
+        "wow_level_adjust_smoothing": args.wow_level_adjust_smoothing,
+        "wow_interpolation_method": args.wow_interpolation_method
     }
 
     if vid_standard == "NTSC" and args.NTSC_color_notch_filter:

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -92,7 +92,7 @@ def scale(buf, begin, end, tgtlen, mult=1):
 
 # Scales and compensates for wow-induced playback-speed variations
 @njit(nogil=True, cache=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, level_smoothing_lines=0, level_adjust_threshold = 15):
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
     # Constants preserved as float32
     point_5 = np.float32(0.5)
     two = np.float32(2)
@@ -116,10 +116,10 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         wowfactors
     )
 
-    if level_smoothing_lines > 0:
+    if wow_level_adjust_smoothing > 0:
         # removes oscillating brightness variations for video with lots of noise around the hsync pulses, i.e. noisy line locations result in noisy wow calculations
         # applies a low pass filter that smooths any sudden brightness variations while still being reactive enough to compensate for low frequency wow
-        alpha = 1 / (level_smoothing_lines * outwidth)
+        alpha = 1 / (wow_level_adjust_smoothing * outwidth)
         one_minus_alpha = 1 - alpha
 
         for i in range(1, len(level_adjusts)):

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -176,7 +176,6 @@ def _get_phase_sequence(
     do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
 
     phase_sequence = []
-    burst_phases = []
 
     if chroma_rotation_starting_index is None:
         # first field
@@ -190,12 +189,24 @@ def _get_phase_sequence(
     else:
         # format that uses a fixed heterodyne phase, or does not rotate
         track_rotation = chroma_rotation_starting_index
+    """
+    "...a signal that represents phase zero with respect to the chroma signal phase 
+    +90°, +180°, +270° etc. or a phase 0°, -90°. —180°. —270°. etc., 
+    depending upon which head is on the tape at the particular time.
 
-    # rewind to the previous phase (line -1)
+    The direction of phase rotation, being related to which head is on the tape at a given time,
+    can be determined and preset by sensing whether the PG (pulse generator) pulse is positive-going or negative-going."
+     - https://archive.org/details/rca-vcr-1-red-book-w-cover/page/n25/mode/2up?q=phase
+
+    See also: https://archive.org/details/video-technical-guide/page/1-9/mode/2up?q=phase
+
+    The phase rotation switch is determined at record time depending on which video head is on the tape.
+    This rotation switch can occur in the middle of a line, causing a small phase artifact
+    TODO: It may be possible to detect where this happens on the line and correct the phase issue mid-line
+          Possibly a 2D aware detection could be used to determine where the color phase is rotated +-90 degrees relative to the lines above and below
+    """
+
     current_phase = 0
-    for _ in range(3):
-        current_phase = (current_phase + track_rotation) % 4
-
     use_next_phase = False
     for linenumber in range(lineoffset, last_line):
         if use_next_phase:
@@ -251,106 +262,20 @@ def _get_phase_sequence(
             else:
                 use_next_phase = True
         
-        phase_sequence.append((linenumber, current_phase))
-        burst_phases.append((linenumber, current_burst_phase, current_burst_magnitude, current_burst_I, current_burst_Q))
+        phase_sequence.append((
+            linenumber,
+            current_phase,
+            current_burst_phase,
+            current_burst_magnitude,
+            current_burst_I,
+            current_burst_Q
+        ))
 
     if chroma_rotation and chroma_rotation_index == chroma_rotation_starting_index:
         # rotate the phase for the next field, if rotation was not detected
         chroma_rotation_index = (chroma_rotation_index + 1) % 2
 
-    return chroma_rotation_index, phase_sequence, burst_phases
-
-# input
-# (
-#    isFirstField
-#    detected color burst phase quadrant (n-180): where n is (0=0, 1=90, 2=180, 3=270)
-#    phase delta from previous color burst: (0=0, 1=90, 2=180, 3=270)
-# )
-#
-# output
-# (
-#    fieldPhaseId
-#    startingPhase
-#    expectedBurstPhase
-# )
-ntsc_phase_rotation_sequence = {
-                           # frame # | field # | burst phase  |        phase delta | fieldPhaseId | burst phase |
-    # frame 1              #         |         |  (measured)  | (prev vs. current) |              |  (expected) |
-    (1, 2, 0):  (3, 0, 2), # frame 1 | field 1 |         180 ->                 +0 |            3 |         180 |
-    (0, 3, 1):  (2, 1, 3), # frame 1 | field 2 |         270 ->                +90 |            2 |         270 |
-    # frame 2
-    (1, 1, 2):  (1, 1, 1), # frame 2 | field 1 |          90 ->               +180 |            1 |          90 |
-    (0, 0, 3):  (4, 0, 0), # frame 2 | field 2 |           0 ->               +270 |            4 |           0 |
-    # frame 3
-    (1, 0, 0):  (3, 2, 0), # frame 3 | field 1 |           0 ->                 +0 |            3 |           0 |
-    (0, 1, 1):  (2, 3, 1), # frame 3 | field 2 |          90 ->                +90 |            2 |          90 |
-    # frame 4
-    (1, 3, 2):  (1, 3, 3), # frame 4 | field 1 |         270 ->               +180 |            1 |         270 |
-    (0, 2, 3):  (4, 2, 2), # frame 4 | field 2 |         180 ->               +270 |            4 |         180 |
-    # copy of the above, but without phase delta for the first field
-    # frame 1
-    (1, 2, -1): (3, 0, 2),
-    (0, 3, -1): (2, 1, 3),
-    # frame 2
-    (1, 1, -1): (1, 1, 1),
-    (0, 0, -1): (4, 0, 0),
-    # frame 3
-    (1, 0, -1): (3, 2, 0),
-    (0, 1, -1): (2, 3, 1),
-    # frame 4
-    (1, 3, -1): (1, 3, 3),
-    (0, 2, -1): (4, 2, 2),
-}
-
-phase_order = (
-    # frame 1
-    (1, 2, 0),
-    (0, 3, 1),
-    # frame 2
-    (1, 1, 2),
-    (0, 0, 3),
-    # frame 3
-    (1, 0, 0),
-    (0, 1, 1),
-    # frame 4
-    (1, 3, 2),
-    (0, 2, 3),
-)
-
-
-def _check_ntsc_phase_rotation(is_first_field, burst_avg, prev_burst_avg):
-    # quantize to 90 degrees
-    quadrant = int(round(burst_avg) / 90) % 4
-    quadrant_error = (quadrant * 90 - burst_avg + 180) % 360 - 180
-
-    # burst_avg = (burst_avg + quadrant_error) % 360
-    # quadrant = int(round(burst_avg) / 90) % 4
-
-    if prev_burst_avg is None:
-        # cannot use the previous burst if this is the first frame
-        phase_delta = -1
-        phase_delta_quadrant = -1
-        phase_delta_error = -1
-    else:
-        prev_burst_avg = (prev_burst_avg + quadrant_error) % 360
-
-        # use the difference from the previous burst to select the correct phase rotation
-        phase_delta = (burst_avg - prev_burst_avg) % 360
-        phase_delta_quadrant = int(round(phase_delta / 90)) % 4
-        phase_delta_error = (phase_delta_quadrant * 90 - phase_delta + 180) % 360 - 180
-    
-    phase_key = (is_first_field, quadrant, phase_delta_quadrant)
-    phase_data = ntsc_phase_rotation_sequence.get(phase_key, None)
-
-    if phase_data and prev_burst_avg is not None:
-        order = phase_order.index(phase_key)
-    else:
-        order = -1
-    
-    print("phase rotation", "I" if phase_data else "O", order, phase_key, burst_avg, phase_delta)
-
-    # check of this current phase rotation sequence is valid
-    return phase_delta, phase_delta_error, phase_data
+    return chroma_rotation_index, phase_sequence
 
 
 def get_phase_rotation_sequence(
@@ -359,7 +284,6 @@ def get_phase_rotation_sequence(
     chroma_filter,
     chroma_rotation,
     chroma_rotation_index,
-    field_number,
     lineoffset,
     linesout,
     outwidth,
@@ -368,9 +292,8 @@ def get_phase_rotation_sequence(
     burst_cos,
     detect_chroma_track_phase,
     rotation_check_start_line,
-    is_first_field,
-    prev_burst_phase_avg,
     color_system,
+    is_first_field,
 ):
     # *****************************************************
     # Gather the phase differences between each color burst
@@ -382,7 +305,7 @@ def get_phase_rotation_sequence(
 
     end = linesout + lineoffset
 
-    chroma_rotation_index, phase_sequence, burst_phases = _get_phase_sequence(
+    chroma_rotation_index, phase_sequence = _get_phase_sequence(
         chroma,
         chroma_heterodyne,
         chroma_filter,
@@ -409,13 +332,13 @@ def get_phase_rotation_sequence(
         delta_180 = 0
         delta_270 = 0
 
-        for i in range(1, len(burst_phases)):
-            _,                         previous_burst_phase, _, _, _ = burst_phases[i-1]
-            current_burst_line_number, current_burst_phase,  _, _, _ = burst_phases[i]
+        for i in range(1, len(phase_sequence)):
+            _,           _, previous_burst_phase, _, _, _ = phase_sequence[i-1]
+            line_number, _, current_burst_phase,  _, _, _ = phase_sequence[i]
 
             if (
-                current_burst_line_number > burst_check_start and
-                current_burst_line_number < burst_check_end
+                line_number > burst_check_start and
+                line_number < burst_check_end
             ):
                 delta = (current_burst_phase - previous_burst_phase) % 360
                 bucket = int((delta + 45) // 90) % 4
@@ -431,7 +354,7 @@ def get_phase_rotation_sequence(
 
         if color_system == "NTSC":
             # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
-            flip_track_phase = delta_0 < delta_90 + delta_180 + delta_270
+            flip_track_phase = delta_0 < delta_180
         elif color_system == "PAL":
             # each line should alternate phase, if there are repeated sequences of phase, recalculate
             alt1 = delta_90 + delta_270
@@ -445,7 +368,7 @@ def get_phase_rotation_sequence(
 
     if flip_track_phase:
         # recalculate with the corrected track rotation
-        chroma_rotation_index, phase_sequence, burst_phases = _get_phase_sequence(
+        chroma_rotation_index, phase_sequence = _get_phase_sequence(
             chroma,
             chroma_heterodyne,
             chroma_filter,
@@ -466,53 +389,76 @@ def get_phase_rotation_sequence(
     # detect the correct starting phase using the expected phase quadrant of the color bursts
     # ***************************************************************************************
     if color_system == "NTSC":
-        # find the phase of the color burst for the entire field
+        # find the phase of the color burst for the entire field, and detect if the burst is rising or falling
         I_total = 0
         Q_total = 0
+        prev_I = None
+        prev_Q = None
+
         avg_count = 0
-        for linenumber, _, magnitude, I, Q in burst_phases:
+        rotation_sum = 0
+        for line_number, _, _, magnitude, I, Q in phase_sequence:
             if (
-                linenumber > burst_check_start and
-                linenumber < burst_check_end
+                line_number > burst_check_start and
+                line_number < burst_check_end
             ):
                 if magnitude != 0:
-                    I_total += I / magnitude
-                    Q_total += Q / magnitude
+                    I /= magnitude
+                    Q /= magnitude
+                    I_total += I
+                    Q_total += Q
+
+                    if prev_I is not None:
+                        rotation_sum += prev_I * I - prev_Q * Q
+
+                    prev_I = I
+                    prev_Q = Q
                     avg_count += 1
 
         coherence = np.hypot(I_total, Q_total) / avg_count
+
         burst_detected = coherence >= coherence_threshold
-
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
+        burst_rising = rotation_sum > 0
 
-        # check of this current phase rotation sequence is valid
-        phase_delta, phase_delta_error, phase_info = _check_ntsc_phase_rotation(is_first_field, burst_phase_avg, prev_burst_phase_avg)
+        field_phase_id = {
+            (1, 1): (1),
+            (0, 0): (2),
+            (1, 0): (3),
+            (0, 1): (4),
+        }[(is_first_field, burst_rising)]
 
-        if phase_info is None:
-            # something is really wrong with the color, log an error
-            # with the current phase sequence, this condition should never be hit
-            ldd.logger.error(f"Invalid NTSC color sequence: isFirstField: {is_first_field}, colorBurstPhase: {burst_phase_avg}, previousColorBurstPhase: {prev_burst_phase_avg}")
-            # use the entry for frame 1
-            field_phase_id = 3
-            ntsc_phase_rotation = 0
-            expected_burst_phase = 2
-        else:
-            field_phase_id, ntsc_phase_rotation, expected_burst_phase = phase_info
-
+        # color burst phase should be normalized to be at 0 degrees
+        heterodyne_offset = int(round(burst_phase_avg / 90)) % 4
+        heterodyned_burst_avg = (burst_phase_avg - heterodyne_offset * 90) % 360
+        
         # adjust the starting phase
-        if ntsc_phase_rotation != 0:
-            shifted_phase_sequence = []
-            for linenumber, rotation in phase_sequence:
-                shifted_phase_sequence.append((linenumber, (rotation + ntsc_phase_rotation) % 4))
-            phase_sequence = shifted_phase_sequence
+        if heterodyne_offset != 0:
+            for i in range(len(phase_sequence)):
+                (
+                    line_number,
+                    phase,
+                    burst_phase,
+                    burst_magnitude,
+                    burst_I,
+                    burst_Q
+                ) = phase_sequence[i]
+
+                phase_sequence[i] = (
+                    line_number,
+                    (phase - heterodyne_offset) % 4,
+                    (burst_phase - (heterodyne_offset * 90)) % 360,
+                    burst_magnitude,
+                    burst_I,
+                    burst_Q
+                )
     else:
-        burst_phases = None
+        heterodyned_burst_avg = None
         field_phase_id = None
-        burst_phase_avg = None
         burst_detected = None
 
-    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected
-    
+    return chroma_rotation_index, phase_sequence, field_phase_id, heterodyned_burst_avg, burst_detected
+
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
     chroma,
@@ -523,7 +469,7 @@ def upconvert_chroma(
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
 
-    for linenumber, current_phase in phase_rotation_sequence:
+    for linenumber, current_phase, _, _, _, _ in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
         lineend = linestart + outwidth
 
@@ -594,11 +540,6 @@ def decode_chroma_phase_rotation(
 
     burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
 
-    prev_burst_phase = None
-    if field.prevfield is not None:
-        if field.rf.color_system == "NTSC":
-            prev_burst_phase = field.prevfield.burst_phase_avg
-
     # Rotation per track
     # VHS PAL:      Track1 0,   Track2 -90
     # VHS NTSC:     Track1 +90, Track2 -90
@@ -613,13 +554,12 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    track_phase, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
+    track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
         chroma_rotation,
         field.rf.track_phase, # index for chroma rotation, and static if there is no chroma rotation
-        field.field_number,
         lineoffset,
         linesout,
         outwidth,
@@ -628,12 +568,11 @@ def decode_chroma_phase_rotation(
         field.rf.fsc_cos_wave,
         detect_chroma_track_phase,
         rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
+        field.rf.color_system,
         field.isFirstField,
-        prev_burst_phase,
-        field.rf.color_system
     )
 
-    return track_phase, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected
+    return track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_detected
 
 def process_chroma(
     field,

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -110,6 +110,26 @@ def comb_c_ntsc(data, line_len):
         ) / 4
     return data
 
+@njit(cache=True, nogil=True, fastmath=True)
+def _demod_burst(
+    burst,
+    burst_start,
+    burst_end,
+    burst_sin,
+    burst_cos
+):
+    I = 0
+    Q = 0
+
+    for i in range(burst_end - burst_start):
+        I += burst[i] * burst_cos[i + burst_start]
+        Q += burst[i] * burst_sin[i + burst_start]
+
+    burst_phase = np.arctan2(Q, I)
+    burst_phase_deg = np.degrees(burst_phase) % 360
+
+    return burst_phase_deg, I, Q
+
 def get_upconverted_burst(
     chroma,
     phase,
@@ -119,18 +139,30 @@ def get_upconverted_burst(
     burstarea,
     chroma_heterodyne,
     chroma_filter,
+    burst_sin,
+    burst_cos
 ):
     burst_padding = burstarea[1] - burstarea[0] # pad the area being filtered
-    burst_start = max(0, (linenumber - lineoffset) * outwidth + burstarea[0] - burst_padding)
-    burst_end = min(len(chroma), burst_start + burstarea[1] + burst_padding)
 
-    burst = chroma_heterodyne[phase][burst_start:burst_end] * chroma[burst_start:burst_end]
+    line_start = (linenumber - lineoffset) * outwidth
+    burst_start = line_start + burstarea[0]
+    burst_start_padding = burst_start - max(0, burst_start - burst_padding)
+    burst_start_with_padding = burst_start - burst_start_padding
+
+    burst_end = line_start + burstarea[1]
+    burst_end_padding = min(len(chroma), burst_end + burst_padding) - burst_end
+    burst_end_with_padding = burst_end + burst_end_padding
+
+    burst_padded = chroma_heterodyne[phase][burst_start_with_padding:burst_end_with_padding] * chroma[burst_start_with_padding:burst_end_with_padding]
 
     # filter out noise so only the color burst is present
-    filtered = sosfiltfilt_rust(chroma_filter, burst)
-    burst_without_padding = filtered[burst_padding:-burst_padding]
+    burst_padded_filtered =  sosfiltfilt_rust(chroma_filter, burst_padded)
 
-    return burst_without_padding, burst_start + burst_padding, burst_end - burst_padding
+    burst_filtered = burst_padded_filtered[burst_start_padding:-burst_end_padding]
+
+    burst_phase_deg, I, Q = _demod_burst(burst_filtered, burst_start, burst_end, burst_sin, burst_cos)
+
+    return burst_phase_deg, I, Q, burst_start, burst_end
 
 # input
 # (
@@ -173,20 +205,92 @@ ntsc_phase_rotation_sequence = {
     (0, 2, -1): (4, 2),
 }
 
+def _get_phase_sequence(
+    chroma,
+    chroma_heterodyne,
+    track_rotation,
+    chroma_rotation,
+    chroma_filter,
+    burst_sin,
+    burst_cos,
+    burstarea,
+    lineoffset,
+    outwidth,
+    linesout,
+    last_line,
+    do_phase_rotation_check,
+    track_change_threshold,
+    rotation_check_start_line,
+):
+    phase_sequence = []
+    burst_phases = []
+
+    # rewind to the previous phase (line -1)
+    current_phase = 0
+    for _ in range(3):
+        current_phase = (current_phase + track_rotation) % 4
+
+    for linenumber in range(lineoffset, last_line):
+        current_phase = (current_phase + track_rotation) % 4
+        current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = get_upconverted_burst(
+            chroma,
+            current_phase,
+            linenumber,
+            lineoffset,
+            outwidth,
+            burstarea,
+            chroma_heterodyne,
+            chroma_filter,
+            burst_sin,
+            burst_cos
+        )
+
+        if (
+            do_phase_rotation_check and
+            linenumber >= rotation_check_start_line and
+            linenumber < last_line - 1
+        ):
+            # get the next burst using the phase rotation for the current track
+            next_phase = (current_phase + track_rotation) % 4
+            next_burst_phase, _, _, _, _ = get_upconverted_burst(
+                chroma,
+                next_phase,
+                linenumber + 1,
+                lineoffset,
+                outwidth,
+                burstarea,
+                chroma_heterodyne,
+                chroma_filter,
+                burst_sin,
+                burst_cos
+            )
+
+            phase_delta = abs((next_burst_phase - current_burst_phase + 180) % 360 - 180)
+            if phase_delta > track_change_threshold:
+                # positive correlation -> in phase
+                # negative correlation -> out of phase
+                # burst is more in phase than out of phase, flip rotation so it remains out of phase
+                track_rotation = chroma_rotation[1] if track_rotation == chroma_rotation[0] else chroma_rotation[0]
+        
+        phase_sequence.append((linenumber, current_phase))
+        burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end))
+
+    return phase_sequence, burst_phases
+
 def get_phase_rotation_sequence(
     chroma,
     rotation_check_start_line,
     lineoffset,
     linesout,
     outwidth,
-    phase_rotation,
     is_first_field,
-    prev_burst_phase,
+    prev_burst_phase_avg,
     color_system,
-    burst_sine,
-    burst_cosine,
+    burst_sin,
+    burst_cos,
     detect_chroma_track_phase,
-    chroma_rotation,
+    track_rotation,
+    chroma_rotations,
     chroma_heterodyne,
     burstarea,
     chroma_filter,
@@ -195,64 +299,107 @@ def get_phase_rotation_sequence(
     # Gather the phase differences between each color burst
     # Color burst alternates phase between lines in a field
     # *****************************************************    
-    track_change_threshold = 0.5
-    phase_rotations = []
-    bursts = []
+    track_change_threshold = 90
     burst_check_skip_lines = 16
-    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
+    coherence_threshold = 0.3
 
-    # rewind to the previous phase (line -1)
-    current_phase = 0
-    for _ in range(3):
-        current_phase = (current_phase + phase_rotation) % 4
-    
+    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotations is not None and chroma_heterodyne is not None
+
     end = linesout + lineoffset
+    phase_sequence, burst_phases = _get_phase_sequence(
+        chroma,
+        chroma_heterodyne,
+        track_rotation,
+        chroma_rotations,
+        chroma_filter,
+        burst_sin,
+        burst_cos,
+        burstarea,
+        lineoffset,
+        outwidth,
+        linesout,
+        end,
+        do_phase_rotation_check,
+        track_change_threshold,
+        rotation_check_start_line,
+    )
 
-    for linenumber in range(lineoffset, end):
-        current_phase = (current_phase + phase_rotation) % 4
-        current_burst, current_burst_start, current_burst_end = get_upconverted_burst(chroma, current_phase, linenumber, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
-        current_burst_norm = np.linalg.norm(current_burst)
+    # detect the track phase, and recalculate if needed
+    burst_check_start = burst_check_skip_lines
+    burst_check_end = end - burst_check_skip_lines
 
-        if (
-            burst_check_skip_lines < linenumber and
-            burst_check_skip_lines < end - linenumber
-        ):
-            bursts.append((current_burst, current_burst_start, current_burst_end))
+    if chroma_rotations:
+        # get the average difference in phase across color bursts
+        avg_delta = 0
+        burst_count = 0
 
-        if (
-            do_phase_rotation_check and
-            linenumber >= rotation_check_start_line and
-            linenumber < end - 1
-        ):
-            # get the next burst using the phase rotation for the current track
-            next_phase = (current_phase + phase_rotation) % 4
-            next_burst, _, _ = get_upconverted_burst(chroma, next_phase, linenumber + 1, lineoffset, outwidth, burstarea, chroma_heterodyne, chroma_filter)
-            next_burst_norm = np.linalg.norm(next_burst)
+        for i in range(1, len(burst_phases)):
+            _,                         previous_burst, _, _, _, _ = burst_phases[i-1]
+            current_burst_line_number, current_burst, _, _, _, _  = burst_phases[i]
 
-            phase_correlation = np.dot(current_burst, next_burst) / (current_burst_norm * next_burst_norm)
+            if (
+                current_burst_line_number > burst_check_start and
+                current_burst_line_number < burst_check_end
+            ):
+                avg_delta = avg_delta + ((current_burst - previous_burst) % 360)
+                burst_count += 1
 
-            if phase_correlation > track_change_threshold:
-                # positive correlation -> in phase
-                # negative correlation -> out of phase
-                # burst is more in phase than out of phase, flip rotation so it remains out of phase
-                phase_rotation = chroma_rotation[1] if phase_rotation == chroma_rotation[0] else chroma_rotation[0]
+        avg_delta /= burst_count
+        
+        # if the bursts are in phase, the track was miss-detected, flip phase and recalculate sequence
+        # TODO: make work for PAL
+        if avg_delta < 90:
+            track_rotation = chroma_rotations[1] if track_rotation == chroma_rotations[0] else chroma_rotations[0]
+            # recalculate with the fixed track rotation
+            phase_sequence, burst_phases = _get_phase_sequence(
+                chroma,
+                chroma_heterodyne,
+                track_rotation,
+                chroma_rotations,
+                chroma_filter,
+                burst_sin,
+                burst_cos,
+                burstarea,
+                lineoffset,
+                outwidth,
+                linesout,
+                end,
+                do_phase_rotation_check,
+                track_change_threshold,
+                rotation_check_start_line,
+            )
 
-        phase_rotations.append(current_phase)
-
+    # ***************************************************************************************
+    # detect the correct starting phase using the expected phase quadrant of the color bursts
+    # ***************************************************************************************
     if color_system == "NTSC":
-        # detect the correct starting phase using the expected phase quadrant of the color bursts
-        burst_phase, burst_detected = detect_ntsc_color_burst_phase(bursts, burst_sine, burst_cosine)
+        # find the phase of the color burst for the entire field
+        I_total = 0
+        Q_total = 0
+        for linenumber, _, I, Q, _, _ in burst_phases:
+            if (
+                linenumber > burst_check_start and
+                linenumber < burst_check_end
+            ):
+                magnitude = np.hypot(I, Q) + 1e-12
+                I_total += I / magnitude
+                Q_total += Q / magnitude  
 
-        if prev_burst_phase is not None:
+        burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
+
+        coherence = np.hypot(I_total, Q_total) / len(burst_phases)
+        burst_detected = coherence >= coherence_threshold      
+
+        if prev_burst_phase_avg is not None:
             # if we have the phase difference between the previous burst and this burst, we further refine the detection based on the known phase delta between rotations
-            delta = (burst_phase - prev_burst_phase) % 360
+            delta = (burst_phase_avg - prev_burst_phase_avg) % 360
             phase_delta = int(round(delta / 90)) % 4
         else:
             # since there is no prior phase to determine the phase delta, only use isFirstField and quadrant
             phase_delta = -1
 
         # quantize to 90 degrees
-        quadrant = int(round(burst_phase) / 90) % 4
+        quadrant = int(round(burst_phase_avg) / 90) % 4
 
         # match the phase using the first field, detected color burst phase quadrant, and the phase difference from the previous burst
         phase_info = ntsc_phase_rotation_sequence.get(
@@ -267,21 +414,24 @@ def get_phase_rotation_sequence(
         else:
             # something is really wrong with the color, log an error
             # with the current phase sequence, this condition should never be hit
-            ldd.logger.error(f"Invalid NTSC color sequence: isFirstField: {is_first_field}, colorBurstPhase: {burst_phase}, previousColorBurstPhase: {prev_burst_phase}")
+            ldd.logger.error(f"Invalid NTSC color sequence: isFirstField: {is_first_field}, colorBurstPhase: {burst_phase_avg}, previousColorBurstPhase: {prev_burst_phase_avg}")
             # use the entry for frame 1
             field_phase_id = 1
             ntsc_phase_rotation = 3
 
         # adjust the starting phase
         if ntsc_phase_rotation != 0:
-            for i in range(0, len(phase_rotations)):
-                phase_rotations[i] = (phase_rotations[i] + ntsc_phase_rotation) % 4
+            shifted_phase_sequence = []
+            for linenumber, rotation in phase_sequence:
+                shifted_phase_sequence.append((linenumber, (rotation + ntsc_phase_rotation) % 4))
+            phase_sequence = shifted_phase_sequence
     else:
+        burst_phases = None
         field_phase_id = None
-        burst_phase = None
+        burst_phase_avg = None
         burst_detected = None
 
-    return phase_rotations, field_phase_id, burst_phase, burst_detected
+    return track_rotation, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -295,10 +445,7 @@ def upconvert_chroma(
     uphet = np.zeros(len(chroma), dtype=np.float32)
     phase_index = 0
 
-    for linenumber in range(lineoffset, linesout + lineoffset):
-        current_phase = phase_rotation_sequence[phase_index]
-        phase_index += 1
-
+    for linenumber, current_phase in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
         lineend = linestart + outwidth
 
@@ -352,15 +499,82 @@ def demod_chroma_filt(
     return shift_chroma_and_remove_dc(out_chroma, move)
 
 
+def decode_chroma_phase_rotation(
+    field,
+    disable_tracking_cafc=False,
+    chroma_rotation=None,
+    detect_chroma_track_phase=False,
+):
+    chroma, _, _ = ldd.Field.downscale(field, channel="demod_burst")
+
+    lineoffset = field.lineoffset + 1
+    linesout = field.outlinecount
+    outwidth = field.outlinelen
+
+    burst_area_init = get_burst_area(field)
+    burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
+
+    prev_burst_phase = None
+    if field.rf.color_system == "NTSC":
+        if field.prevfield is not None:
+            prev_burst_phase = field.prevfield.burst_phase_avg
+
+    # Rotation per track
+    # VHS PAL: Track1 0, Track2 -90
+    # VHS NTSC: Track1 +90, Track2 -90
+    # Betamax PAL: None - uses frequency offset instead
+    # Betamax NTSC: Track1 180, Track2 0
+    # Video8 NTSC: Track1 0, Track2 180
+    # Video8 PAL: Track1 0, Track2 -90
+
+    if field.rf.track_phase is None:
+        # guess something for the first field
+        if chroma_rotation:
+            track_rotation = chroma_rotation[0]
+        else:
+            # Track 2 is rotated ccw in both NTSC and PAL for VHS
+            # u-matic has no phase rotation.
+            track_rotation = 0
+    elif chroma_rotation:
+        # flip
+        if field.rf.track_phase == chroma_rotation[0]:
+            track_rotation = chroma_rotation[1]
+        else:
+            track_rotation = chroma_rotation[0]
+    else:
+        track_rotation = field.rf.track_phase
+
+    chroma_heterodyne = (
+        field.rf.chroma_afc.getChromaHet()
+        if (field.rf.do_cafc and not disable_tracking_cafc)
+        else field.rf.chroma_heterodyne
+    )
+
+    return get_phase_rotation_sequence(
+        chroma,
+        lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
+        lineoffset,
+        linesout,
+        outwidth,
+        field.isFirstField,
+        prev_burst_phase,
+        field.rf.color_system,
+        field.rf.fsc_wave,
+        field.rf.fsc_cos_wave,
+        detect_chroma_track_phase,
+        track_rotation,
+        chroma_rotation,
+        chroma_heterodyne,
+        burstarea,
+        field.rf.Filters["FChromaFinal"],
+    )
+
 def process_chroma(
     field,
-    track_phase,
     disable_deemph=False,
     disable_comb=False,
     disable_tracking_cafc=False,
-    chroma_rotation=None,
     do_chroma_deemphasis=False,
-    detect_chroma_track_phase=False,
 ):
     # Run TBC/downscale on chroma (if new field, else uses cache)
     # Cached if chroma process is run multiple times on one field due to track detection.
@@ -399,44 +613,10 @@ def process_chroma(
     burst_area_init = get_burst_area(field)
     burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
 
-    # narrow_filtered = utils.filter_simple(chroma, field.rf.Filters["FBurstNarrow"])
-
-    # for line_num in range(16, linesout - 2):
-    # lstart = line_num * outwidth
-    # lend = (line_num + 1) * outwidth
-    #
-    # chroma[lstart:lend][burstarea[0]:burstarea[1]] = narrow_filtered[lstart:lend][burstarea[0]:burstarea[1]] * 2
-
     # For NTSC, the color burst amplitude is doubled when recording, so we have to undo that.
-    prev_burst_phase = None
-    
     if field.rf.color_system == "NTSC":
-        if field.prevfield is not None:
-            prev_burst_phase = field.prevfield.burstPhase
-
         if not disable_deemph:
             chroma = burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea)
-
-    # Rotation per track
-    # VHS PAL: Track1 0, Track2 -90
-    # VHS NTSC: Track1 +90, Track2 -90
-    # Betamax PAL: None - uses frequency offset instead
-    # Betamax NTSC: Track1 180, Track2 0
-    # Video8 NTSC: Track1 0, Track2 180
-    # Video8 PAL: Track1 0, Track2 -90
-
-    if track_phase is not None:
-        if chroma_rotation:
-            if field.field_number % 2 == track_phase:
-                phase_rotation = chroma_rotation[0]
-            else:
-                phase_rotation = chroma_rotation[1]
-        else:
-            phase_rotation = track_phase
-    else:
-        # Track 2 is rotated ccw in both NTSC and PAL for VHS
-        # u-matic has no phase rotation.
-        phase_rotation = 0
 
     chroma_heterodyne = (
         field.rf.chroma_afc.getChromaHet()
@@ -444,39 +624,13 @@ def process_chroma(
         else field.rf.chroma_heterodyne
     )
 
-    phase_rotation_sequence, field_phase_id, burst_phase, burst_detected = get_phase_rotation_sequence(
-        chroma,
-        lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
-        lineoffset,
-        linesout,
-        outwidth,
-        phase_rotation,
-        field.isFirstField,
-        prev_burst_phase,
-        field.rf.color_system,
-        field.rf.fsc_wave,
-        field.rf.fsc_cos_wave,
-        detect_chroma_track_phase,
-        chroma_rotation,
-        chroma_heterodyne,
-        burstarea,
-        field.rf.Filters["FChromaFinal"],
-    )
-
-    if field.rf.color_system == "NTSC":
-        field.fieldPhaseID = field_phase_id
-        field.burstPhase = burst_phase
-        # TODO: possibly use this to enable a color killer
-        # if not burst_detected:
-        #     ldd.logger.info("Color burst was not detected.")
-
     uphet = upconvert_chroma(
         chroma,
         lineoffset,
         linesout,
         outwidth,
         chroma_heterodyne,
-        phase_rotation_sequence,
+        field.phase_sequence,
     )
 
     # Filter out unwanted frequencies from the final chroma signal.
@@ -553,58 +707,28 @@ def decode_chroma_simple(field):
     raw_loc = check_increment_field_no(field.rf, field)
 
     uphet = process_chroma(
-        field, None, True, field.rf.options.disable_comb, disable_tracking_cafc=False
+        field, True, field.rf.options.disable_comb, disable_tracking_cafc=False
     )
     # Release to avoid keeping this im memory - TODO: should do this in a cleaner manner.
     field.chroma_tbc_buffer = None
     field.uphet_temp = uphet
-    # Store previous raw location so we can detect if we moved in the next call.
-    field.rf.last_raw_loc = raw_loc
     return chroma_to_u16(uphet)
 
 
-def decode_chroma(field, chroma_rotation=None, do_chroma_deemphasis=False, detect_chroma_track_phase=False):
+def decode_chroma(field, do_chroma_deemphasis=False):
     """Do track detection if needed and upconvert the chroma signal"""
     rf = field.rf
     field.chroma_tbc_buffer = None
 
-    # Use field number based on raw data position
-    # This may not be 100% accurate, so we may want to add some more logic to
-    # make sure we re-check the phase occasionally.
-    raw_loc = check_increment_field_no(rf, field)
-
-    # If we moved significantly more than the length of one field, re-check phase
-    # as we may have skipped fields.
-    # if raw_loc - rf.last_raw_loc > 1.3:
-    if (
-        not field.prevfield
-        or ((field.readloc - field.prevfield.readloc) / rf.decoder.bytes_per_field)
-        > 1.3
-        or rf.compute_linelocs_issues
-    ):
-        if rf.detect_track and not rf.needs_detect:
-            ldd.logger.info(
-                "Possibly skipped a track, re-checking phase.. %s", rf.track_phase
-            )
-            rf.needs_detect = True
-
-    if rf.detect_track and rf.needs_detect or rf.recheck_phase:
-        rf.track_phase, rf.needs_detect = field.try_detect_track()
-
     uphet = process_chroma(
         field,
-        track_phase=rf.track_phase,
         disable_comb=rf.options.disable_comb,
         disable_tracking_cafc=False,
-        chroma_rotation=chroma_rotation,
         do_chroma_deemphasis=do_chroma_deemphasis,
-        detect_chroma_track_phase=detect_chroma_track_phase
     )
     field.uphet_temp = uphet
     # Release to avoid keeping this im memory - should do this in a cleaner manner.
     field.chroma_tbc_buffer = None
-    # Store previous raw location so we can detect if we moved in the next call.
-    rf.last_raw_loc = raw_loc
     return chroma_to_u16(uphet)
 
 
@@ -759,44 +883,6 @@ def detect_burst_pal_line(
 
     return LineInfo(line_number, line_bp, line_bq, line_vsw, line_burst_norm)
 
-@njit(fastmath=True, cache=True, nogil=True)
-def detect_ntsc_color_burst_phase(
-    bursts,
-    sine_wave,
-    cosine_wave,
-    coherence_threshold=0.3
-):
-    """ Detects the phase rotation quadrant using the color burst phase"""
-    # Ignore the first and last 16 lines of the field.
-    # first ones contain sync and often doesn't have color burst,
-    # while the last lines of the field will contain the head switch and may be distorted.
-    I_total = 0
-    Q_total = 0
-
-    for burst, burst_start, burst_end in bursts:
-        I = 0
-        Q = 0
-
-        for i in range(burst_end - burst_start):
-            I += burst[i] * cosine_wave[i + burst_start]
-            Q += burst[i] * sine_wave[i + burst_start]
-
-        magnitude = np.hypot(I, Q)
-        if magnitude > 0:
-            I_total += I / magnitude
-            Q_total += Q / magnitude
-
-    # Check that burst phase is consistent
-    # If phase is not consistent, then likely there is no color burst present
-    coherence = np.hypot(I_total, Q_total) / len(bursts)
-    burst_detected = coherence >= coherence_threshold        
-
-    # Global field phase
-    avg_phase = np.arctan2(Q_total, I_total)
-    avg_phase_deg = np.degrees(avg_phase) % 360
-
-    return avg_phase_deg, burst_detected
-
 
 # Phase comprensation stuff - needs rework.
 # def phase_shift(data, angle):
@@ -835,8 +921,8 @@ def try_detect_track_vhs_pal(field, chroma_rotation=None):
 
     # Upconvert chroma twice, once for each possible track phase
     uphet = [
-        process_chroma(field, 0, True, True, chroma_rotation=chroma_rotation),
-        process_chroma(field, 1, True, True, chroma_rotation=chroma_rotation),
+        process_chroma(field, True, True),
+        process_chroma(field, True, True),
     ]
 
     sine_wave = field.rf.fsc_wave
@@ -864,48 +950,3 @@ def try_detect_track_vhs_pal(field, chroma_rotation=None):
 
     return assumed_phase, needs_recheck(phase0_mean, phase1_mean)
 
-
-def try_detect_track_ntsc(field, chroma_rotation=None):
-    """Try to detect which track the current field was read from.
-    returns 0 or 1 depending on detected track phase.
-
-    We use the fact that the color burst in NTSC is inverted on every line, so
-    in a perfect signal, the burst from one line and the previous one should cancel
-    each other out when summed together. When upconverting with the wrong phase rotation,
-    the bursts will have the same phase instead, and thus the mean absolute
-    sum will be much higher. This seem to give a reasonably good guess, but could probably
-    be improved.
-
-    assumed_phase is 0 if field number % 2 matches second track,
-     1 if it matches settings for the first track.
-
-    """
-    ldd.logger.debug("Trying to detect NTSC track phase ...")
-    burst_area = get_burstarea(field)
-
-    # Upconvert chroma twice, once for each possible track phase
-
-    uphet = [
-        process_chroma(field, 0, True, chroma_rotation=chroma_rotation),
-        process_chroma(field, 1, True, chroma_rotation=chroma_rotation),
-    ]
-
-    # Look at the bursts from each upconversion and see which one looks most
-    # normal.
-    burst_mean_sum = list()
-    for ix, uph in enumerate(uphet):
-        burst_mean_sum.append(
-            mean_of_burst_sums(
-                uph, field.outlinelen, field.outlinecount, burst_area[0], burst_area[1]
-            )
-        )
-
-    burst_mean_sum_0, burst_mean_sum_1 = burst_mean_sum[0], burst_mean_sum[1]
-
-    assumed_phase = int(burst_mean_sum_1 < burst_mean_sum_0)
-
-    log_track_phase(
-        field.rf.track_phase, burst_mean_sum_0, burst_mean_sum_1, assumed_phase
-    )
-
-    return assumed_phase, needs_recheck(burst_mean_sum_0, burst_mean_sum_1)

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -230,20 +230,32 @@ def _get_phase_sequence(
     for _ in range(3):
         current_phase = (current_phase + track_rotation) % 4
 
+    use_next_phase = False
     for linenumber in range(lineoffset, last_line):
-        current_phase = (current_phase + track_rotation) % 4
-        current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = _get_upconverted_burst(
-            chroma,
-            chroma_heterodyne,
-            chroma_filter,
-            current_phase,
-            burstarea,
-            burst_sin,
-            burst_cos,
-            linenumber,
-            lineoffset,
-            outwidth,
-        )
+        if use_next_phase:
+            # reuse the calculated phase from the previous iteration
+            current_phase = next_phase
+            current_burst_phase = next_burst_phase
+            current_burst_I = next_burst_I
+            current_burst_Q = next_burst_Q
+            current_burst_start = next_burst_start
+            current_burst_end  = next_burst_end
+
+            use_next_phase = False
+        else:
+            current_phase = (current_phase + track_rotation) % 4
+            current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = _get_upconverted_burst(
+                chroma,
+                chroma_heterodyne,
+                chroma_filter,
+                current_phase,
+                burstarea,
+                burst_sin,
+                burst_cos,
+                linenumber,
+                lineoffset,
+                outwidth,
+            )
 
         # check if the track has rotated around the head switching area
         if (
@@ -253,7 +265,7 @@ def _get_phase_sequence(
         ):
             # get the next burst using the phase rotation for the current track
             next_phase = (current_phase + track_rotation) % 4
-            next_burst_phase, _, _, _, _ = _get_upconverted_burst(
+            next_burst_phase, next_burst_I, next_burst_Q, next_burst_start, next_burst_end  = _get_upconverted_burst(
                 chroma,
                 chroma_heterodyne,
                 chroma_filter,
@@ -273,6 +285,8 @@ def _get_phase_sequence(
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
                 chroma_rotation_index = (chroma_rotation_index + 1) % 2
                 track_rotation = chroma_rotation[chroma_rotation_index]
+            else:
+                use_next_phase = True
         
         phase_sequence.append((linenumber, current_phase))
         burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end))

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -208,7 +208,7 @@ ntsc_phase_rotation_sequence = {
 def _get_phase_sequence(
     chroma,
     chroma_heterodyne,
-    track_rotation,
+    track_phase,
     chroma_rotation,
     chroma_filter,
     burst_sin,
@@ -216,7 +216,6 @@ def _get_phase_sequence(
     burstarea,
     lineoffset,
     outwidth,
-    linesout,
     last_line,
     do_phase_rotation_check,
     track_change_threshold,
@@ -224,6 +223,7 @@ def _get_phase_sequence(
 ):
     phase_sequence = []
     burst_phases = []
+    track_rotation = chroma_rotation[track_phase] if chroma_rotation else 0
 
     # rewind to the previous phase (line -1)
     current_phase = 0
@@ -270,7 +270,8 @@ def _get_phase_sequence(
                 # positive correlation -> in phase
                 # negative correlation -> out of phase
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
-                track_rotation = chroma_rotation[1] if track_rotation == chroma_rotation[0] else chroma_rotation[0]
+                track_phase = (track_phase + 1) % 2
+                track_rotation = chroma_rotation[track_phase]
         
         phase_sequence.append((linenumber, current_phase))
         burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end))
@@ -289,7 +290,7 @@ def get_phase_rotation_sequence(
     burst_sin,
     burst_cos,
     detect_chroma_track_phase,
-    track_rotation,
+    track_phase,
     chroma_rotations,
     chroma_heterodyne,
     burstarea,
@@ -309,7 +310,7 @@ def get_phase_rotation_sequence(
     phase_sequence, burst_phases = _get_phase_sequence(
         chroma,
         chroma_heterodyne,
-        track_rotation,
+        track_phase,
         chroma_rotations,
         chroma_filter,
         burst_sin,
@@ -317,7 +318,6 @@ def get_phase_rotation_sequence(
         burstarea,
         lineoffset,
         outwidth,
-        linesout,
         end,
         do_phase_rotation_check,
         track_change_threshold,
@@ -329,9 +329,11 @@ def get_phase_rotation_sequence(
     burst_check_end = end - burst_check_skip_lines
 
     if chroma_rotations:
-        # get the average difference in phase across color bursts
-        avg_delta = 0
-        burst_count = 0
+        # detect relative phase difference between lines
+        delta_0 = 0
+        delta_90 = 0
+        delta_180 = 0
+        delta_270 = 0
 
         for i in range(1, len(burst_phases)):
             _,                         previous_burst, _, _, _, _ = burst_phases[i-1]
@@ -341,33 +343,51 @@ def get_phase_rotation_sequence(
                 current_burst_line_number > burst_check_start and
                 current_burst_line_number < burst_check_end
             ):
-                avg_delta = avg_delta + ((current_burst - previous_burst) % 360)
-                burst_count += 1
+                delta = (current_burst - previous_burst) % 360
+                bucket = int((delta + 45) // 90) % 4
 
-        avg_delta /= burst_count
-        
-        # if the bursts are in phase, the track was miss-detected, flip phase and recalculate sequence
-        # TODO: make work for PAL
-        if avg_delta < 90:
-            track_rotation = chroma_rotations[1] if track_rotation == chroma_rotations[0] else chroma_rotations[0]
-            # recalculate with the fixed track rotation
-            phase_sequence, burst_phases = _get_phase_sequence(
-                chroma,
-                chroma_heterodyne,
-                track_rotation,
-                chroma_rotations,
-                chroma_filter,
-                burst_sin,
-                burst_cos,
-                burstarea,
-                lineoffset,
-                outwidth,
-                linesout,
-                end,
-                do_phase_rotation_check,
-                track_change_threshold,
-                rotation_check_start_line,
-            )
+                if bucket == 0:
+                    delta_0 += 1
+                elif bucket == 1:
+                    delta_90 += 1
+                elif bucket == 2:
+                    delta_180 += 1
+                else:
+                    delta_270 += 1
+
+        if color_system == "NTSC":
+            # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
+            should_flip = delta_0 < (delta_90 + delta_180 + delta_270)
+        elif color_system == "PAL":
+            # each line should alternate phase, if there are repeated sequences of phase, recalculate
+            alt1 = delta_90 + delta_270
+            alt2 = delta_0 + delta_180
+
+            # choose whichever pattern dominates
+            should_flip = alt1 < alt2
+    else:
+        # no difference between track phases, do not flip
+        should_flip = False
+
+    if should_flip:
+        track_phase = (track_phase + 1) % 2
+        # recalculate with the corrected track rotation
+        phase_sequence, burst_phases = _get_phase_sequence(
+            chroma,
+            chroma_heterodyne,
+            track_phase,
+            chroma_rotations,
+            chroma_filter,
+            burst_sin,
+            burst_cos,
+            burstarea,
+            lineoffset,
+            outwidth,
+            end,
+            do_phase_rotation_check,
+            track_change_threshold,
+            rotation_check_start_line,
+        )
 
     # ***************************************************************************************
     # detect the correct starting phase using the expected phase quadrant of the color bursts
@@ -431,7 +451,7 @@ def get_phase_rotation_sequence(
         burst_phase_avg = None
         burst_detected = None
 
-    return track_rotation, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
+    return track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -515,9 +535,10 @@ def decode_chroma_phase_rotation(
     burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
 
     prev_burst_phase = None
-    if field.rf.color_system == "NTSC":
-        if field.prevfield is not None:
+    if field.prevfield is not None:
+        if field.rf.color_system == "NTSC":
             prev_burst_phase = field.prevfield.burst_phase_avg
+        
 
     # Rotation per track
     # VHS PAL: Track1 0, Track2 -90
@@ -528,21 +549,10 @@ def decode_chroma_phase_rotation(
     # Video8 PAL: Track1 0, Track2 -90
 
     if field.rf.track_phase is None:
-        # guess something for the first field
-        if chroma_rotation:
-            track_rotation = chroma_rotation[0]
-        else:
-            # Track 2 is rotated ccw in both NTSC and PAL for VHS
-            # u-matic has no phase rotation.
-            track_rotation = 0
-    elif chroma_rotation:
-        # flip
-        if field.rf.track_phase == chroma_rotation[0]:
-            track_rotation = chroma_rotation[1]
-        else:
-            track_rotation = chroma_rotation[0]
-    else:
-        track_rotation = field.rf.track_phase
+        field.rf.track_phase = 0
+    elif not field.track_phase_set and chroma_rotation:
+        # if this is the first time this is called, flip the rotation
+        field.rf.track_phase = (field.rf.track_phase + 1) % 2
 
     chroma_heterodyne = (
         field.rf.chroma_afc.getChromaHet()
@@ -550,7 +560,7 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    return get_phase_rotation_sequence(
+    track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
         chroma,
         lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
         lineoffset,
@@ -562,12 +572,14 @@ def decode_chroma_phase_rotation(
         field.rf.fsc_wave,
         field.rf.fsc_cos_wave,
         detect_chroma_track_phase,
-        track_rotation,
+        field.rf.track_phase,
         chroma_rotation,
         chroma_heterodyne,
         burstarea,
         field.rf.Filters["FChromaFinal"],
     )
+
+    return track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
 
 def process_chroma(
     field,
@@ -692,27 +704,6 @@ def check_increment_field_no(rf, field):
     # print("self field number", field.field_number, " rf.field_number", rf.field_number)
 
     return raw_loc
-
-
-def decode_chroma_simple(field):
-    """Upconvert the chroma signal
-    Simple upconversion with no rotation etc for umatic, vcr, eiaj and similar.
-    """
-
-    field.chroma_tbc_buffer = None
-
-    # Use field number based on raw data position
-    # This may not be 100% accurate, so we may want to add some more logic to
-    # make sure we re-check the phase occasionally.
-    raw_loc = check_increment_field_no(field.rf, field)
-
-    uphet = process_chroma(
-        field, True, field.rf.options.disable_comb, disable_tracking_cafc=False
-    )
-    # Release to avoid keeping this im memory - TODO: should do this in a cleaner manner.
-    field.chroma_tbc_buffer = None
-    field.uphet_temp = uphet
-    return chroma_to_u16(uphet)
 
 
 def decode_chroma(field, do_chroma_deemphasis=False):
@@ -894,59 +885,3 @@ def get_burstarea(field):
         math.floor(field.usectooutpx(field.rf.SysParams["colorBurstUS"][0])),
         math.ceil(field.usectooutpx(field.rf.SysParams["colorBurstUS"][1])),
     )
-
-
-def log_track_phase(track_phase, phase0_mean, phase1_mean, assumed_phase):
-    ldd.logger.debug("Phase previously set: %i", track_phase)
-    ldd.logger.debug("phase0 mean: %.02f", phase0_mean)
-    ldd.logger.debug("phase1 mean: %.02f", phase1_mean)
-    ldd.logger.debug("assumed_phase: %d", assumed_phase)
-
-
-def try_detect_track_betamax_pal(field):
-    pass
-
-
-def try_detect_track_vhs_pal(field, chroma_rotation=None):
-    """Try to detect what video track we are on.
-
-    VHS tapes have two tracks with different azimuth that alternate and are read by alternating
-    heads on the video drum. The phase of the color heterodyne varies depending on what track is
-    being read from to avoid chroma crosstalk.
-    Additionally, most tapes are recorded with a luma half-shift which shifts the fm-encoded
-    luma frequencies slightly depending on the track to avoid luma crosstalk.
-    """
-    ldd.logger.debug("Trying to detect PAL track phase...")
-    burst_area = get_burstarea(field)
-
-    # Upconvert chroma twice, once for each possible track phase
-    uphet = [
-        process_chroma(field, True, True),
-        process_chroma(field, True, True),
-    ]
-
-    sine_wave = field.rf.fsc_wave
-    cosine_wave = field.rf.fsc_cos_wave
-
-    # Try to decode the color burst from each of the upconverted chroma signals
-    phase = list()
-    for ix, uph in enumerate(uphet):
-        phase.append(
-            detect_burst_pal(
-                uph,
-                sine_wave,
-                cosine_wave,
-                burst_area,
-                field.outlinelen,
-                field.outlinecount,
-            )
-        )
-
-    # We use the one where the phase of the chroma vectors make the most sense.
-    phase0_mean, phase1_mean = phase[0][1], phase[1][1]
-    assumed_phase = int(phase0_mean < phase1_mean)
-
-    log_track_phase(field.rf.track_phase, phase0_mean, phase1_mean, assumed_phase)
-
-    return assumed_phase, needs_recheck(phase0_mean, phase1_mean)
-

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -114,14 +114,14 @@ def comb_c_ntsc(data, line_len):
 def _demod_burst(
     burst,
     burst_start,
-    burst_end,
+    burst_len,
     burst_sin,
     burst_cos
 ):
     I = 0
     Q = 0
 
-    for i in range(burst_end - burst_start):
+    for i in range(burst_len):
         I += burst[i] * burst_cos[i + burst_start]
         Q += burst[i] * burst_sin[i + burst_start]
 
@@ -144,24 +144,18 @@ def _get_upconverted_burst(
     outwidth,
 ):
     burst_padding = burstarea[1] - burstarea[0] # pad the area being filtered
+    burst_start = max(0, (linenumber - lineoffset) * outwidth + burstarea[0] - burst_padding)
+    burst_end = min(len(chroma), burst_start + burstarea[1] + burst_padding)
 
-    line_start = (linenumber - lineoffset) * outwidth
-    burst_start = line_start + burstarea[0]
-    burst_start_padding = burst_start - max(0, burst_start - burst_padding)
-    burst_start_with_padding = burst_start - burst_start_padding
-
-    burst_end = line_start + burstarea[1]
-    burst_end_padding = min(len(chroma), burst_end + burst_padding) - burst_end
-    burst_end_with_padding = burst_end + burst_end_padding
-
-    burst_padded = chroma_heterodyne[current_phase][burst_start_with_padding:burst_end_with_padding] * chroma[burst_start_with_padding:burst_end_with_padding]
+    burst = chroma_heterodyne[current_phase][burst_start:burst_end] * chroma[burst_start:burst_end]
 
     # filter out noise so only the color burst is present
-    burst_padded_filtered =  sosfiltfilt_rust(chroma_filter, burst_padded)
+    filtered_padded = sosfiltfilt_rust(chroma_filter, burst)
+    filtered = filtered_padded[burst_padding:-burst_padding]
 
-    burst_filtered = burst_padded_filtered[burst_start_padding:-burst_end_padding]
+    burst_len = len(filtered)
 
-    return _demod_burst(burst_filtered, burst_start, burst_end, burst_sin, burst_cos)
+    return _demod_burst(filtered, burst_start + burst_padding, burst_len, burst_sin, burst_cos)
 
 def _get_phase_sequence(
     chroma,
@@ -176,6 +170,7 @@ def _get_phase_sequence(
     outwidth,
     last_line,
     detect_chroma_track_phase,
+    rotation_check_start_line,
     track_change_threshold,
 ):
     do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
@@ -328,9 +323,8 @@ def _check_ntsc_phase_rotation(is_first_field, burst_avg, prev_burst_avg):
     quadrant = int(round(burst_avg) / 90) % 4
     quadrant_error = (quadrant * 90 - burst_avg + 180) % 360 - 180
 
-    burst_avg = (burst_avg + quadrant_error) % 360
-
-    quadrant = int(round(burst_avg) / 90) % 4
+    # burst_avg = (burst_avg + quadrant_error) % 360
+    # quadrant = int(round(burst_avg) / 90) % 4
 
     if prev_burst_avg is None:
         # cannot use the previous burst if this is the first frame
@@ -353,7 +347,7 @@ def _check_ntsc_phase_rotation(is_first_field, burst_avg, prev_burst_avg):
     else:
         order = -1
     
-    # print("phase rotation", "I" if phase_data else "O", order, phase_key, burst_avg, phase_delta, phase_delta_error, quadrant_error)
+    print("phase rotation", "I" if phase_data else "O", order, phase_key, burst_avg, phase_delta)
 
     # check of this current phase rotation sequence is valid
     return phase_delta, phase_delta_error, phase_data
@@ -401,6 +395,7 @@ def get_phase_rotation_sequence(
         outwidth,
         end,
         detect_chroma_track_phase,
+        rotation_check_start_line,
         track_change_threshold
     )
 
@@ -449,7 +444,6 @@ def get_phase_rotation_sequence(
         flip_track_phase = False
 
     if flip_track_phase:
-        print("flipping", chroma_rotation_index)
         # recalculate with the corrected track rotation
         chroma_rotation_index, phase_sequence, burst_phases = _get_phase_sequence(
             chroma,
@@ -464,6 +458,7 @@ def get_phase_rotation_sequence(
             outwidth,
             end,
             detect_chroma_track_phase,
+            rotation_check_start_line,
             track_change_threshold
         )
 

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -372,7 +372,7 @@ def get_phase_rotation_sequence(
 
         if color_system == "NTSC":
             # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
-            should_flip = delta_0 < (delta_90 + delta_180 + delta_270)
+            should_flip = delta_0 < delta_180
         elif color_system == "PAL":
             # each line should alternate phase, if there are repeated sequences of phase, recalculate
             alt1 = delta_90 + delta_270

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -145,19 +145,19 @@ def get_upconverted_burst(
 #    startingPhase
 # )
 ntsc_phase_rotation_sequence = {
-                       # field # | burst phase |        phase delta | fieldPhaseId |
-    # frame 1          #         |             | (prev vs. current) |              |
-    (1, 2, 0): (3, 0), # field 1 |         180 |                 +0 |            3 |
-    (0, 3, 1): (2, 1), # field 2 |         270 |                +90 |            2 |
+                       # frame # | field # | burst phase |        phase delta | fieldPhaseId |
+    # frame 1          #         |         |             | (prev vs. current) |              |
+    (1, 2, 0): (3, 0), # frame 1 | field 1 |         180 |                 +0 |            3 |
+    (0, 3, 1): (2, 1), # frame 1 | field 2 |         270 |                +90 |            2 |
     # frame 2
-    (1, 1, 2): (1, 1), # field 1 |          90 |               +180 |            1 |
-    (0, 0, 3): (4, 0), # field 2 |           0 |               +270 |            4 |
+    (1, 1, 2): (1, 1), # frame 2 | field 1 |          90 |               +180 |            1 |
+    (0, 0, 3): (4, 0), # frame 2 | field 2 |           0 |               +270 |            4 |
     # frame 3
-    (1, 0, 0): (3, 2), # field 1 |           0 |                 +0 |            3 |
-    (0, 1, 1): (2, 3), # field 2 |          90 |                +90 |            2 |
+    (1, 0, 0): (3, 2), # frame 3 | field 1 |           0 |                 +0 |            3 |
+    (0, 1, 1): (2, 3), # frame 3 | field 2 |          90 |                +90 |            2 |
     # frame 4
-    (1, 3, 2): (1, 3), # field 1 |         270 |               +180 |            1 |
-    (0, 2, 3): (4, 2), # field 2 |         180 |               +270 |            4 |
+    (1, 3, 2): (1, 3), # frame 4 | field 1 |         270 |               +180 |            1 |
+    (0, 2, 3): (4, 2), # frame 4 | field 2 |         180 |               +270 |            4 |
     # copy of the above, but without phase delta for the first field
     # frame 1
     (1, 2, -1): (3, 0),

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -403,21 +403,25 @@ def get_phase_rotation_sequence(
                     avg_count += 1
 
         coherence = np.hypot(I_total, Q_total) / avg_count
-
         burst_detected = coherence >= coherence_threshold
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
-        burst_rising = rotation_sum > 0
+
+        # color burst phase should be normalized to be within 0 to 90 degrees
+        heterodyne_offset = int(burst_phase_avg // 90) % 4
+        heterodyned_burst_avg = burst_phase_avg % 90
+
+        # if the corrected burst is in the +45 area of the quadrant, the rising check switches direction
+        # this isn't completely perfect, if the phase is really close to 45, noise can throw off this measurement
+        # any miss-detection here only only affects the NTSC 3D decoder,
+        # since there is a bug that prevents phase correction from working properly when the field phase id is miss-detected
+        burst_rising = rotation_sum < 0 if heterodyned_burst_avg > 45 else rotation_sum > 0
 
         field_phase_id = {
-            (1, 1): (1),
-            (0, 0): (2),
-            (1, 0): (3),
-            (0, 1): (4),
+            (1, 1): 1,
+            (0, 0): 2,
+            (1, 0): 3,
+            (0, 1): 4,
         }[(is_first_field, burst_rising)]
-
-        # color burst phase should be normalized to be at 0 degrees
-        heterodyne_offset = int(round(burst_phase_avg / 90)) % 4
-        heterodyned_burst_avg = (burst_phase_avg - heterodyne_offset * 90) % 360
         
         # adjust the starting phase
         if heterodyne_offset != 0:

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -162,48 +162,7 @@ def _get_upconverted_burst(
 
     burst_phase_deg, I, Q = _demod_burst(burst_filtered, burst_start, burst_end, burst_sin, burst_cos)
 
-    return burst_phase_deg, I, Q, burst_start, burst_end
-
-# input
-# (
-#    isFirstField
-#    detected color burst phase quadrant (n-180): where n is (0=0, 1=90, 2=180, 3=270)
-#    phase delta from previous color burst: (0=0, 1=90, 2=180, 3=270)
-# )
-#
-# output
-# (
-#    fieldPhaseId
-#    startingPhase
-# )
-ntsc_phase_rotation_sequence = {
-                       # frame # | field # | burst phase |        phase delta | fieldPhaseId |
-    # frame 1          #         |         |             | (prev vs. current) |              |
-    (1, 2, 0): (3, 0), # frame 1 | field 1 |         180 |                 +0 |            3 |
-    (0, 3, 1): (2, 1), # frame 1 | field 2 |         270 |                +90 |            2 |
-    # frame 2
-    (1, 1, 2): (1, 1), # frame 2 | field 1 |          90 |               +180 |            1 |
-    (0, 0, 3): (4, 0), # frame 2 | field 2 |           0 |               +270 |            4 |
-    # frame 3
-    (1, 0, 0): (3, 2), # frame 3 | field 1 |           0 |                 +0 |            3 |
-    (0, 1, 1): (2, 3), # frame 3 | field 2 |          90 |                +90 |            2 |
-    # frame 4
-    (1, 3, 2): (1, 3), # frame 4 | field 1 |         270 |               +180 |            1 |
-    (0, 2, 3): (4, 2), # frame 4 | field 2 |         180 |               +270 |            4 |
-    # copy of the above, but without phase delta for the first field
-    # frame 1
-    (1, 2, -1): (3, 0),
-    (0, 3, -1): (2, 1),
-    # frame 2
-    (1, 1, -1): (1, 1),
-    (0, 0, -1): (4, 0),
-    # frame 3
-    (1, 0, -1): (3, 2),
-    (0, 1, -1): (2, 3),
-    # frame 4
-    (1, 3, -1): (1, 3),
-    (0, 2, -1): (4, 2),
-}
+    return burst_phase_deg, I, Q
 
 def _get_phase_sequence(
     chroma,
@@ -238,13 +197,11 @@ def _get_phase_sequence(
             current_burst_phase = next_burst_phase
             current_burst_I = next_burst_I
             current_burst_Q = next_burst_Q
-            current_burst_start = next_burst_start
-            current_burst_end  = next_burst_end
 
             use_next_phase = False
         else:
             current_phase = (current_phase + track_rotation) % 4
-            current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = _get_upconverted_burst(
+            current_burst_phase, current_burst_I, current_burst_Q = _get_upconverted_burst(
                 chroma,
                 chroma_heterodyne,
                 chroma_filter,
@@ -265,7 +222,7 @@ def _get_phase_sequence(
         ):
             # get the next burst using the phase rotation for the current track
             next_phase = (current_phase + track_rotation) % 4
-            next_burst_phase, next_burst_I, next_burst_Q, next_burst_start, next_burst_end  = _get_upconverted_burst(
+            next_burst_phase, next_burst_I, next_burst_Q = _get_upconverted_burst(
                 chroma,
                 chroma_heterodyne,
                 chroma_filter,
@@ -289,9 +246,51 @@ def _get_phase_sequence(
                 use_next_phase = True
         
         phase_sequence.append((linenumber, current_phase))
-        burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end))
+        burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q))
 
     return phase_sequence, burst_phases
+
+# input
+# (
+#    isFirstField
+#    detected color burst phase quadrant (n-180): where n is (0=0, 1=90, 2=180, 3=270)
+#    phase delta from previous color burst: (0=0, 1=90, 2=180, 3=270)
+# )
+#
+# output
+# (
+#    fieldPhaseId
+#    startingPhase
+#    expectedBurstPhase
+# )
+ntsc_phase_rotation_sequence = {
+                           # frame # | field # | burst phase  |        phase delta | fieldPhaseId | burst phase |
+    # frame 1              #         |         |  (measured)  | (prev vs. current) |              |  (expected) |
+    (1, 2, 0):  (3, 0, 2), # frame 1 | field 1 |         180 ->                 +0 |            3 |         180 |
+    (0, 3, 1):  (2, 1, 3), # frame 1 | field 2 |         270 ->                +90 |            2 |         270 |
+    # frame 2
+    (1, 1, 2):  (1, 1, 1), # frame 2 | field 1 |          90 ->               +180 |            1 |          90 |
+    (0, 0, 3):  (4, 0, 0), # frame 2 | field 2 |           0 ->               +270 |            4 |           0 |
+    # frame 3
+    (1, 0, 0):  (3, 2, 0), # frame 3 | field 1 |           0 ->                 +0 |            3 |           0 |
+    (0, 1, 1):  (2, 3, 1), # frame 3 | field 2 |          90 ->                +90 |            2 |          90 |
+    # frame 4
+    (1, 3, 2):  (1, 3, 3), # frame 4 | field 1 |         270 ->               +180 |            1 |         270 |
+    (0, 2, 3):  (4, 2, 2), # frame 4 | field 2 |         180 ->               +270 |            4 |         180 |
+    # copy of the above, but without phase delta for the first field
+    # frame 1
+    (1, 2, -1): (3, 0, 2),
+    (0, 3, -1): (2, 1, 3),
+    # frame 2
+    (1, 1, -1): (1, 1, 1),
+    (0, 0, -1): (4, 0, 0),
+    # frame 3
+    (1, 0, -1): (3, 2, 0),
+    (0, 1, -1): (2, 3, 1),
+    # frame 4
+    (1, 3, -1): (1, 3, 3),
+    (0, 2, -1): (4, 2, 2),
+}
 
 def get_phase_rotation_sequence(
     chroma,
@@ -351,14 +350,14 @@ def get_phase_rotation_sequence(
         delta_270 = 0
 
         for i in range(1, len(burst_phases)):
-            _,                         previous_burst, _, _, _, _ = burst_phases[i-1]
-            current_burst_line_number, current_burst, _, _, _, _  = burst_phases[i]
+            _,                         previous_burst_phase, _, _ = burst_phases[i-1]
+            current_burst_line_number, current_burst_phase,  _, _ = burst_phases[i]
 
             if (
                 current_burst_line_number > burst_check_start and
                 current_burst_line_number < burst_check_end
             ):
-                delta = (current_burst - previous_burst) % 360
+                delta = (current_burst_phase - previous_burst_phase) % 360
                 bucket = int((delta + 45) // 90) % 4
 
                 if bucket == 0:
@@ -411,7 +410,7 @@ def get_phase_rotation_sequence(
         # find the phase of the color burst for the entire field
         I_total = 0
         Q_total = 0
-        for linenumber, _, I, Q, _, _ in burst_phases:
+        for linenumber, _, I, Q in burst_phases:
             if (
                 linenumber > burst_check_start and
                 linenumber < burst_check_end
@@ -445,14 +444,15 @@ def get_phase_rotation_sequence(
         )
 
         if phase_info:
-            field_phase_id, ntsc_phase_rotation = phase_info
+            field_phase_id, ntsc_phase_rotation, expected_burst_phase = phase_info
         else:
             # something is really wrong with the color, log an error
             # with the current phase sequence, this condition should never be hit
             ldd.logger.error(f"Invalid NTSC color sequence: isFirstField: {is_first_field}, colorBurstPhase: {burst_phase_avg}, previousColorBurstPhase: {prev_burst_phase_avg}")
             # use the entry for frame 1
-            field_phase_id = 1
-            ntsc_phase_rotation = 3
+            field_phase_id = 3
+            ntsc_phase_rotation = 0
+            expected_burst_phase = 2
 
         # adjust the starting phase
         if ntsc_phase_rotation != 0:
@@ -466,7 +466,7 @@ def get_phase_rotation_sequence(
         burst_phase_avg = None
         burst_detected = None
 
-    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
+    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -575,7 +575,7 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
+    track_phase, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
@@ -594,7 +594,7 @@ def decode_chroma_phase_rotation(
         field.rf.color_system
     )
 
-    return track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
+    return track_phase, phase_sequence, field_phase_id, burst_phases, expected_burst_phase, burst_phase_avg, burst_detected
 
 def process_chroma(
     field,

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -175,6 +175,7 @@ def _get_phase_sequence(
         track_rotation = chroma_rotation[chroma_rotation_index]
     else:
         # format that uses a fixed heterodyne phase, or does not rotate
+        chroma_rotation_index = 0
         track_rotation = chroma_rotation_starting_index
     """
     "...a signal that represents phase zero with respect to the chroma signal phase 
@@ -408,13 +409,13 @@ def get_phase_rotation_sequence(
 
         # color burst phase should be normalized to be within 0 to 90 degrees
         heterodyne_offset = int(burst_phase_avg // 90) % 4
-        heterodyned_burst_avg = burst_phase_avg % 90
+        corrected_burst_avg = burst_phase_avg % 90
 
         # if the corrected burst is in the +45 area of the quadrant, the rising check switches direction
         # this isn't completely perfect, if the phase is really close to 45, noise can throw off this measurement
         # any miss-detection here only only affects the NTSC 3D decoder,
         # since there is a bug that prevents phase correction from working properly when the field phase id is miss-detected
-        burst_rising = rotation_sum < 0 if heterodyned_burst_avg > 45 else rotation_sum > 0
+        burst_rising = rotation_sum < 0 if corrected_burst_avg > 45 else rotation_sum > 0
 
         field_phase_id = {
             (1, 1): 1,
@@ -444,11 +445,11 @@ def get_phase_rotation_sequence(
                     burst_Q
                 )
     else:
-        heterodyned_burst_avg = None
+        corrected_burst_avg = None
         field_phase_id = None
         burst_detected = None
 
-    return chroma_rotation_index, phase_sequence, field_phase_id, heterodyned_burst_avg, burst_detected
+    return chroma_rotation_index, phase_sequence, field_phase_id, corrected_burst_avg, burst_detected
 
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -1,24 +1,11 @@
 import math
-from collections import namedtuple
 import numpy as np
 import lddecode.utils as lddu
 import lddecode.core as ldd
-from vhsdecode.utils import get_line
 import scipy.signal as sps
 from vhsdecode.rust_utils import sosfiltfilt_rust
 
 from numba import njit
-
-
-@njit(cache=True)
-def needs_recheck(sum_0: float, sum_1: float):
-    """Check if the magnitude difference between the sums is larger than the set threshold
-    If it's small, we want to make sure we re-check on the next field.
-    """
-    # Trigger a re-check on next field if the magnitude difference is smaller than this value.
-    RECHECK_THRESHOLD = 1.2
-    return True if max(sum_0, sum_1) / min(sum_0, sum_1) < RECHECK_THRESHOLD else False
-
 
 @njit(cache=True, nogil=True)
 def chroma_to_u16(chroma):
@@ -675,29 +662,6 @@ def process_chroma(
     return uphet
 
 
-def check_increment_field_no(rf, field):
-    """Increment field number if the raw data location moved significantly since the last call"""
-    return None
-    raw_loc = rf.decoder.readloc / rf.decoder.bytes_per_field
-
-    prev_loc = field.prevfield.readloc if field.prevfield else None
-
-    # print("dec readloc: ", rf.decoder.readloc, " field readloc", field.readloc, " prev readloc", prev_loc)
-    # print("dec raw loc", raw_loc, "field raw loc", field.readloc / rf.decoder.bytes_per_field)
-
-    if rf.last_raw_loc is None:
-        rf.last_raw_loc = raw_loc
-
-    if raw_loc > rf.last_raw_loc:
-        rf.field_number += 1
-    else:
-        ldd.logger.debug("Raw data loc didn't advance.")
-
-    # print("self field number", field.field_number, " rf.field_number", rf.field_number)
-
-    return raw_loc
-
-
 def decode_chroma(field, do_chroma_deemphasis=False):
     """Do track detection if needed and upconvert the chroma signal"""
     field.chroma_tbc_buffer = None
@@ -715,163 +679,6 @@ def decode_chroma(field, do_chroma_deemphasis=False):
 
 
 def get_burst_area(field):
-    return (
-        math.floor(field.usectooutpx(field.rf.SysParams["colorBurstUS"][0])),
-        math.ceil(field.usectooutpx(field.rf.SysParams["colorBurstUS"][1])),
-    )
-
-
-def mean_of_burst_sums(chroma_data, line_length, lines, burst_start, burst_end):
-    """Sum the burst areas of two and two lines together, and return the mean of these sums."""
-    IGNORED_LINES = 16
-
-    burst_sums = []
-
-    # We ignore the top and bottom 16 lines. The top will typically not have a color burst, and
-    # the bottom 16 may be after or at the head switch where the phase rotation will be different.
-    start_line = IGNORED_LINES
-    end_line = lines - IGNORED_LINES
-
-    for line_number in range(start_line, end_line, 2):
-        burst_a = get_line(chroma_data, line_length, line_number)[burst_start:burst_end]
-        burst_b = get_line(chroma_data, line_length, line_number + 1)[
-            burst_start:burst_end
-        ]
-
-        # Use the absolute of the sums to differences cancelling out.
-        mean_dev = np.mean(abs(burst_a + burst_b))
-
-        burst_sums.append(mean_dev)
-
-    mean_burst_sum = np.nanmean(burst_sums)
-    return mean_burst_sum
-
-
-@njit(cache=True, nogil=True)
-def detect_burst_pal(
-    chroma_data, sine_wave, cosine_wave, burst_area, line_length, lines
-):
-    """Decode the burst of most lines to see if we have a valid PAL color burst."""
-
-    # Ignore the first and last 16 lines of the field.
-    # first ones contain sync and often doesn't have color burst,
-    # while the last lines of the field will contain the head switch and may be distorted.
-    IGNORED_LINES = 16
-    line_data = []
-    burst_norm = np.full(lines, np.nan)
-
-    # Decode the burst vectors on each line and try to get an average of the burst amplitude.
-    for linenumber in range(IGNORED_LINES, lines - IGNORED_LINES):
-        info = detect_burst_pal_line(
-            chroma_data, sine_wave, cosine_wave, burst_area, line_length, linenumber
-        )
-        line_data.append(info)
-        burst_norm[linenumber] = info.burst_norm
-
-    burst_mean = np.nanmean(burst_norm[IGNORED_LINES : lines - IGNORED_LINES])
-
-    return line_data, burst_mean
-
-
-LineInfo = namedtuple("LineInfo", "linenum, bp, bq, vsw, burst_norm")
-
-
-@njit(cache=True, nogil=True)
-def detect_burst_pal_line(
-    chroma_data, sine, cosine, burst_area, line_length, line_number
-):
-    """Detect burst function ported from the C++ chroma decoder (palcolour.cpp)
-
-    Tries to decode the PAL chroma vectors from the line's color burst
-    """
-    empty_line = np.zeros_like(chroma_data[0:line_length])
-    num_lines = chroma_data.size / line_length
-
-    # Use an empty line if we try to access outside the field.
-    def line_or_empty(line):
-        return (
-            get_line(chroma_data, line_length, line)
-            if line >= 0 and line < num_lines
-            else empty_line
-        )
-
-    in0 = line_or_empty(line_number)
-    in1 = line_or_empty(line_number - 1)
-    in2 = line_or_empty(line_number + 1)
-    in3 = line_or_empty(line_number - 2)
-    in4 = line_or_empty(line_number + 2)
-    bp = 0
-    bq = 0
-    bpo = 0
-    bqo = 0
-
-    # (Comment from palcolor.cpp)
-    # Find absolute burst phase relative to the reference carrier by
-    # product detection.
-    #
-    # To avoid hue-shifts on alternate lines, the phase is determined by
-    # averaging the phase on the current-line with the average of two
-    # other lines, one above and one below the current line.
-    #
-    # For PAL we use the next-but-one line above and below (in the field),
-    # which will have the same V-switch phase as the current-line (and 180
-    # degree change of phase), and we also analyse the average (bpo/bqo
-    # 'old') of the line immediately above and below, which have the
-    # opposite V-switch phase (and a 90 degree subcarrier phase shift).
-    for i in range(burst_area[0], burst_area[1]):
-        bp += ((in0[i] - ((in3[i] + in4[i]) / 2.0)) / 2.0) * sine[i]
-        bq += ((in0[i] - ((in3[i] + in4[i]) / 2.0)) / 2.0) * cosine[i]
-        bpo += ((in2[i] - in1[i]) / 2.0) * sine[i]
-        bqo += ((in2[i] - in1[i]) / 2.0) * cosine[i]
-
-    # (Comment from palcolor.cpp)
-    # Normalise the sums above
-    burst_length = burst_area[1] - burst_area[0]
-
-    bp /= burst_length
-    bq /= burst_length
-    bpo /= burst_length
-    bqo /= burst_length
-
-    # (Comment from palcolor.cpp)
-    # Detect the V-switch state on this line.
-    # I forget exactly why this works, but it's essentially comparing the
-    # vector magnitude /difference/ between the phases of the burst on the
-    # present line and previous line to the magnitude of the burst. This
-    # may effectively be a dot-product operation...
-
-    line_bp = 0
-    line_bq = 0
-    line_vsw = -1
-    line_burst_norm = 0
-
-    if ((bp - bpo) * (bp - bpo) + (bq - bqo) * (bq - bqo)) < (bp * bp + bq * bq) * 2:
-        line_vsw = 1
-
-    # (Comment from palcolor.cpp)
-    # Average the burst phase to get -U (reference) phase out -- burst
-    # phase is (-U +/-V). bp and bq will be of the order of 1000.
-    line_bp = (bp - bqo) / 2
-    line_bq = (bq + bpo) / 2
-
-    # (Comment from palcolor.cpp)
-    # Normalise the magnitude of the bp/bq vector to 1.
-    # Kill colour if burst too weak.
-    # XXX magic number 130000 !!! check!
-    burst_norm = max(math.sqrt(line_bp * line_bp + line_bq * line_bq), 10000.0 / 128)
-    line_burst_norm = burst_norm
-    line_bp /= burst_norm
-    line_bq /= burst_norm
-
-    return LineInfo(line_number, line_bp, line_bq, line_vsw, line_burst_norm)
-
-
-# Phase comprensation stuff - needs rework.
-# def phase_shift(data, angle):
-#     return np.fft.irfft(np.fft.rfft(data) * np.exp(1.0j * angle), len(data)).real
-
-
-def get_burstarea(field):
     return (
         math.floor(field.usectooutpx(field.rf.SysParams["colorBurstUS"][0])),
         math.ceil(field.usectooutpx(field.rf.SysParams["colorBurstUS"][1])),

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -130,17 +130,17 @@ def _demod_burst(
 
     return burst_phase_deg, I, Q
 
-def get_upconverted_burst(
+def _get_upconverted_burst(
     chroma,
-    phase,
+    chroma_heterodyne,
+    chroma_filter,
+    current_phase,
+    burstarea,
+    burst_sin,
+    burst_cos,
     linenumber,
     lineoffset,
     outwidth,
-    burstarea,
-    chroma_heterodyne,
-    chroma_filter,
-    burst_sin,
-    burst_cos
 ):
     burst_padding = burstarea[1] - burstarea[0] # pad the area being filtered
 
@@ -153,7 +153,7 @@ def get_upconverted_burst(
     burst_end_padding = min(len(chroma), burst_end + burst_padding) - burst_end
     burst_end_with_padding = burst_end + burst_end_padding
 
-    burst_padded = chroma_heterodyne[phase][burst_start_with_padding:burst_end_with_padding] * chroma[burst_start_with_padding:burst_end_with_padding]
+    burst_padded = chroma_heterodyne[current_phase][burst_start_with_padding:burst_end_with_padding] * chroma[burst_start_with_padding:burst_end_with_padding]
 
     # filter out noise so only the color burst is present
     burst_padded_filtered =  sosfiltfilt_rust(chroma_filter, burst_padded)
@@ -208,22 +208,22 @@ ntsc_phase_rotation_sequence = {
 def _get_phase_sequence(
     chroma,
     chroma_heterodyne,
-    track_phase,
-    chroma_rotation,
     chroma_filter,
+    chroma_rotation,
+    chroma_rotation_index,
+    burstarea,
     burst_sin,
     burst_cos,
-    burstarea,
     lineoffset,
     outwidth,
     last_line,
     do_phase_rotation_check,
-    track_change_threshold,
     rotation_check_start_line,
+    track_change_threshold,
 ):
     phase_sequence = []
     burst_phases = []
-    track_rotation = chroma_rotation[track_phase] if chroma_rotation else 0
+    track_rotation = chroma_rotation[chroma_rotation_index] if chroma_rotation else 0
 
     # rewind to the previous phase (line -1)
     current_phase = 0
@@ -232,19 +232,20 @@ def _get_phase_sequence(
 
     for linenumber in range(lineoffset, last_line):
         current_phase = (current_phase + track_rotation) % 4
-        current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = get_upconverted_burst(
+        current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end = _get_upconverted_burst(
             chroma,
+            chroma_heterodyne,
+            chroma_filter,
             current_phase,
+            burstarea,
+            burst_sin,
+            burst_cos,
             linenumber,
             lineoffset,
             outwidth,
-            burstarea,
-            chroma_heterodyne,
-            chroma_filter,
-            burst_sin,
-            burst_cos
         )
 
+        # check if the track has rotated around the head switching area
         if (
             do_phase_rotation_check and
             linenumber >= rotation_check_start_line and
@@ -252,17 +253,17 @@ def _get_phase_sequence(
         ):
             # get the next burst using the phase rotation for the current track
             next_phase = (current_phase + track_rotation) % 4
-            next_burst_phase, _, _, _, _ = get_upconverted_burst(
+            next_burst_phase, _, _, _, _ = _get_upconverted_burst(
                 chroma,
+                chroma_heterodyne,
+                chroma_filter,
                 next_phase,
+                burstarea,
+                burst_sin,
+                burst_cos,
                 linenumber + 1,
                 lineoffset,
                 outwidth,
-                burstarea,
-                chroma_heterodyne,
-                chroma_filter,
-                burst_sin,
-                burst_cos
             )
 
             phase_delta = abs((next_burst_phase - current_burst_phase + 180) % 360 - 180)
@@ -270,8 +271,8 @@ def _get_phase_sequence(
                 # positive correlation -> in phase
                 # negative correlation -> out of phase
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
-                track_phase = (track_phase + 1) % 2
-                track_rotation = chroma_rotation[track_phase]
+                chroma_rotation_index = (chroma_rotation_index + 1) % 2
+                track_rotation = chroma_rotation[chroma_rotation_index]
         
         phase_sequence.append((linenumber, current_phase))
         burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q, current_burst_start, current_burst_end))
@@ -280,21 +281,21 @@ def _get_phase_sequence(
 
 def get_phase_rotation_sequence(
     chroma,
-    rotation_check_start_line,
+    chroma_heterodyne,
+    chroma_filter,
+    chroma_rotation,
+    chroma_rotation_index,
     lineoffset,
     linesout,
     outwidth,
-    is_first_field,
-    prev_burst_phase_avg,
-    color_system,
+    burstarea,
     burst_sin,
     burst_cos,
     detect_chroma_track_phase,
-    track_phase,
-    chroma_rotations,
-    chroma_heterodyne,
-    burstarea,
-    chroma_filter,
+    rotation_check_start_line,
+    is_first_field,
+    prev_burst_phase_avg,
+    color_system,
 ):
     # *****************************************************
     # Gather the phase differences between each color burst
@@ -304,31 +305,31 @@ def get_phase_rotation_sequence(
     burst_check_skip_lines = 16
     coherence_threshold = 0.3
 
-    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotations is not None and chroma_heterodyne is not None
+    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
 
     end = linesout + lineoffset
     phase_sequence, burst_phases = _get_phase_sequence(
         chroma,
         chroma_heterodyne,
-        track_phase,
-        chroma_rotations,
         chroma_filter,
+        chroma_rotation,
+        chroma_rotation_index,
+        burstarea,
         burst_sin,
         burst_cos,
-        burstarea,
         lineoffset,
         outwidth,
         end,
         do_phase_rotation_check,
-        track_change_threshold,
         rotation_check_start_line,
+        track_change_threshold
     )
 
     # detect the track phase, and recalculate if needed
     burst_check_start = burst_check_skip_lines
     burst_check_end = end - burst_check_skip_lines
 
-    if chroma_rotations:
+    if chroma_rotation:
         # detect relative phase difference between lines
         delta_0 = 0
         delta_90 = 0
@@ -370,23 +371,23 @@ def get_phase_rotation_sequence(
         should_flip = False
 
     if should_flip:
-        track_phase = (track_phase + 1) % 2
+        chroma_rotation_index = (chroma_rotation_index + 1) % 2
         # recalculate with the corrected track rotation
         phase_sequence, burst_phases = _get_phase_sequence(
             chroma,
             chroma_heterodyne,
-            track_phase,
-            chroma_rotations,
             chroma_filter,
+            chroma_rotation,
+            chroma_rotation_index,
+            burstarea,
             burst_sin,
             burst_cos,
-            burstarea,
             lineoffset,
             outwidth,
             end,
             do_phase_rotation_check,
-            track_change_threshold,
             rotation_check_start_line,
+            track_change_threshold
         )
 
     # ***************************************************************************************
@@ -451,19 +452,17 @@ def get_phase_rotation_sequence(
         burst_phase_avg = None
         burst_detected = None
 
-    return track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
+    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
     
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
     chroma,
     lineoffset,
-    linesout,
     outwidth,
     chroma_heterodyne,
     phase_rotation_sequence
 ):
     uphet = np.zeros(len(chroma), dtype=np.float32)
-    phase_index = 0
 
     for linenumber, current_phase in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
@@ -532,6 +531,8 @@ def decode_chroma_phase_rotation(
     outwidth = field.outlinelen
 
     burst_area_init = get_burst_area(field)
+    rotation_check_start_line = lineoffset + linesout - 16
+
     burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
 
     prev_burst_phase = None
@@ -562,21 +563,21 @@ def decode_chroma_phase_rotation(
 
     track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
         chroma,
-        lineoffset + linesout - 16, # check for track phase rotation around the headswitching area (bottom of field)
+        chroma_heterodyne,
+        field.rf.Filters["FChromaFinal"],
+        chroma_rotation,
+        field.rf.track_phase, # index for chroma rotation, and static if there is no chroma rotation
         lineoffset,
         linesout,
         outwidth,
-        field.isFirstField,
-        prev_burst_phase,
-        field.rf.color_system,
+        burstarea,
         field.rf.fsc_wave,
         field.rf.fsc_cos_wave,
         detect_chroma_track_phase,
-        field.rf.track_phase,
-        chroma_rotation,
-        chroma_heterodyne,
-        burstarea,
-        field.rf.Filters["FChromaFinal"],
+        rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
+        field.isFirstField,
+        prev_burst_phase,
+        field.rf.color_system
     )
 
     return track_phase, phase_sequence, field_phase_id, burst_phases, burst_phase_avg, burst_detected
@@ -639,7 +640,6 @@ def process_chroma(
     uphet = upconvert_chroma(
         chroma,
         lineoffset,
-        linesout,
         outwidth,
         chroma_heterodyne,
         field.phase_sequence,
@@ -708,12 +708,11 @@ def check_increment_field_no(rf, field):
 
 def decode_chroma(field, do_chroma_deemphasis=False):
     """Do track detection if needed and upconvert the chroma signal"""
-    rf = field.rf
     field.chroma_tbc_buffer = None
 
     uphet = process_chroma(
         field,
-        disable_comb=rf.options.disable_comb,
+        disable_comb=field.rf.options.disable_comb,
         disable_tracking_cafc=False,
         do_chroma_deemphasis=do_chroma_deemphasis,
     )

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -125,10 +125,11 @@ def _demod_burst(
         I += burst[i] * burst_cos[i + burst_start]
         Q += burst[i] * burst_sin[i + burst_start]
 
+    burst_magnitude = np.hypot(I, Q)
     burst_phase = np.arctan2(Q, I)
     burst_phase_deg = np.degrees(burst_phase) % 360
 
-    return burst_phase_deg, I, Q
+    return burst_phase_deg, burst_magnitude, I, Q
 
 def _get_upconverted_burst(
     chroma,
@@ -160,29 +161,40 @@ def _get_upconverted_burst(
 
     burst_filtered = burst_padded_filtered[burst_start_padding:-burst_end_padding]
 
-    burst_phase_deg, I, Q = _demod_burst(burst_filtered, burst_start, burst_end, burst_sin, burst_cos)
-
-    return burst_phase_deg, I, Q
+    return _demod_burst(burst_filtered, burst_start, burst_end, burst_sin, burst_cos)
 
 def _get_phase_sequence(
     chroma,
     chroma_heterodyne,
     chroma_filter,
     chroma_rotation,
-    chroma_rotation_index,
+    chroma_rotation_starting_index,
     burstarea,
     burst_sin,
     burst_cos,
     lineoffset,
     outwidth,
     last_line,
-    do_phase_rotation_check,
-    rotation_check_start_line,
+    detect_chroma_track_phase,
     track_change_threshold,
 ):
+    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
+
     phase_sequence = []
     burst_phases = []
-    track_rotation = chroma_rotation[chroma_rotation_index] if chroma_rotation else 0
+
+    if chroma_rotation_starting_index is None:
+        # first field
+        chroma_rotation_starting_index = 0
+        chroma_rotation_index = 0
+
+    if chroma_rotation:
+        # color under format that uses a phase rotated heterodyne to down convert the composite chroma
+        chroma_rotation_index = chroma_rotation_starting_index
+        track_rotation = chroma_rotation[chroma_rotation_index]
+    else:
+        # format that uses a fixed heterodyne phase, or does not rotate
+        track_rotation = chroma_rotation_starting_index
 
     # rewind to the previous phase (line -1)
     current_phase = 0
@@ -197,11 +209,12 @@ def _get_phase_sequence(
             current_burst_phase = next_burst_phase
             current_burst_I = next_burst_I
             current_burst_Q = next_burst_Q
+            current_burst_magnitude = next_burst_magnitude
 
             use_next_phase = False
         else:
             current_phase = (current_phase + track_rotation) % 4
-            current_burst_phase, current_burst_I, current_burst_Q = _get_upconverted_burst(
+            current_burst_phase, current_burst_magnitude, current_burst_I, current_burst_Q = _get_upconverted_burst(
                 chroma,
                 chroma_heterodyne,
                 chroma_filter,
@@ -222,7 +235,7 @@ def _get_phase_sequence(
         ):
             # get the next burst using the phase rotation for the current track
             next_phase = (current_phase + track_rotation) % 4
-            next_burst_phase, next_burst_I, next_burst_Q = _get_upconverted_burst(
+            next_burst_phase, next_burst_magnitude, next_burst_I, next_burst_Q = _get_upconverted_burst(
                 chroma,
                 chroma_heterodyne,
                 chroma_filter,
@@ -235,10 +248,8 @@ def _get_phase_sequence(
                 outwidth,
             )
 
-            phase_delta = abs((next_burst_phase - current_burst_phase + 180) % 360 - 180)
-            if phase_delta > track_change_threshold:
-                # positive correlation -> in phase
-                # negative correlation -> out of phase
+            phase_delta_quadrant = abs((next_burst_phase - current_burst_phase + 180) % 360 - 180)
+            if phase_delta_quadrant > track_change_threshold:
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
                 chroma_rotation_index = (chroma_rotation_index + 1) % 2
                 track_rotation = chroma_rotation[chroma_rotation_index]
@@ -246,9 +257,13 @@ def _get_phase_sequence(
                 use_next_phase = True
         
         phase_sequence.append((linenumber, current_phase))
-        burst_phases.append((linenumber, current_burst_phase, current_burst_I, current_burst_Q))
+        burst_phases.append((linenumber, current_burst_phase, current_burst_magnitude, current_burst_I, current_burst_Q))
 
-    return phase_sequence, burst_phases
+    if chroma_rotation and chroma_rotation_index == chroma_rotation_starting_index:
+        # rotate the phase for the next field, if rotation was not detected
+        chroma_rotation_index = (chroma_rotation_index + 1) % 2
+
+    return chroma_rotation_index, phase_sequence, burst_phases
 
 # input
 # (
@@ -292,12 +307,65 @@ ntsc_phase_rotation_sequence = {
     (0, 2, -1): (4, 2, 2),
 }
 
+phase_order = (
+    # frame 1
+    (1, 2, 0),
+    (0, 3, 1),
+    # frame 2
+    (1, 1, 2),
+    (0, 0, 3),
+    # frame 3
+    (1, 0, 0),
+    (0, 1, 1),
+    # frame 4
+    (1, 3, 2),
+    (0, 2, 3),
+)
+
+
+def _check_ntsc_phase_rotation(is_first_field, burst_avg, prev_burst_avg):
+    # quantize to 90 degrees
+    quadrant = int(round(burst_avg) / 90) % 4
+    quadrant_error = (quadrant * 90 - burst_avg + 180) % 360 - 180
+
+    burst_avg = (burst_avg + quadrant_error) % 360
+
+    quadrant = int(round(burst_avg) / 90) % 4
+
+    if prev_burst_avg is None:
+        # cannot use the previous burst if this is the first frame
+        phase_delta = -1
+        phase_delta_quadrant = -1
+        phase_delta_error = -1
+    else:
+        prev_burst_avg = (prev_burst_avg + quadrant_error) % 360
+
+        # use the difference from the previous burst to select the correct phase rotation
+        phase_delta = (burst_avg - prev_burst_avg) % 360
+        phase_delta_quadrant = int(round(phase_delta / 90)) % 4
+        phase_delta_error = (phase_delta_quadrant * 90 - phase_delta + 180) % 360 - 180
+    
+    phase_key = (is_first_field, quadrant, phase_delta_quadrant)
+    phase_data = ntsc_phase_rotation_sequence.get(phase_key, None)
+
+    if phase_data and prev_burst_avg is not None:
+        order = phase_order.index(phase_key)
+    else:
+        order = -1
+    
+    # print("phase rotation", "I" if phase_data else "O", order, phase_key, burst_avg, phase_delta, phase_delta_error, quadrant_error)
+
+    # check of this current phase rotation sequence is valid
+    return phase_delta, phase_delta_error, phase_data
+
+
 def get_phase_rotation_sequence(
     chroma,
     chroma_heterodyne,
     chroma_filter,
     chroma_rotation,
     chroma_rotation_index,
+    field_number,
     lineoffset,
     linesout,
     outwidth,
@@ -318,10 +386,9 @@ def get_phase_rotation_sequence(
     burst_check_skip_lines = 16
     coherence_threshold = 0.3
 
-    do_phase_rotation_check = detect_chroma_track_phase and chroma_rotation is not None and chroma_heterodyne is not None
-
     end = linesout + lineoffset
-    phase_sequence, burst_phases = _get_phase_sequence(
+
+    chroma_rotation_index, phase_sequence, burst_phases = _get_phase_sequence(
         chroma,
         chroma_heterodyne,
         chroma_filter,
@@ -333,12 +400,10 @@ def get_phase_rotation_sequence(
         lineoffset,
         outwidth,
         end,
-        do_phase_rotation_check,
-        rotation_check_start_line,
+        detect_chroma_track_phase,
         track_change_threshold
     )
 
-    # detect the track phase, and recalculate if needed
     burst_check_start = burst_check_skip_lines
     burst_check_end = end - burst_check_skip_lines
 
@@ -350,8 +415,8 @@ def get_phase_rotation_sequence(
         delta_270 = 0
 
         for i in range(1, len(burst_phases)):
-            _,                         previous_burst_phase, _, _ = burst_phases[i-1]
-            current_burst_line_number, current_burst_phase,  _, _ = burst_phases[i]
+            _,                         previous_burst_phase, _, _, _ = burst_phases[i-1]
+            current_burst_line_number, current_burst_phase,  _, _, _ = burst_phases[i]
 
             if (
                 current_burst_line_number > burst_check_start and
@@ -371,22 +436,22 @@ def get_phase_rotation_sequence(
 
         if color_system == "NTSC":
             # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
-            should_flip = delta_0 < delta_180
+            flip_track_phase = delta_0 < delta_90 + delta_180 + delta_270
         elif color_system == "PAL":
             # each line should alternate phase, if there are repeated sequences of phase, recalculate
             alt1 = delta_90 + delta_270
             alt2 = delta_0 + delta_180
 
             # choose whichever pattern dominates
-            should_flip = alt1 < alt2
+            flip_track_phase = alt1 < alt2
     else:
         # no difference between track phases, do not flip
-        should_flip = False
+        flip_track_phase = False
 
-    if should_flip:
-        chroma_rotation_index = (chroma_rotation_index + 1) % 2
+    if flip_track_phase:
+        print("flipping", chroma_rotation_index)
         # recalculate with the corrected track rotation
-        phase_sequence, burst_phases = _get_phase_sequence(
+        chroma_rotation_index, phase_sequence, burst_phases = _get_phase_sequence(
             chroma,
             chroma_heterodyne,
             chroma_filter,
@@ -398,8 +463,7 @@ def get_phase_rotation_sequence(
             lineoffset,
             outwidth,
             end,
-            do_phase_rotation_check,
-            rotation_check_start_line,
+            detect_chroma_track_phase,
             track_change_threshold
         )
 
@@ -410,42 +474,26 @@ def get_phase_rotation_sequence(
         # find the phase of the color burst for the entire field
         I_total = 0
         Q_total = 0
-        for linenumber, _, I, Q in burst_phases:
+        avg_count = 0
+        for linenumber, _, magnitude, I, Q in burst_phases:
             if (
                 linenumber > burst_check_start and
                 linenumber < burst_check_end
             ):
-                magnitude = np.hypot(I, Q) + 1e-12
-                I_total += I / magnitude
-                Q_total += Q / magnitude  
+                if magnitude != 0:
+                    I_total += I / magnitude
+                    Q_total += Q / magnitude
+                    avg_count += 1
+
+        coherence = np.hypot(I_total, Q_total) / avg_count
+        burst_detected = coherence >= coherence_threshold
 
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
 
-        coherence = np.hypot(I_total, Q_total) / len(burst_phases)
-        burst_detected = coherence >= coherence_threshold      
+        # check of this current phase rotation sequence is valid
+        phase_delta, phase_delta_error, phase_info = _check_ntsc_phase_rotation(is_first_field, burst_phase_avg, prev_burst_phase_avg)
 
-        if prev_burst_phase_avg is not None:
-            # if we have the phase difference between the previous burst and this burst, we further refine the detection based on the known phase delta between rotations
-            delta = (burst_phase_avg - prev_burst_phase_avg) % 360
-            phase_delta = int(round(delta / 90)) % 4
-        else:
-            # since there is no prior phase to determine the phase delta, only use isFirstField and quadrant
-            phase_delta = -1
-
-        # quantize to 90 degrees
-        quadrant = int(round(burst_phase_avg) / 90) % 4
-
-        # match the phase using the first field, detected color burst phase quadrant, and the phase difference from the previous burst
-        phase_info = ntsc_phase_rotation_sequence.get(
-            (is_first_field, quadrant, phase_delta),
-            # if no matches, try without phase delta populated, possible if there is a gap in field cadence
-            # results may be incorrect
-            ntsc_phase_rotation_sequence.get((is_first_field, quadrant, -1), None)
-        )
-
-        if phase_info:
-            field_phase_id, ntsc_phase_rotation, expected_burst_phase = phase_info
-        else:
+        if phase_info is None:
             # something is really wrong with the color, log an error
             # with the current phase sequence, this condition should never be hit
             ldd.logger.error(f"Invalid NTSC color sequence: isFirstField: {is_first_field}, colorBurstPhase: {burst_phase_avg}, previousColorBurstPhase: {prev_burst_phase_avg}")
@@ -453,6 +501,8 @@ def get_phase_rotation_sequence(
             field_phase_id = 3
             ntsc_phase_rotation = 0
             expected_burst_phase = 2
+        else:
+            field_phase_id, ntsc_phase_rotation, expected_burst_phase = phase_info
 
         # adjust the starting phase
         if ntsc_phase_rotation != 0:
@@ -553,21 +603,14 @@ def decode_chroma_phase_rotation(
     if field.prevfield is not None:
         if field.rf.color_system == "NTSC":
             prev_burst_phase = field.prevfield.burst_phase_avg
-        
 
     # Rotation per track
-    # VHS PAL: Track1 0, Track2 -90
-    # VHS NTSC: Track1 +90, Track2 -90
-    # Betamax PAL: None - uses frequency offset instead
+    # VHS PAL:      Track1 0,   Track2 -90
+    # VHS NTSC:     Track1 +90, Track2 -90
+    # Betamax PAL:  None - uses frequency offset instead
     # Betamax NTSC: Track1 180, Track2 0
-    # Video8 NTSC: Track1 0, Track2 180
-    # Video8 PAL: Track1 0, Track2 -90
-
-    if field.rf.track_phase is None:
-        field.rf.track_phase = 0
-    elif not field.track_phase_set and chroma_rotation:
-        # if this is the first time this is called, flip the rotation
-        field.rf.track_phase = (field.rf.track_phase + 1) % 2
+    # Video8 PAL:   Track1 0,   Track2 -90
+    # Video8 NTSC:  Track1 0,   Track2 180
 
     chroma_heterodyne = (
         field.rf.chroma_afc.getChromaHet()
@@ -581,6 +624,7 @@ def decode_chroma_phase_rotation(
         field.rf.Filters["FChromaFinal"],
         chroma_rotation,
         field.rf.track_phase, # index for chroma rotation, and static if there is no chroma rotation
+        field.field_number,
         lineoffset,
         linesout,
         outwidth,

--- a/vhsdecode/cmdcommons.py
+++ b/vhsdecode/cmdcommons.py
@@ -429,6 +429,8 @@ def get_extra_options(args, checkagc=False):
         # Only used for ld, but could maybe be used for vhs too.
         "deemp_coeff": (0, 0),
         "debug": args.debug,
+        "wow_level_adjust_smoothing": args.wow_level_adjust_smoothing,
+        "wow_interpolation_method": args.wow_interpolation_method
     }
     if checkagc:
         extra_options["useAGC"]: args.AGC and not args.noAGC

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1843,17 +1843,14 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.ire0_backporch = (74, 124)
 
     @staticmethod
-    @njit(cache=True, fastmath=True, nogil=True)
     def _sync_to_burst(
         linelocs,
         outlinelen,
         burst_avg_phase,
         phase_sequence
     ):
-        for line_number, _, burst_phase, _, _, _ in phase_sequence[16:]:
+        for line_number, _, burst_phase, _, _, _ in phase_sequence[9:]:
             phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
-
-            phase_delta = max(-45, min(45, phase_delta))
 
             # scale up burst fsc for each line
             line_start = linelocs[line_number]
@@ -1873,7 +1870,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         # populates color burst info for hsync refinement the step below
         self.lock_to_burst()
 
-        if self.phase_sequence is not None:
+        if not self.rf.options.disable_burst_hsync and self.phase_sequence is not None:
             FieldNTSCShared._sync_to_burst(
                 linelocs,
                 self.outlinelen,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1141,7 +1141,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phases, self.burst_phase_expected, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
@@ -1847,17 +1847,13 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
     def _sync_to_burst(
         linelocs,
         outlinelen,
-        expected_quadrant,
-        burst_phase_avg,
-        burst_phases
+        burst_avg_phase,
+        phase_sequence
     ):
-        measured_quadrant = int(round(burst_phase_avg) / 90) % 4
-        measured_quadrant_phase = measured_quadrant * 90
-        expected_quadrant_phase = expected_quadrant * 90
+        for line_number, _, burst_phase, _, _, _ in phase_sequence[16:]:
+            phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
 
-        for line_number, burst_phase, _, _, _ in burst_phases[16:]:
-            # phase delta relative to expected phase (0, 90, 180, 270)
-            phase_delta = (expected_quadrant_phase - burst_phase + 180) % 360 - 180
+            phase_delta = max(-45, min(45, phase_delta))
 
             # scale up burst fsc for each line
             line_start = linelocs[line_number]
@@ -1877,13 +1873,12 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         # populates color burst info for hsync refinement the step below
         self.lock_to_burst()
 
-        if self.burst_phases:
+        if self.phase_sequence is not None:
             FieldNTSCShared._sync_to_burst(
                 linelocs,
                 self.outlinelen,
-                self.burst_phase_expected,
                 self.burst_phase_avg,
-                self.burst_phases,
+                self.phase_sequence,
             )
 
         return linelocs

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -10,11 +10,8 @@ import vhsdecode.formats as formats
 from vhsdecode.doc import detect_dropouts_rf
 from vhsdecode.addons.resync import Pulse
 from vhsdecode.chroma import (
-    decode_chroma_simple,
     decode_chroma,
-    decode_chroma_phase_rotation,
-    try_detect_track_vhs_pal,
-    try_detect_track_betamax_pal,
+    decode_chroma_phase_rotation
 )
 
 from vhsdecode.debug_plot import plot_data_and_pulses
@@ -1143,12 +1140,12 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-
         self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phases, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
+        self.track_phase_set = True
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldShared, self).downscale(
@@ -1815,6 +1812,7 @@ class FieldShared:
 class FieldPALShared(FieldShared, ldd.FieldPAL):
     def __init__(self, *args, **kwargs):
         super(FieldPALShared, self).__init__(*args, **kwargs)
+        self.track_phase_set = False
         self.ire0_backporch = (96, 160)
 
     def refine_linelocs_pilot(self, linelocs=None):
@@ -1824,7 +1822,9 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         else:
             linelocs = linelocs.copy()
 
-        self.lock_to_burst()
+        if not self.track_phase_set:
+            # only do this once, since this does not affect hsync currently
+            self.lock_to_burst()
 
         return linelocs
 
@@ -1837,6 +1837,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
 class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCShared, self).__init__(*args, **kwargs)
+        self.track_phase_set = False
         self.fieldPhaseID = 0
         self.ire0_backporch = (74, 124)
 
@@ -1846,6 +1847,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         else:
             linelocs = linelocs.copy()
 
+        # populates color burst info for hsync refinement the step below
         self.lock_to_burst()
 
         if self.burst_phases:
@@ -1862,8 +1864,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
 
                 # TODO try to match up color burst more than +-180 degrees using cross correlation
                 linelocs[line_number] += line_adjust
-
-                print(line_number, line_adjust, scale, self.burst_phase_avg, burst_phase, phase_delta)
+                #print(line_number, line_adjust, scale, self.burst_phase_avg, burst_phase, phase_delta)
 
         return linelocs
 
@@ -1879,9 +1880,6 @@ class FieldPALVHS(FieldPALShared):
         dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
-
-    def try_detect_track(self):
-        return try_detect_track_vhs_pal(self, self.rf.DecoderParams["chroma_rotation"])
 
 
 class FieldPALSVHS(FieldPALVHS):
@@ -1899,7 +1897,7 @@ class FieldPALUMatic(FieldPALShared):
         dsout, dsaudio, dsefm = super(FieldPALUMatic, self).downscale(
             final=final, *args, **kwargs
         )
-        dschroma = decode_chroma_simple(self)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -1907,10 +1905,6 @@ class FieldPALUMatic(FieldPALShared):
 class FieldPALBetamax(FieldPALShared):
     def __init__(self, *args, **kwargs):
         super(FieldPALBetamax, self).__init__(*args, **kwargs)
-
-    def try_detect_track(self):
-        _ = try_detect_track_betamax_pal(self)
-        return 0, False
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldPALBetamax, self).downscale(
@@ -1925,10 +1919,6 @@ class FieldPALBetamax(FieldPALShared):
 class FieldPALVideo8(FieldPALShared):
     def __init__(self, *args, **kwargs):
         super(FieldPALVideo8, self).__init__(*args, **kwargs)
-
-    def try_detect_track(self):
-        # PAL Video8 uses the same chroma phase rotation setup as PAL VHS.
-        return try_detect_track_vhs_pal(self, self.rf.DecoderParams["chroma_rotation"])
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldPALVideo8, self).downscale(
@@ -1995,9 +1985,6 @@ class FieldMPALVHS(FieldNTSCVHS):
     def __init__(self, *args, **kwargs):
         super(FieldMPALVHS, self).__init__(*args, **kwargs)
 
-    def try_detect_track(self):
-        return try_detect_track_vhs_pal(self, self.rf.DecoderParams["chroma_rotation"])
-
 
 class FieldNTSCUMatic(FieldNTSCShared):
     def __init__(self, *args, **kwargs):
@@ -2007,7 +1994,7 @@ class FieldNTSCUMatic(FieldNTSCShared):
         dsout, dsaudio, dsefm = super(FieldNTSCUMatic, self).downscale(
             final=final, *args, **kwargs
         )
-        dschroma = decode_chroma_simple(self)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -2047,13 +2034,10 @@ class FieldMESECAMVHS(FieldPALShared):
     def __init__(self, *args, **kwargs):
         super(FieldMESECAMVHS, self).__init__(*args, **kwargs)
 
-    def try_detect_track(self):
-        return 0, False
-
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldMESECAMVHS, self).downscale(
             final=final, *args, **kwargs
         )
-        dschroma = decode_chroma_simple(self)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1855,7 +1855,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         measured_quadrant_phase = measured_quadrant * 90
         expected_quadrant_phase = expected_quadrant * 90
 
-        for line_number, burst_phase, _, _ in burst_phases[16:]:
+        for line_number, burst_phase, _, _, _ in burst_phases[16:]:
             # phase delta relative to expected phase (0, 90, 180, 270)
             phase_delta = (expected_quadrant_phase - burst_phase + 180) % 360 - 180
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -12,8 +12,8 @@ from vhsdecode.addons.resync import Pulse
 from vhsdecode.chroma import (
     decode_chroma_simple,
     decode_chroma,
+    decode_chroma_phase_rotation,
     try_detect_track_vhs_pal,
-    try_detect_track_ntsc,
     try_detect_track_betamax_pal,
 )
 
@@ -1141,6 +1141,15 @@ class FieldShared:
             + 0.5
         )
 
+    def lock_to_burst(self):
+        self.chroma_tbc_buffer = None
+
+        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phases, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
+            self,
+            chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
+            detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
+        )
+
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldShared, self).downscale(
             final=False, *args, **kwargs
@@ -1809,13 +1818,13 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         self.ire0_backporch = (96, 160)
 
     def refine_linelocs_pilot(self, linelocs=None):
-        """Override this as most regular band tape formats does not use have a pilot burst.
-        Tape formats that do have it will need separate logic for it anyhow.
-        """
+        # Currently only supported with NTSC
         if linelocs is None:
             linelocs = self.linelocs2.copy()
         else:
             linelocs = linelocs.copy()
+
+        self.lock_to_burst()
 
         return linelocs
 
@@ -1832,14 +1841,29 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.ire0_backporch = (74, 124)
 
     def refine_linelocs_burst(self, linelocs=None):
-        """Override this as it's LD specific
-        At some point in the future we could maybe use the burst location to improve hsync accuracy,
-        but ignore it for now.
-        """
         if linelocs is None:
-            linelocs = self.linelocs2
+            linelocs = self.linelocs2.copy()
         else:
             linelocs = linelocs.copy()
+
+        self.lock_to_burst()
+
+        if self.burst_phases:
+            for line_number, burst_phase, _, _, _, _ in self.burst_phases:
+                # scale up burst fsc
+                line_start = self.linelocs2[line_number]
+                line_end = self.linelocs2[line_number + 1]
+                line_length = line_end - line_start
+
+                scale = line_length / self.outlinelen
+
+                phase_delta = (self.burst_phase_avg - burst_phase + 180) % 360 - 180
+                line_adjust = (phase_delta / 360.0 * 4) * scale # 4fsc, then scaled up to the input line length
+
+                # TODO try to match up color burst more than +-180 degrees using cross correlation
+                linelocs[line_number] += line_adjust
+
+                print(line_number, line_adjust, scale, self.burst_phase_avg, burst_phase, phase_delta)
 
         return linelocs
 
@@ -1852,7 +1876,7 @@ class FieldPALVHS(FieldPALShared):
         dsout, dsaudio, dsefm = super(FieldPALVHS, self).downscale(
             final=final, *args, **kwargs
         )
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -1893,9 +1917,7 @@ class FieldPALBetamax(FieldPALShared):
             final=final, *args, **kwargs
         )
 
-        dschroma = decode_chroma(
-            self, chroma_rotation=self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
-        )
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -1915,9 +1937,7 @@ class FieldPALVideo8(FieldPALShared):
 
         dschroma = decode_chroma(
             self,
-            chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
-            do_chroma_deemphasis=True,
-            detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
+            do_chroma_deemphasis=True
         )
 
         return (dsout, dschroma), dsaudio, dsefm
@@ -1939,16 +1959,13 @@ class FieldNTSCVHS(FieldNTSCShared):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCVHS, self).__init__(*args, **kwargs)
 
-    def try_detect_track(self):
-        return try_detect_track_ntsc(self, self.rf.DecoderParams["chroma_rotation"])
-
     def downscale(self, final=False, *args, **kwargs):
         """Downscale the channels and upconvert chroma to standard color carrier frequency."""
         dsout, dsaudio, dsefm = super(FieldNTSCVHS, self).downscale(
             final=final, *args, **kwargs
         )
 
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -1964,15 +1981,12 @@ class FieldNTSCBetamax(FieldNTSCShared):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCBetamax, self).__init__(*args, **kwargs)
 
-    def try_detect_track(self):
-        return try_detect_track_ntsc(self, self.rf.DecoderParams["chroma_rotation"])
-
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldNTSCBetamax, self).downscale(
             final=final, *args, **kwargs
         )
 
-        dschroma = decode_chroma(self, self.rf.DecoderParams["chroma_rotation"], detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase)
+        dschroma = decode_chroma(self)
 
         return (dsout, dschroma), dsaudio, dsefm
 
@@ -2016,9 +2030,6 @@ class FieldNTSCVideo8(FieldNTSCShared):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCVideo8, self).__init__(*args, **kwargs)
 
-    def try_detect_track(self):
-        return try_detect_track_ntsc(self, self.rf.DecoderParams["chroma_rotation"])
-
     def downscale(self, final=False, *args, **kwargs):
         """Downscale the channels and upconvert chroma to standard color carrier frequency."""
         dsout, dsaudio, dsefm = super(FieldNTSCVideo8, self).downscale(
@@ -2026,7 +2037,7 @@ class FieldNTSCVideo8(FieldNTSCShared):
         )
 
         dschroma = decode_chroma(
-            self, self.rf.DecoderParams["chroma_rotation"], do_chroma_deemphasis=True, detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
+            self, do_chroma_deemphasis=True
         )
 
         return (dsout, dschroma), dsaudio, dsefm

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numba import njit
 
 import lddecode.core as ldd
 import lddecode.utils as lddu
@@ -1140,7 +1141,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phases, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phases, self.burst_phase_expected, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
@@ -1841,6 +1842,32 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.fieldPhaseID = 0
         self.ire0_backporch = (74, 124)
 
+    @staticmethod
+    @njit(cache=True, fastmath=True, nogil=True)
+    def _sync_to_burst(
+        linelocs,
+        outlinelen,
+        expected_quadrant,
+        burst_phase_avg,
+        burst_phases
+    ):
+        measured_quadrant = int(round(burst_phase_avg) / 90) % 4
+        measured_quadrant_phase = measured_quadrant * 90
+        expected_quadrant_phase = expected_quadrant * 90
+
+        for line_number, burst_phase, _, _ in burst_phases[16:]:
+            # phase delta relative to expected phase (0, 90, 180, 270)
+            phase_delta = (expected_quadrant_phase - burst_phase + 180) % 360 - 180
+
+            # scale up burst fsc for each line
+            line_start = linelocs[line_number]
+            line_end = linelocs[line_number + 1]
+            line_length = line_end - line_start
+            scale = line_length / outlinelen
+
+            line_adjust = (phase_delta / 360.0 * 4)
+            linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
+
     def refine_linelocs_burst(self, linelocs=None):
         if linelocs is None:
             linelocs = self.linelocs2.copy()
@@ -1851,20 +1878,13 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.lock_to_burst()
 
         if self.burst_phases:
-            for line_number, burst_phase, _, _, _, _ in self.burst_phases:
-                # scale up burst fsc
-                line_start = self.linelocs2[line_number]
-                line_end = self.linelocs2[line_number + 1]
-                line_length = line_end - line_start
-
-                scale = line_length / self.outlinelen
-
-                phase_delta = (self.burst_phase_avg - burst_phase + 180) % 360 - 180
-                line_adjust = (phase_delta / 360.0 * 4) * scale # 4fsc, then scaled up to the input line length
-
-                # TODO try to match up color burst more than +-180 degrees using cross correlation
-                linelocs[line_number] += line_adjust
-                #print(line_number, line_adjust, scale, self.burst_phase_avg, burst_phase, phase_delta)
+            FieldNTSCShared._sync_to_burst(
+                linelocs,
+                self.outlinelen,
+                self.burst_phase_expected,
+                self.burst_phase_avg,
+                self.burst_phases,
+            )
 
         return linelocs
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1143,7 +1143,7 @@ class FieldShared:
         self.chroma_tbc_buffer = None
         self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
             self,
-            chroma_rotation=self.rf.DecoderParams["chroma_rotation"],
+            chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
         self.track_phase_set = True

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -218,7 +218,7 @@ def main(args=None, use_gui=False):
         help=(
             "Tries to detect the chroma carrier frequency on a field basis within some"
             " limit instead of using the default one for the format. Mainly useful for"
-            " debug purposes and used on PAL betamax. implies --recheck_phase"
+            " debug purposes and used on PAL betamax."
         ),
     )
     chroma_group.add_argument(
@@ -236,13 +236,6 @@ def main(args=None, use_gui=False):
         action="store_true",
         default=False,
         help="Detect and correct chroma phase consistency for each track / field. Corrects chroma artifacts around head-switching area for VHS. (Experimental feature)",
-    )
-    chroma_group.add_argument(
-        "--recheck_phase",
-        dest="recheck_phase",
-        action="store_true",
-        default=False,
-        help="Re-check chroma phase on every field. (No effect on U-matic)",
     )
     chroma_group.add_argument(
         "--no_comb",
@@ -493,7 +486,6 @@ def main(args=None, use_gui=False):
     rf_options["dod_threshold_a"] = args.dod_threshold_a
     rf_options["dod_hysteresis"] = args.dod_hysteresis
     rf_options["track_phase"] = args.track_phase
-    rf_options["recheck_phase"] = args.recheck_phase
     rf_options["high_boost"] = args.high_boost
     rf_options["disable_diff_demod"] = args.disable_diff_demod
     rf_options["fm_audio_notch"] = args.fm_audio_notch

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -128,14 +128,26 @@ def main(args=None, use_gui=False):
         ),
     )
     luma_group.add_argument(
-        "--wow_adjust_smoothing_lines",
-        type=float,
+        "--wow_level_adjust_smoothing",
+        type=int,
         default=None,
         help=(
-            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow. "
-            "\nWow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
-            "\nDefault is (video system lines / 2) i.e. NTSC=525/2, PAL=625/2, etc."
-            "\nSet to `0` to disable smoothing (only recommended for low noise video)"
+            "Adjusts the amount of smoothing in lines that is performed when compensating for brightness variations caused by wow."
+            "\n  Default is (video system lines / 2) i.e. NTSC=525/2, PAL=625/2, etc."
+            "\n  Wow calculation is based on position of hsync pulses which is affected by the accuracy of the TBC. "
+            "\n  If you see vertical brightness variations (banding), setting to a value larger than 0 will smooth the wow adjustment."
+        )
+    )
+    luma_group.add_argument(
+        "--wow_interpolation_method",
+        type=str,
+        default="linear",
+        choices=["linear", "quadratic", "cubic"],
+        help=(
+            "Sets the type of interpolation spline used to correct wow."
+            "\n  linear     [default]"
+            "\n  quadratic"
+            "\n  cubic"
         )
     )
     luma_group.add_argument(
@@ -555,7 +567,6 @@ def main(args=None, use_gui=False):
         extra_options=extra_options,
         debug_plot=debug_plot,
         field_order_action=args.field_order_action,
-        level_smoothing_lines=args.wow_adjust_smoothing_lines
     )
 
     if check_debug():

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -230,12 +230,20 @@ def main(args=None, use_gui=False):
         help="If set to 0 or 1, force use of video track phase. (No effect on U-matic)",
     )
     chroma_group.add_argument(
-        "-dctp",
+        "--dctp",
         "--detect_chroma_track_phase",
         dest="detect_chroma_track_phase",
         action="store_true",
         default=False,
-        help="Detect and correct chroma phase consistency for each track / field. Corrects chroma artifacts around head-switching area for VHS. (Experimental feature)",
+        help="Detects and corrects color-under heterodyne rotation change around head-switching area. Corrects chroma artifacts around head-switching area for color-under formats. (Experimental feature)",
+    )
+    chroma_group.add_argument(
+        "--dbh",
+        "--disable_burst_hsync",
+        dest="disable_burst_hsync",
+        action="store_true",
+        default=False,
+        help="Disables using the color burst phase to refine hsync. (currently only applicable to NTSC)",
     )
     chroma_group.add_argument(
         "--no_comb",
@@ -507,6 +515,7 @@ def main(args=None, use_gui=False):
     rf_options["tape_speed"] = args.tape_speed
     rf_options["ire0_adjust"] = args.ire0_adjust
     rf_options["detect_chroma_track_phase"] = args.detect_chroma_track_phase
+    rf_options["disable_burst_hsync"] = args.disable_burst_hsync
     rf_options["gnrc_afe"] = args.gnrc_afe
 
     extra_options = get_extra_options(args, not use_gui)

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -613,7 +613,6 @@ class VHSRFDecode(ldd.RFDecode):
             tape_format == "BETAMAX" or tape_format == "BETAMAX_HIFI"
         )
         track_phase = None if is_secam(system) else rf_options.get("track_phase", None)
-        self._recheck_phase = rf_options.get("recheck_phase", False)
         high_boost = rf_options.get("high_boost", None)
         self._notch = rf_options.get("notch", None)
         self._notch_q = rf_options.get("notch_q", 10.0)
@@ -627,19 +626,11 @@ class VHSRFDecode(ldd.RFDecode):
             if (tape_format == "BETAMAX" and system != "NTSC")
             else rf_options.get("cafc", False)
         )
-        # cafc requires --recheck_phase
-        self._recheck_phase = True if self._do_cafc else self._recheck_phase
 
-        self.detect_track = False
-        self.needs_detect = False
-        if track_phase is None:
-            self.track_phase = 0
-            if not is_secam(system):
-                self.detect_track = True
-                self.needs_detect = True
-        elif track_phase == 0 or track_phase == 1:
+        self.track_phase = None
+        if track_phase == 0 or track_phase == 1:
             self.track_phase = track_phase
-        else:
+        elif track_phase is not None:
             raise Exception("Track phase can only be 0, 1 or None")
 
         self.hsync_tolerance = 0.8
@@ -933,10 +924,6 @@ class VHSRFDecode(ldd.RFDecode):
     @property
     def do_cafc(self):
         return self._do_cafc
-
-    @property
-    def recheck_phase(self):
-        return self._recheck_phase
 
     @property
     def color_system(self):

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -699,6 +699,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "gnrc_afe",
                 "relaxed_line0",
                 "detect_chroma_track_phase",
+                "disable_burst_hsync"
             ],
         )(
             self.iretohz(100) * 2,
@@ -738,6 +739,7 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("gnrc_afe", False),
             rf_options.get("relaxed_line0", False),
             rf_options.get("detect_chroma_track_phase", False),
+            rf_options.get("disable_burst_hsync", False)
         )
 
         # As agc can alter these sysParams values, store a copy to then

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -92,7 +92,6 @@ class VHSDecode(ldd.LDdecode):
         extra_options={},
         debug_plot=None,
         field_order_action="detect",
-        level_smoothing_lines=None,
     ):
 
         # monkey patch init with a dummy to prevent calling set_start_method twice on macos
@@ -176,11 +175,10 @@ class VHSDecode(ldd.LDdecode):
             self.field_order_action = "none"
         self.duplicate_prev_field = True
 
-        self.level_smoothing_lines = (
-            level_smoothing_lines
-            if level_smoothing_lines is not None
-            else self.rf.SysParams["frame_lines"] / 2
-        )
+        # For tape, it is recommended to use `--ire0_adjust` to fix brightness variations between lines
+        # This method usually gives false positives for noisy signals, so smooth the correction out by an entire field to avoid banding
+        if self.wow_level_adjust_smoothing is None:
+            self.wow_level_adjust_smoothing = self.rf.SysParams["frame_lines"] / 2
 
         # Needs to be overridden since this is overwritten for 405-line.
         # self.output_lines = (self.rf.SysParams["frame_lines"] // 2) + 1


### PR DESCRIPTION
Testing Notes:
- [x] - VHS (works)
- [x] - SVHS (works)
- [x] - Video8 (works)
- [x] - Betamax (works)
- [x] - Super Betamax (works, but the sample on the shared drive appears to have significant interference)
- [x] - U-Matic (works)

* Use the NTSC color burst location to refine the hsync.
  * Enabled by default. Setting `--disable_burst_hsync` disables it.
  * This calculates the average phase of the color burst across the field, then aligns each line so the burst is at that average phase.
  * It is currently limited to +-180 degrees of correction, since only using the phase of the color burst.
    * A future enhancement might be to detect the relative location of the burst to correct larger errors.
* Fix NTSC burst phase alignment so it is color frame synced on the correct 4 field sequence.
* Refactor chroma decoding:
  * Split out the burst phase calculations from the actual chroma decoding, so the burst phase can be used for TBC without having to upconvert the rest of the chroma.
  * Move track detection logic into the burst phase detection. This avoids having to upconvert the entire chroma signal twice to detect the track phase. Since the burst is always demodulated, track phase detection always happens by default (if heterodyne rotation is enabled for the format)
  * `--recheck_phase` is removed since it is no longer needed
    * `--recheck_phase` was only needed to check that the color under heterodyne was rotating in the correct direction. That just happens by default now since the color burst is being demodulated, so it's trivial to do the check with no performance impact. Also, `--recheck_phase` was demodulating the entire chroma section twice, which is why it would slow things down. Only the burst area needs to be checked, not the entire chroma channel.
  * Deleted dead code that was used for recheck_phase