### PR TITLE
Fix NTSC 3D decoding for color under

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -455,7 +455,10 @@ class LoadFFmpeg:
         while sample_bytes > self.position:
             # Seeking forwards - read and discard samples
             count = min(sample_bytes - self.position, self.rewind_size)
-            self._read_data(count)
+            data = self._read_data(count)
+            if len(data) == 0:
+                # EOF
+                return None
 
         if readlen_bytes > 0:
             # Read some new data from ffmpeg
@@ -566,7 +569,10 @@ class LoadLDF:
         while sample_bytes > self.position:
             # Seeking forwards - read and discard samples
             count = min(sample_bytes - self.position, self.rewind_size)
-            self._read_data(count)
+            data = self._read_data(count)
+            if len(data) == 0:
+                # EOF
+                return None
 
         if readlen_bytes > 0:
             # Read some new data from ffmpeg

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -281,9 +281,6 @@ def get_phase_rotation_sequence(
     detect_chroma_track_phase,
     rotation_check_start_line,
     color_system,
-    is_first_field,
-    prev_burst_phase_avg,
-    prev_burst_rising
 ):
     # Detects the correct color-under heterodyne starting phase and rotation direction
     # Additional for NTSC, this function calculates the color burst average for burst-locked TBC later on
@@ -373,103 +370,33 @@ def get_phase_rotation_sequence(
             track_change_threshold
         )
 
-    # detect the correct NTSC starting heterodyne phase and fieldPhaseId
     if color_system == "NTSC":
-        # find the phase of the color burst for the entire field, and detect if the burst is rising or falling
+        # find the phase of the color burst for the entire field
         I_total = 0
         Q_total = 0
-        prev_I = None
-        prev_Q = None
-
         avg_count = 0
-        rotation_sum = 0
         for line_number, _, _, magnitude, I, Q in phase_sequence:
             if (
                 line_number > burst_check_start and
                 line_number < burst_check_end
             ):
                 if magnitude != 0:
-                    I /= magnitude
-                    Q /= magnitude
-                    I_total += I
-                    Q_total += Q
-
-                    if prev_I is not None:
-                        rotation_sum += prev_I * I - prev_Q * Q
-
-                    prev_I = I
-                    prev_Q = Q
+                    I_total += I / magnitude
+                    Q_total += Q / magnitude
                     avg_count += 1
 
         coherence = np.hypot(I_total, Q_total) / avg_count
         burst_detected = coherence >= coherence_threshold
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
 
