### PR TITLE
fix: minimum required python3.11 and cargo linker performance

### DIFF
--- a/.github/workflows/push_pypi.yml
+++ b/.github/workflows/push_pypi.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     env:
-      CIBW_SKIP: "cp38-* cp39-* pp* cp310-macosx_arm64 cp311-macosx_arm64 cp310-win_amd64"
+      CIBW_SKIP: "cp38-* cp39-* cp310-* pp* cp311-macosx_arm64 cp312-macosx_arm64 cp311-win_amd64"
       CIBW_ARCHS_LINUX: "x86_64"
       CIBW_ARCHS_WINDOWS: "AMD64"
       CIBW_ARCHS_MACOS: "arm64 universal2"

--- a/.github/workflows/push_testpypi.yml
+++ b/.github/workflows/push_testpypi.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
     env:
-      CIBW_SKIP: "cp38-* cp39-* pp*"
+      CIBW_SKIP: "cp38-* cp39-* cp310-* pp*"
       CIBW_ARCHS_LINUX: "x86_64"
       CIBW_ARCHS_WINDOWS: "AMD64"
       CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
@@ -27,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v3.1.3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ sci-rs = "0.4.1"
 itertools = "0.14.0"
 #ndarray = { version = "0.15.6", features = ["rayon"]}
 
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+
 [lib]
 name = "vhsd_rust"
 # "cdylib" is necessary to produce a shared library for Python to import from.

--- a/README.md
+++ b/README.md
@@ -256,11 +256,11 @@ While type and voltage does not matter drastically it's best to use new/tested c
 
 VHS-Decode, as with LD-Decode, has been developed and tested on machines running the latest versions of Ubuntu, Debian, Linux Mint & Windows 10/11, and has user testing on current versions of MacOS.
 
-The tools should however be able to be built on other distributions too, provided they have access to somewhat recent versions of the needed dependencies, including at least Python 3.8.
+The tools should however be able to be built on other distributions too, provided they have access to somewhat recent versions of the needed dependencies, including at least Python 3.11.
 
 There is a [Linux compatibility doc](https://docs.google.com/document/d/132ycIMMNvdKvrNZSzbckXVEPQVLTnH_YX0Oh3lqtkkQ) for various tested distributions of Linux.
 
-Other dependencies include Python 3.8+, NumPy, SciPy, Cython, Numba, Pandas, Qt5, Qwt, Cmake, and FFmpeg.
+Other dependencies include Python 3.11+, NumPy, SciPy, Cython, Numba, Pandas, Qt5, Qwt, Cmake, and FFmpeg.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,18 @@ requires-python = ">=3.11"
 keywords = ["laserdisc", "vhs", "video", "tape", "decoder"]
 license = {file = "LICENSE"}
 classifiers = [
-    "Topic :: Multimedia :: Video",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Multimedia :: Video :: Capture",
 ]
 dependencies = [
     "cython",
@@ -54,6 +64,9 @@ decode-launcher = "vhsdecode.decode_launcher:main"
 
 [project.urls]
 Homepage = "https://www.domesday86.com"
+Repository = "https://github.com/oyvindln/vhs-decode"
+Documentation = "https://github.com/oyvindln/vhs-decode/wiki"
+Issues = "https://github.com/oyvindln/vhs-decode/issues"
 
 [tool.setuptools_scm]
 write_to = "vhsdecode/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 name = "vhs_decode"
 description = "Software Decoder for raw rf captures of laserdisc, vhs and other analog video formats"
 readme = "README_pypi.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 keywords = ["laserdisc", "vhs", "video", "tape", "decoder"]
 license = {file = "LICENSE"}
 classifiers = [
@@ -15,7 +15,17 @@ classifiers = [
     "Programming Language :: Rust",
 ]
 dependencies = [
-    "numpy>=1.22","numba>=0.58.1","scipy>=1.10.1", "soxr", "static-ffmpeg", "cython", "soundfile>=0.13.1", "sounddevice", "importlib_resources >= 5.0; python_version < '3.10'", "matplotlib", "noisereduce>=2.0.0", "setproctitle"
+    "cython",
+    "matplotlib",
+    "noisereduce>=2.0.0",
+    "numba>=0.59",
+    "numpy>=1.24",
+    "scipy>=1.11",
+    "setproctitle",
+    "sounddevice",
+    "soundfile>=0.13.1",
+    "soxr",
+    "static-ffmpeg",
 ]
 dynamic = ["version"]
 # version = "0.2.1dev0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 Cython
 matplotlib
-numba>=0.58.1
-numpy>=1.22
-soxr
-scipy >=1.10
-soundfile>=0.13.1
-sounddevice
 noisereduce>=2.0.0
-pyzmq
+numba>=0.59
+numpy>=1.24
+scipy>=1.11
 setproctitle
+sounddevice
+soundfile>=0.13.1
+soxr
+static-ffmpeg


### PR DESCRIPTION
Pyo3 0.27 actually requires Python 3.11 or higher
https://github.com/PyO3/pyo3/releases/tag/v0.27.0
https://github.com/oyvindln/vhs-decode/blob/vhs_decode/Cargo.toml#L8

This PR bumps the documentation to be closer to truth, as the Py3.8 is misleading. 3.8 is EOL and there's been a lot of perf improvements since. All major distros have 3.11 support. (3.13 is commonly available).

I've aligned the requirements and pyproject, with some small bumps to the lower bounds. (Why do we declare both ways?)

I've added some release instructions to the toml which costs a little more at compile time in linking, but increases FPS in operation by a nominal ~2.5%. We do lose debugging symbols, but those probably shouldn't be in the distributed builds anyway.