### PR TITLE
fix: add QWT_FOUND guard in ld-analyse CMakeLists.txt

### DIFF
--- a/tools/ld-analyse/CMakeLists.txt
+++ b/tools/ld-analyse/CMakeLists.txt
@@ -34,9 +34,11 @@ elseif(UNIX)
 endif()
 
 
-target_include_directories(ld-analyse PRIVATE
-    ${QWT_INCLUDE_DIR}  ${FFTW_INCLUDE_DIR}
-)
+if(QWT_FOUND)
+    target_include_directories(ld-analyse PRIVATE
+        ${QWT_INCLUDE_DIR}  ${FFTW_INCLUDE_DIR}
+    )
+endif()
 
 
 # Include Homebrew folders manually for qwt on macOS.
@@ -64,7 +66,7 @@ endif()
 
 target_link_libraries(ld-analyse PRIVATE
     Qt::Core Qt::Gui Qt::Widgets
-    ${QWT_LIBRARY}
+    $<$<BOOL:${QWT_FOUND}>:${QWT_LIBRARY}>
     lddecode-library lddecode-chroma
 )
 


### PR DESCRIPTION
Without a QWT_FOUND guard, the build fails on Windows when 
building without QWT (e.g. with -DUSE_QWT=OFF), because 
target_include_directories and target_link_libraries 
unconditionally reference QWT variables that are empty or 
undefined.

This fix wraps the QWT-dependent include and link directives 
in appropriate guards so the build succeeds cleanly with or 
without QWT present.

Tested on Windows with -DUSE_QWT=OFF via MSYS2/MinGW64.