### PR TITLE
fix heterodyne correction to minimize phase difference between fields

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -285,10 +285,8 @@ def get_phase_rotation_sequence(
     prev_burst_phase_avg,
     prev_burst_rising
 ):
-    # *****************************************************
-    # Gather the phase differences between each color burst
-    # Color burst alternates phase between lines in a field
-    # *****************************************************    
+    # Detects the correct color-under heterodyne starting phase and rotation direction
+    # Additional for NTSC, this function calculates the color burst average for burst-locked TBC later on
     track_change_threshold = 90
     burst_check_skip_lines = 16
     coherence_threshold = 0.3
@@ -345,7 +343,7 @@ def get_phase_rotation_sequence(
         if color_system == "NTSC":
             # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
             flip_track_phase = delta_0 < delta_180
-        elif color_system == "PAL":
+        elif color_system == "PAL" or color_system == "NLINHA":
             # each line should alternate phase, if there are repeated sequences of phase, recalculate
             alt1 = delta_90 + delta_270
             alt2 = delta_0 + delta_180
@@ -375,10 +373,11 @@ def get_phase_rotation_sequence(
             track_change_threshold
         )
 
-    # ***************************************************************************************
-    # detect the correct starting phase using the expected phase quadrant of the color bursts
-    # ***************************************************************************************
-    if color_system == "NTSC":
+    # detect the correct NTSC starting heterodyne phase and fieldPhaseId
+    if (
+        color_system == "NTSC" or
+        color_system == "NLINHA" # these measurements are not used by NLINHA, but they need to be calculated so the downstream NTSC code works
+    ):
         # find the phase of the color burst for the entire field, and detect if the burst is rising or falling
         I_total = 0
         Q_total = 0
@@ -462,6 +461,8 @@ def get_phase_rotation_sequence(
                 )
     else:
         field_phase_id = None
+        burst_phase_avg = None
+        burst_rising = None
         burst_detected = None
 
     return chroma_rotation_index, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -374,10 +374,7 @@ def get_phase_rotation_sequence(
         )
 
     # detect the correct NTSC starting heterodyne phase and fieldPhaseId
-    if (
-        color_system == "NTSC" or
-        color_system == "NLINHA" # these measurements are not used by NLINHA, but they need to be calculated so the downstream NTSC code works
-    ):
+    if color_system == "NTSC":
         # find the phase of the color burst for the entire field, and detect if the burst is rising or falling
         I_total = 0
         Q_total = 0
@@ -459,6 +456,13 @@ def get_phase_rotation_sequence(
                     burst_I,
                     burst_Q
                 )
+    elif color_system in ("MPAL", "NLINHA"):
+        # fieldPhaseID needs to be populated for these color systems so code downstream works.
+        # As far as I can tell, it is not used for anything since PAL decoding works without proper color framing
+        field_phase_id = 0
+        burst_phase_avg = None
+        burst_rising = None
+        burst_detected = None
     else:
         field_phase_id = None
         burst_phase_avg = None

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -343,7 +343,7 @@ def get_phase_rotation_sequence(
         if color_system == "NTSC":
             # if the bursts are out of phase with each other, the track was miss-detected, flip phase and recalculate sequence
             flip_track_phase = delta_0 < delta_180
-        elif color_system == "PAL" or color_system == "NLINHA":
+        else: # color_system in ("PAL", "MPAL", "PALM", "NLINHA", "MESECAM")
             # each line should alternate phase, if there are repeated sequences of phase, recalculate
             alt1 = delta_90 + delta_270
             alt2 = delta_0 + delta_180

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -411,9 +411,18 @@ def get_phase_rotation_sequence(
 
         # shift the phase +-[0, 90, 180, 270] degrees so that the burst_phase_avg is as close as possible to prev_burst_phase_avg
         if prev_burst_phase_avg is not None:
-            # Possible shifts in degrees
             delta = (burst_phase_avg - prev_burst_phase_avg + 180) % 360 - 180
             best_shift = round(-delta / 90) * 90
+
+            # prevent phase from drifting +-45 away from the quadrant
+            shifted_phase = (burst_phase_avg + best_shift) % 360
+            # if outside of +- 45 of quadrant 0: (315) 0 to 90 (135)
+            if shifted_phase > 135 and shifted_phase < 315:
+                # shift the phase back into quadrant 0 using the shortest possible distance
+                if shifted_phase < 180:
+                    best_shift -= 1
+                else:
+                    best_shift += 1
 
             burst_phase_avg = (burst_phase_avg + best_shift) % 360
             heterodyne_offset = best_shift // 90

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -282,6 +282,8 @@ def get_phase_rotation_sequence(
     rotation_check_start_line,
     color_system,
     is_first_field,
+    prev_burst_phase_avg,
+    prev_burst_rising
 ):
     # *****************************************************
     # Gather the phase differences between each color burst
@@ -407,15 +409,30 @@ def get_phase_rotation_sequence(
         burst_detected = coherence >= coherence_threshold
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
 
-        # color burst phase should be normalized to be within 0 to 90 degrees
-        heterodyne_offset = int(burst_phase_avg // 90) % 4
-        corrected_burst_avg = burst_phase_avg % 90
+        # shift the phase +-[0, 90, 180, 270] degrees so that the burst_phase_avg is as close as possible to prev_burst_phase_avg
+        if prev_burst_phase_avg is not None:
+            # Possible shifts in degrees
+            delta = (burst_phase_avg - prev_burst_phase_avg + 180) % 360 - 180
+            best_shift = round(-delta / 90) * 90
 
-        # if the corrected burst is in the +45 area of the quadrant, the rising check switches direction
-        # this isn't completely perfect, if the phase is really close to 45, noise can throw off this measurement
-        # any miss-detection here only only affects the NTSC 3D decoder,
-        # since there is a bug that prevents phase correction from working properly when the field phase id is miss-detected
-        burst_rising = rotation_sum < 0 if corrected_burst_avg > 45 else rotation_sum > 0
+            burst_phase_avg = (burst_phase_avg + best_shift) % 360
+            heterodyne_offset = best_shift // 90
+
+            # rising/falling calculation
+            # if the corrected burst is in the +45 area of the quadrant, the rising check switches direction
+            # this isn't completely perfect, if the phase is really close to 45, noise can throw off this measurement
+            # so use the predicted next burst_rising value when the calculation is not confident enough
+            # rotation sum indicates how many rising vs. falling waves were detected
+            if -8 < rotation_sum < 8:
+                burst_rising = prev_burst_rising if is_first_field else not prev_burst_rising
+            else:
+                burst_rising = rotation_sum < 0 if burst_phase_avg > 45 else rotation_sum > 0
+        else:
+            heterodyne_offset = -(int(burst_phase_avg // 90) % 4)
+            burst_phase_avg = burst_phase_avg % 90
+
+            # rising/falling calculation
+            burst_rising = rotation_sum < 0 if burst_phase_avg > 45 else rotation_sum > 0
 
         field_phase_id = {
             (1, 1): 1,
@@ -423,7 +440,7 @@ def get_phase_rotation_sequence(
             (1, 0): 3,
             (0, 1): 4,
         }[(is_first_field, burst_rising)]
-        
+
         # adjust the starting phase
         if heterodyne_offset != 0:
             for i in range(len(phase_sequence)):
@@ -438,18 +455,17 @@ def get_phase_rotation_sequence(
 
                 phase_sequence[i] = (
                     line_number,
-                    (phase - heterodyne_offset) % 4,
-                    (burst_phase - (heterodyne_offset * 90)) % 360,
+                    (phase + heterodyne_offset) % 4,
+                    (burst_phase + (heterodyne_offset * 90)) % 360,
                     burst_magnitude,
                     burst_I,
                     burst_Q
                 )
     else:
-        corrected_burst_avg = None
         field_phase_id = None
         burst_detected = None
 
-    return chroma_rotation_index, phase_sequence, field_phase_id, corrected_burst_avg, burst_detected
+    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected
 
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -546,7 +562,13 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
+    prev_burst_phase_avg = None
+    prev_burst_rising = None
+    if field.prevfield is not None:
+        prev_burst_phase_avg = field.prevfield.burst_phase_avg
+        prev_burst_rising = field.prevfield.burst_rising
+
+    track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
@@ -562,9 +584,11 @@ def decode_chroma_phase_rotation(
         rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
         field.rf.color_system,
         field.isFirstField,
+        prev_burst_phase_avg,
+        prev_burst_rising
     )
 
-    return track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_detected
+    return track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected
 
 def process_chroma(
     field,

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -414,16 +414,6 @@ def get_phase_rotation_sequence(
             delta = (burst_phase_avg - prev_burst_phase_avg + 180) % 360 - 180
             best_shift = round(-delta / 90) * 90
 
-            # prevent phase from drifting +-45 away from the quadrant
-            shifted_phase = (burst_phase_avg + best_shift) % 360
-            # if outside of +- 45 of quadrant 0: (315) 0 to 90 (135)
-            if shifted_phase > 135 and shifted_phase < 315:
-                # shift the phase back into quadrant 0 using the shortest possible distance
-                if shifted_phase < 180:
-                    best_shift -= 1
-                else:
-                    best_shift += 1
-
             burst_phase_avg = (burst_phase_avg + best_shift) % 360
             heterodyne_offset = best_shift // 90
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1141,7 +1141,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phase_avg, _ = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phase_avg, self.burst_rising, _ = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1870,7 +1870,11 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         # populates color burst info for hsync refinement the step below
         self.lock_to_burst()
 
-        if not self.rf.options.disable_burst_hsync and self.phase_sequence is not None:
+        if (
+            not self.rf.options.disable_burst_hsync and
+            self.phase_sequence is not None and
+            self.rf.color_system == "NTSC" # disable for NLINHA, since that uses PAL style phase rotation
+        ):
             FieldNTSCShared._sync_to_burst(
                 linelocs,
                 self.outlinelen,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1873,7 +1873,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         if (
             not self.rf.options.disable_burst_hsync and
             self.phase_sequence is not None and
-            self.rf.color_system == "NTSC" # disable for NLINHA, since that uses PAL style phase rotation
+            self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
         ):
             FieldNTSCShared._sync_to_burst(
                 linelocs,


### PR DESCRIPTION
* Fixes NLINHA color system (obscure Brazilian system used only in VHS recordings)
* Fixes PAL-M color system
* This changes how the heterodyne is derived from the phase measurement. The heterodyne should be chosen from the adjustment that results in the least distance between the previous phase and the current phase. This used to be constrained to 0-90 degrees, but this would cause wrapping around the 0 and 90 degree boundaries. 
* This also corrects an issue where the rising vs. falling measurement can be noisy when the corrected phase is around 45 degrees (mid point of 0 to 90). When the measurement is not confident (i.e less than +-8 rising / falling directions measured) it uses the estimated value derived from the previous measurement.