### PR TITLE
Fix dropout bug

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -999,16 +999,18 @@ def roundfloat(fl, places=3):
     return np.round(fl * r) / r
 
 
-@njit(nogil=True, cache=True)
+@njit(nogil=True, cache=True, fastmath=True)
 def hz_to_output_array(input, ire0, hz_ire, outputZero, vsync_ire, out_scale):
-    reduced = (input - ire0) / hz_ire
-    reduced -= vsync_ire
+    n = len(input)
+    out = np.empty(n, dtype=np.uint16)
 
-    return (
-        np.clip((reduced * out_scale) + outputZero, 0, 65535) + 0.5
-    ).astype(np.uint16)
+    scale = out_scale / hz_ire
+    offset = outputZero - vsync_ire * out_scale - ire0 * scale
 
+    for i in range(n):
+        out[i] = np.uint16(max(0, min(65535, input[i] * scale + offset)))
 
+    return out
 
 # Something like this should be a numpy function, but I can't find it.
 @jit(cache=True, nopython=True)

--- a/vhsdecode/doc.py
+++ b/vhsdecode/doc.py
@@ -109,12 +109,13 @@ def map_dropouts_rf_to_tbc(errlist, start_line_idx, end_line_idx, linelocs, outl
     for (start_rf, end_rf) in errlist:
         while line_idx < end_line_idx:
             # find the line that contains start of the dropout
-            if (start_rf >= line_start_rf or line_idx == start_line_idx) and start_rf < line_end_rf:
+            line_len = line_end_rf - line_start_rf
+            if (start_rf >= line_start_rf or line_idx == start_line_idx) and start_rf < line_end_rf and line_len > 0::
                 rv_lines.append(line_idx - lineoffset)
                 
                 # scale down to tbc line position
                 start_rf_linepos = start_rf - line_start_rf
-                start_linepos = math.floor(start_rf_linepos / (line_end_rf - line_start_rf) * outlinelen)
+                start_linepos = math.floor(start_rf_linepos / line_len * outlinelen)
 
                 rv_starts.append(max(0, start_linepos))
                 break
@@ -124,11 +125,12 @@ def map_dropouts_rf_to_tbc(errlist, start_line_idx, end_line_idx, linelocs, outl
                 line_end_rf = linelocs[line_idx + 1]
 
         while line_idx < end_line_idx:
-            if end_rf < line_end_rf:
+            line_len = line_end_rf - line_start_rf
+            if end_rf < line_end_rf and line_len > 0:
                 # dropout is contained within this line
                 # scale down to tbc line position
                 end_rf_linepos = end_rf - line_start_rf
-                end_linepos = math.ceil(end_rf_linepos / (line_end_rf - line_start_rf) * outlinelen)
+                end_linepos = math.ceil(end_rf_linepos / line_len * outlinelen)
 
                 rv_ends.append(min(outlinelen, end_linepos))
                 break

--- a/vhsdecode/doc.py
+++ b/vhsdecode/doc.py
@@ -110,7 +110,7 @@ def map_dropouts_rf_to_tbc(errlist, start_line_idx, end_line_idx, linelocs, outl
         while line_idx < end_line_idx:
             # find the line that contains start of the dropout
             line_len = line_end_rf - line_start_rf
-            if (start_rf >= line_start_rf or line_idx == start_line_idx) and start_rf < line_end_rf and line_len > 0::
+            if (start_rf >= line_start_rf or line_idx == start_line_idx) and start_rf < line_end_rf and line_len > 0:
                 rv_lines.append(line_idx - lineoffset)
                 
                 # scale down to tbc line position

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1094,6 +1094,11 @@ class FieldShared:
                     and input.size == self.outlinecount * self.outlinelen
                 ):
                     hsync_start, hsync_end = self.ire0_backporch
+
+                    ire0_adjust_padding = 4 # 4fsc, prevents noise around the hsync transition from interfering with this measurement
+                    hsync_start += ire0_adjust_padding
+                    hsync_end -= ire0_adjust_padding
+
                     blank_levels = np.sort([
                         np.median(input[i * self.outlinelen + hsync_start :
                                         i * self.outlinelen + hsync_end])

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1093,21 +1093,14 @@ class FieldShared:
                     self.rf.options.ire0_adjust
                     and input.size == self.outlinecount * self.outlinelen
                 ):
-                    blank_levels = np.empty(self.outlinecount)
-                    for i in range(0, self.outlinecount):
-                        line_offset = i * self.outlinelen
-                        ire0_adjust_start = line_offset + self.ire0_backporch[0]
-                        ire0_adjust_end =   line_offset + self.ire0_backporch[1]
+                    hsync_start, hsync_end = self.ire0_backporch
+                    blank_levels = np.sort([
+                        np.median(input[i * self.outlinelen + hsync_start :
+                                        i * self.outlinelen + hsync_end])
+                        for i in range(0, self.outlinecount)
+                    ])
+                    ire0 = np.mean(blank_levels[self.outlinecount // 3 : (self.outlinecount * 2) // 3])
 
-                        blank_levels[i] = np.median(
-                            input[ire0_adjust_start:ire0_adjust_end]
-                        )
-                    blank_levels = np.sort(blank_levels)
-                    ire0 = np.mean(
-                        blank_levels[
-                            int(self.outlinecount / 3) : int(self.outlinecount * 2 / 3)
-                        ]
-                    )
                     ldd.logger.debug("calculated ire0: %.02f", ire0)
 
                 if self.rf.track_phase is not None:

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1095,12 +1095,12 @@ class FieldShared:
                 ):
                     blank_levels = np.empty(self.outlinecount)
                     for i in range(0, self.outlinecount):
+                        line_offset = i * self.outlinelen
+                        ire0_adjust_start = line_offset + self.ire0_backporch[0]
+                        ire0_adjust_end =   line_offset + self.ire0_backporch[1]
+
                         blank_levels[i] = np.median(
-                            input[
-                                i * self.outlinelen
-                                + self.ire0_backporch[0] : i * self.outlinelen
-                                + self.ire0_backporch[1]
-                            ]
+                            input[ire0_adjust_start:ire0_adjust_end]
                         )
                     blank_levels = np.sort(blank_levels)
                     ire0 = np.mean(
@@ -1109,12 +1109,13 @@ class FieldShared:
                         ]
                     )
                     ldd.logger.debug("calculated ire0: %.02f", ire0)
+
+                if self.rf.track_phase is not None:
+                    ire0 += self.rf.DecoderParams["track_ire0_offset"][self.rf.track_phase ^ (self.field_number % 2)]
+
                 return hz_to_output_array(
                     input,
-                    ire0
-                    + self.rf.DecoderParams["track_ire0_offset"][
-                        self.rf.track_phase ^ (self.field_number % 2)
-                    ],
+                    ire0,
                     self.rf.DecoderParams["hz_ire"],
                     self.rf.SysParams["outputZero"],
                     self.rf.DecoderParams["vsync_ire"],
@@ -1814,7 +1815,6 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
     def __init__(self, *args, **kwargs):
         super(FieldPALShared, self).__init__(*args, **kwargs)
         self.track_phase_set = False
-        self.rf.track_phase = 0
         self.ire0_backporch = (96, 160)
 
     def refine_linelocs_pilot(self, linelocs=None):
@@ -1840,7 +1840,6 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
     def __init__(self, *args, **kwargs):
         super(FieldNTSCShared, self).__init__(*args, **kwargs)
         self.track_phase_set = False
-        self.rf.track_phase = 0
         self.fieldPhaseID = None
         self.ire0_backporch = (74, 124)
 


### PR DESCRIPTION
* Fix divide by zero in dropout correction if linelocs are miss-detected
* Skip track phase ire0 adjustment if there is no track phase set
* Condense ire0_adjust logic
* Optimize `hz_to_output_array` to allocate no intermediate arrays and use SIMD