-        # shift the phase +-[0, 90, 180, 270] degrees so that the burst_phase_avg is as close as possible to prev_burst_phase_avg
-        if prev_burst_phase_avg is not None:
-            delta = (burst_phase_avg - prev_burst_phase_avg + 180) % 360 - 180
-            best_shift = round(-delta / 90) * 90
-
-            burst_phase_avg = (burst_phase_avg + best_shift) % 360
-            heterodyne_offset = best_shift // 90
-
-            # rising/falling calculation
-            # if the corrected burst is in the +45 area of the quadrant, the rising check switches direction
-            # this isn't completely perfect, if the phase is really close to 45, noise can throw off this measurement
-            # so use the predicted next burst_rising value when the calculation is not confident enough
-            # rotation sum indicates how many rising vs. falling waves were detected
-            if -8 < rotation_sum < 8:
-                burst_rising = prev_burst_rising if is_first_field else not prev_burst_rising
-            else:
-                burst_rising = rotation_sum < 0 if burst_phase_avg > 45 else rotation_sum > 0
-        else:
-            heterodyne_offset = -(int(burst_phase_avg // 90) % 4)
-            burst_phase_avg = burst_phase_avg % 90
-
-            # rising/falling calculation
-            burst_rising = rotation_sum < 0 if burst_phase_avg > 45 else rotation_sum > 0
-
-        field_phase_id = {
-            (1, 1): 1,
-            (0, 0): 2,
-            (1, 0): 3,
-            (0, 1): 4,
-        }[(is_first_field, burst_rising)]
-
-        # adjust the starting phase
-        if heterodyne_offset != 0:
-            for i in range(len(phase_sequence)):
-                (
-                    line_number,
-                    phase,
-                    burst_phase,
-                    burst_magnitude,
-                    burst_I,
-                    burst_Q
-                ) = phase_sequence[i]
-
-                phase_sequence[i] = (
-                    line_number,
-                    (phase + heterodyne_offset) % 4,
-                    (burst_phase + (heterodyne_offset * 90)) % 360,
-                    burst_magnitude,
-                    burst_I,
-                    burst_Q
-                )
     elif color_system in ("MPAL", "NLINHA"):
-        # fieldPhaseID needs to be populated for these color systems so code downstream works.
-        # As far as I can tell, it is not used for anything since PAL decoding works without proper color framing
-        field_phase_id = 0
         burst_phase_avg = None
-        burst_rising = None
         burst_detected = None
     else:
-        field_phase_id = None
         burst_phase_avg = None
-        burst_rising = None
         burst_detected = None
 
-    return chroma_rotation_index, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected
+    return chroma_rotation_index, phase_sequence, burst_phase_avg, burst_detected
 
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
@@ -491,6 +418,38 @@ def upconvert_chroma(
 
     return uphet
 
+@njit(cache=True, nogil=True, fastmath=True)
+def adjust_phase(
+    input_data,
+    output_data,
+    input_phase,
+    target_phase
+):
+    # rotates the phase of the chroma signal
+    phase_adjustment = np.deg2rad(target_phase) - np.deg2rad(input_phase)
+    rotation = np.exp(1j * phase_adjustment)
+
+    for i in range(len(input_data)):
+        # Apply phase adjustment in baseband
+        # Convert back to real and store
+        output_data[i] = (input_data[i] * rotation).real
+
+def ntsc_phase_comp(
+    uphet,
+    burst_phase_avg,
+    target_phase = 0
+):
+    # TODO: Can we use the Rust version here?
+    uphet_hilbert = sps.hilbert(uphet)
+
+    adjust_phase(
+        uphet_hilbert,
+        uphet,
+        burst_phase_avg,
+        target_phase
+    )
+
+    return uphet
 
 @njit(cache=True, nogil=True)
 def burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea):
@@ -566,13 +525,7 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    prev_burst_phase_avg = None
-    prev_burst_rising = None
-    if field.prevfield is not None:
-        prev_burst_phase_avg = field.prevfield.burst_phase_avg
-        prev_burst_rising = field.prevfield.burst_rising
-
-    track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected = get_phase_rotation_sequence(
+    track_phase, phase_sequence, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
@@ -587,12 +540,9 @@ def decode_chroma_phase_rotation(
         detect_chroma_track_phase,
         rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
         field.rf.color_system,
-        field.isFirstField,
-        prev_burst_phase_avg,
-        prev_burst_rising
     )
 
-    return track_phase, phase_sequence, field_phase_id, burst_phase_avg, burst_rising, burst_detected
+    return track_phase, phase_sequence, burst_phase_avg, burst_detected
 
 def process_chroma(
     field,
@@ -656,6 +606,17 @@ def process_chroma(
         chroma_heterodyne,
         field.phase_sequence,
     )
+
+    if (
+        field.rf.color_system == "NTSC" and
+        not field.rf.options.disable_phase_correction
+    ):
+        # it's not possible to know the color framing, due to the color under heterodyne starting at an unknown rotation
+        # instead shift the color phase consistently to 0 degrees and let the chroma decoder fine tune it
+        uphet = ntsc_phase_comp(
+            uphet,
+            field.burst_phase_avg
+        )
 
     # Filter out unwanted frequencies from the final chroma signal.
     # Mixing the signals will produce waves at the difference and sum of the

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1823,7 +1823,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         else:
             linelocs = linelocs.copy()
 
-        if not self.track_phase_set:
+        if not self.track_phase_set and self.rf.options.write_chroma:
             # only do this once, since this does not affect hsync currently
             self.lock_to_burst()
 
@@ -1868,7 +1868,8 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             linelocs = linelocs.copy()
 
         # populates color burst info for hsync refinement the step below
-        self.lock_to_burst()
+        if self.rf.options.write_chroma:
+            self.lock_to_burst()
 
         if (
             not self.rf.options.disable_burst_hsync and
@@ -1952,6 +1953,7 @@ class FieldPALVideo8(FieldPALShared):
 class FieldPALTypeC(FieldPALShared, ldd.FieldPAL):
     def __init__(self, *args, **kwargs):
         super(FieldPALTypeC, self).__init__(*args, **kwargs)
+        self.rf.track_phase = 0
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldPALTypeC, self).downscale(
@@ -2018,6 +2020,7 @@ class FieldNTSCUMatic(FieldNTSCShared):
 class FieldNTSCTypeC(FieldShared, ldd.FieldNTSC):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCTypeC, self).__init__(*args, **kwargs)
+        self.rf.track_phase = 0
 
     def downscale(self, final=False, *args, **kwargs):
         dsout, dsaudio, dsefm = super(FieldNTSCTypeC, self).downscale(

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1141,7 +1141,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.fieldPhaseID, self.burst_phase_avg, self.burst_rising, _ = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.burst_phase_avg, self.burst_detected = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
@@ -1839,7 +1839,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCShared, self).__init__(*args, **kwargs)
         self.track_phase_set = False
-        self.fieldPhaseID = 0
+        self.fieldPhaseID = None
         self.ire0_backporch = (74, 124)
 
     @staticmethod
@@ -2023,8 +2023,6 @@ class FieldNTSCTypeC(FieldShared, ldd.FieldNTSC):
         dsout, dsaudio, dsefm = super(FieldNTSCTypeC, self).downscale(
             final=final, *args, **kwargs
         )
-
-        self.fieldPhaseID = 0
 
         return (dsout, None), dsaudio, dsefm
 

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -6,6 +6,8 @@ import traceback
 import json
 import shutil
 import time
+import faulthandler
+import signal
 
 import numpy
 
@@ -55,6 +57,9 @@ supported_tape_formats = {
 
 
 def main(args=None, use_gui=False):
+    # allows user to send SIGUSR1 via `kill -USR1 <pid>` to show a stack trace of the currently running code without killing the app
+    faulthandler.register(signal.SIGUSR1) 
+
     import vhsdecode.formats as f
 
     format_help = "Tape format - " + " ".join(supported_tape_formats) + "are supported"

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -250,6 +250,14 @@ def main(args=None, use_gui=False):
         help="Detects and corrects color-under heterodyne rotation change around head-switching area. Corrects chroma artifacts around head-switching area for color-under formats. (Experimental feature)",
     )
     chroma_group.add_argument(
+        "--dpc",
+        "--disable_phase_correction",
+        dest="disable_phase_correction",
+        action="store_true",
+        default=False,
+        help="Disables phase correction after up-heterodyning color under formats. This can safely be disabled if not using the NTSC 3D decoder. (currently only applicable to NTSC)",
+    )
+    chroma_group.add_argument(
         "--dbh",
         "--disable_burst_hsync",
         dest="disable_burst_hsync",
@@ -528,6 +536,7 @@ def main(args=None, use_gui=False):
     rf_options["ire0_adjust"] = args.ire0_adjust
     rf_options["detect_chroma_track_phase"] = args.detect_chroma_track_phase
     rf_options["disable_burst_hsync"] = args.disable_burst_hsync
+    rf_options["disable_phase_correction"] = args.disable_phase_correction
     rf_options["gnrc_afe"] = args.gnrc_afe
 
     extra_options = get_extra_options(args, not use_gui)

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -219,8 +219,18 @@ class VHSDecode(ldd.LDdecode):
             "seqNo": len(self.fieldinfo) + 1,
             "diskLoc": np.round((f.readloc / self.bytes_per_field) * 10) / 10,
             "fileLoc": int(np.floor(f.readloc)),
-            "fieldPhaseID": f.fieldPhaseID,
         }
+
+        if f.fieldPhaseID is None:
+            fi["fieldPhaseID"] = {
+                (1, 0): 1,
+                (0, 1): 2,
+                (1, 1): 3,
+                (0, 0): 4,
+            }[(fi["isFirstField"], (fi["seqNo"] // 2) % 2)]
+        else:
+            fi["fieldPhaseID"] = f.fieldPhaseID
+
         write_field = True
 
         if self.doDOD:
@@ -697,7 +707,8 @@ class VHSRFDecode(ldd.RFDecode):
                 "gnrc_afe",
                 "relaxed_line0",
                 "detect_chroma_track_phase",
-                "disable_burst_hsync"
+                "disable_burst_hsync",
+                "disable_phase_correction"
             ],
         )(
             self.iretohz(100) * 2,
@@ -737,7 +748,8 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("gnrc_afe", False),
             rf_options.get("relaxed_line0", False),
             rf_options.get("detect_chroma_track_phase", False),
-            rf_options.get("disable_burst_hsync", False)
+            rf_options.get("disable_burst_hsync", False),
+            rf_options.get("disable_phase_correction", False)
         )
 
         # As agc can alter these sysParams values, store a copy to then


### PR DESCRIPTION
The existing attempt to detect the color framing for the NTSC 3D decoder was unreliable and caused the color frame and/or phase correction to flip on rounding boundaries among other issues. Instead, this approach applies the up-heterodyning normally, and then phase corrects the resulting chroma to be at 0 degrees. Also, the color framing information is now just based on the field number, which is more consistent. The NTSC 3D decoder is able to handle phase correction now, since the phase will be consistent across fields.

* Add option:  `--disable_phase_correction` `--dpc` to disable phase correction. It can be safely disabled it not using the NTSC 3D decoder
* Fix infinite loop when no frames are decoded and the end of the file is reached
* Add hook to `SIGUSR1` that prints a stack trace. To show the trace while the app is running, run `kill -USR1 <pid>` where pid is the process id of the parent python process running vhs-decode.