### PR TITLE
Add Color Killer, per-line NTSC color-under phase comp

### DIFF
--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -169,6 +169,7 @@ def _get_phase_sequence(
     detect_chroma_track_phase,
     rotation_check_start_line,
     track_change_threshold,
+    color_system
 ):
     do_phase_rotation_check = (
         detect_chroma_track_phase
@@ -263,8 +264,15 @@ def _get_phase_sequence(
                 )
             )
 
+            if color_system == "NTSC":
+                # check one line back
+                comparison_burst = current_burst_phase
+            elif color_system == "PAL":
+                # check two lines back
+                comparison_burst = phase_sequence[-1][2]
+
             phase_delta_quadrant = abs(
-                (next_burst_phase - current_burst_phase + 180) % 360 - 180
+                (next_burst_phase - comparison_burst + 180) % 360 - 180
             )
             if phase_delta_quadrant > track_change_threshold:
                 # burst is more in phase than out of phase, flip rotation so it remains out of phase
@@ -334,6 +342,7 @@ def get_phase_rotation_sequence(
         detect_chroma_track_phase,
         rotation_check_start_line,
         track_change_threshold,
+        color_system
     )
 
     burst_check_start = burst_check_skip_lines
@@ -395,6 +404,7 @@ def get_phase_rotation_sequence(
             detect_chroma_track_phase,
             rotation_check_start_line,
             track_change_threshold,
+            color_system
         )
 
     if color_system == "NTSC":

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -20,9 +20,9 @@ def chroma_to_u16(chroma):
 
 
 @njit(cache=True, nogil=True)
-def acc(chroma, burst_abs_ref, burststart, burstend, linelength, lines):
+def acc(chroma, burst_abs_ref, burststart, burstend, linelength, lines, burst_detected_line):
     """Scale chroma according to the level of the color burst on each line."""
-    STARTING_LINE = int(16)
+    STARTING_LINE = int(16) 
     assert lines > STARTING_LINE
 
     output = np.zeros(chroma.size, dtype=np.double)
@@ -30,10 +30,15 @@ def acc(chroma, burst_abs_ref, burststart, burstend, linelength, lines):
     for linenumber in range(16, lines):
         linestart = linelength * linenumber
         lineend = linestart + linelength
-        line = chroma[linestart:lineend]
-        acced, rms = acc_line(line, burst_abs_ref, burststart, burstend)
-        output[linestart:lineend] = acced
-        mean_burst_accumulator += rms
+
+        if linenumber < burst_detected_line:
+            # color killer active for this line
+            output[linestart:lineend] = 0
+        else:
+            line = chroma[linestart:lineend]
+            acced, rms = acc_line(line, burst_abs_ref, burststart, burstend)
+            output[linestart:lineend] = acced
+            mean_burst_accumulator += rms
 
     return output, mean_burst_accumulator / (lines - STARTING_LINE)
 
@@ -673,10 +678,6 @@ def process_chroma(
         else:
             uphet = comb_c_pal(uphet, outwidth)
 
-    if field.burst_detected_line > 0:
-        # remove any stray color if the color killer was deactivated during this field
-        uphet[0:(field.burst_detected_line - lineoffset) * outwidth] = 0
-
     # Final automatic chroma gain.
     uphet, mean_rms = acc(
         uphet,
@@ -685,6 +686,7 @@ def process_chroma(
         burstarea[1],
         outwidth,
         linesout,
+        field.burst_detected_line
     )
 
     field.rf.field_averages.chroma_level.push(mean_rms)

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -22,7 +22,7 @@ def chroma_to_u16(chroma):
 @njit(cache=True, nogil=True)
 def acc(chroma, burst_abs_ref, burststart, burstend, linelength, lines, burst_detected_line):
     """Scale chroma according to the level of the color burst on each line."""
-    STARTING_LINE = int(16) 
+    STARTING_LINE = int(16)
     assert lines > STARTING_LINE
 
     output = np.zeros(chroma.size, dtype=np.double)

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -105,20 +105,32 @@ def comb_c_ntsc(data, line_len):
 
 
 @njit(cache=True, nogil=True, fastmath=True)
-def _demod_burst(burst, burst_start, burst_len, burst_sin, burst_cos):
-    I = 0
-    Q = 0
+def _demod_burst(
+    burst,
+    line_scale,
+    line_start,
+    burst_start,
+    burst_len,
+    burst_sin,
+    burst_cos
+):
+    I = 0.0
+    Q = 0.0
 
     for i in range(burst_len):
-        I += burst[i] * burst_cos[i + burst_start]
-        Q += burst[i] * burst_sin[i + burst_start]
+        burst_sample = burst[i]
+        carrier_idx = i + burst_start
+        I += burst_sample * burst_cos[carrier_idx]
+        Q += burst_sample * burst_sin[carrier_idx]
 
+    phase = np.arctan2(Q, I)
+
+    # correct phase measurement error due to line scaling
+    phase -= (burst_start - line_start) * (1.0 - line_scale) * (np.pi / 2.0)
+    burst_phase_deg = np.mod(np.degrees(phase), 360.0)
     burst_magnitude = np.hypot(I, Q)
-    burst_phase = np.arctan2(Q, I)
-    burst_phase_deg = np.degrees(burst_phase) % 360
 
     return burst_phase_deg, burst_magnitude, I, Q
-
 
 def _get_upconverted_burst(
     chroma,
@@ -128,13 +140,15 @@ def _get_upconverted_burst(
     burstarea,
     burst_sin,
     burst_cos,
+    line_scale,
     linenumber,
     lineoffset,
     outwidth,
 ):
     burst_padding = burstarea[1] - burstarea[0]  # pad the area being filtered
+    line_start = (linenumber - lineoffset) * outwidth
     burst_start = max(
-        0, (linenumber - lineoffset) * outwidth + burstarea[0] - burst_padding
+        0, line_start + burstarea[0] - burst_padding
     )
     burst_end = min(len(chroma), burst_start + burstarea[1] + burst_padding)
 
@@ -150,7 +164,7 @@ def _get_upconverted_burst(
     burst_len = len(filtered)
 
     return _demod_burst(
-        filtered, burst_start + burst_padding, burst_len, burst_sin, burst_cos
+        filtered, line_scale, line_start, burst_start + burst_padding, burst_len, burst_sin, burst_cos
     )
 
 
@@ -163,7 +177,9 @@ def _get_phase_sequence(
     burstarea,
     burst_sin,
     burst_cos,
+    linelocs,
     lineoffset,
+    inwidth,
     outwidth,
     last_line,
     detect_chroma_track_phase,
@@ -223,6 +239,8 @@ def _get_phase_sequence(
             use_next_phase = False
         else:
             current_phase = (current_phase + track_rotation) % 4
+            line_scale = (linelocs[linenumber + 1] - linelocs[linenumber]) / inwidth if linenumber < last_line - 1 else 1
+
             (
                 current_burst_phase,
                 current_burst_magnitude,
@@ -236,6 +254,7 @@ def _get_phase_sequence(
                 burstarea,
                 burst_sin,
                 burst_cos,
+                line_scale,
                 linenumber,
                 lineoffset,
                 outwidth,
@@ -249,6 +268,8 @@ def _get_phase_sequence(
         ):
             # get the next burst using the phase rotation for the current track
             next_phase = (current_phase + track_rotation) % 4
+            line_scale = (linelocs[linenumber + 2] - linelocs[linenumber + 1]) / inwidth if linenumber < last_line - 2 else 1
+
             next_burst_phase, next_burst_magnitude, next_burst_I, next_burst_Q = (
                 _get_upconverted_burst(
                     chroma,
@@ -258,6 +279,7 @@ def _get_phase_sequence(
                     burstarea,
                     burst_sin,
                     burst_cos,
+                    line_scale,
                     linenumber + 1,
                     lineoffset,
                     outwidth,
@@ -305,8 +327,10 @@ def get_phase_rotation_sequence(
     chroma_filter,
     chroma_rotation,
     chroma_rotation_index,
+    linelocs,
     lineoffset,
     linesout,
+    inwidth,
     outwidth,
     burstarea,
     burst_sin,
@@ -336,7 +360,9 @@ def get_phase_rotation_sequence(
         burstarea,
         burst_sin,
         burst_cos,
+        linelocs,
         lineoffset,
+        inwidth,
         outwidth,
         end,
         detect_chroma_track_phase,
@@ -398,7 +424,9 @@ def get_phase_rotation_sequence(
             burstarea,
             burst_sin,
             burst_cos,
+            linelocs,
             lineoffset,
+            inwidth,
             outwidth,
             end,
             detect_chroma_track_phase,
@@ -558,6 +586,7 @@ def demod_chroma_filt(
 
 def decode_chroma_phase_rotation(
     field,
+    linelocs,
     disable_tracking_cafc=False,
     chroma_rotation=None,
     detect_chroma_track_phase=False,
@@ -566,6 +595,7 @@ def decode_chroma_phase_rotation(
 
     lineoffset = field.lineoffset + 1
     linesout = field.outlinecount
+    inwidth = field.inlinelen
     outwidth = field.outlinelen
 
     burst_area_init = get_burst_area(field)
@@ -597,8 +627,10 @@ def decode_chroma_phase_rotation(
         field.rf.Filters["FChromaFinal"],
         chroma_rotation,
         field.rf.track_phase, # index for chroma rotation, and static if there is no chroma rotation
+        linelocs,
         lineoffset,
         linesout,
+        inwidth,
         outwidth,
         burstarea,
         field.rf.fsc_wave,

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -301,6 +301,7 @@ def get_phase_rotation_sequence(
     detect_chroma_track_phase,
     rotation_check_start_line,
     enable_color_killer,
+    prev_burst_detected_line,
     color_system,
 ):
     # Detects the correct color-under heterodyne starting phase and rotation direction
@@ -332,7 +333,7 @@ def get_phase_rotation_sequence(
 
     burst_check_start = burst_check_skip_lines
     burst_check_end = end - burst_check_skip_lines
-    burst_detected = True
+    burst_detected_line = 0 # color enabled by default
 
     if chroma_rotation:
         # detect relative phase difference between lines
@@ -405,17 +406,32 @@ def get_phase_rotation_sequence(
                     avg_count += 1
                     magnitude_avg += magnitude
 
+                    if enable_color_killer:
+                        # find the first line that might have a valid burst if the previous field had the burst disabled
+                        # broadcasters would sometime turn on the burst mid-field, so attempt to detect that transition here
+                        if (
+                            prev_burst_detected_line == -1 # previous field had color killer activated
+                            and burst_detected_line == 0 and magnitude > burst_magnitude_threshold # first burst that exceeds threshold
+                        ):
+                            # first burst that exceeds threshold
+                            # color killer will be active until this line, then it deactivates
+                            # it is only reactivated after an entire field is without color (below)
+                            burst_detected_line = line_number
+
         magnitude_avg /= avg_count
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
 
         if enable_color_killer:
-            burst_detected = magnitude_avg >= burst_magnitude_threshold
+            if magnitude_avg < burst_magnitude_threshold:
+                # (re)activate color killer for the entire field
+                burst_detected_line = -1
+
     elif color_system in ("MPAL", "NLINHA"):
         burst_phase_avg = None
     else:
         burst_phase_avg = None
 
-    return chroma_rotation_index, phase_sequence, burst_phase_avg, burst_detected
+    return chroma_rotation_index, phase_sequence, burst_phase_avg, burst_detected_line
 
 
 @njit(cache=True, nogil=True, fastmath=True)
@@ -531,7 +547,11 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    track_phase, phase_sequence, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
+    prev_burst_detected_line = 0
+    if field.prevfield is not None:
+        prev_burst_detected_line = field.prevfield.burst_detected_line
+
+    track_phase, phase_sequence, burst_phase_avg, burst_detected_line = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
@@ -546,10 +566,11 @@ def decode_chroma_phase_rotation(
         detect_chroma_track_phase,
         rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
         field.rf.options.enable_color_killer,
+        prev_burst_detected_line,
         field.rf.color_system,
     )
 
-    return track_phase, phase_sequence, burst_phase_avg, burst_detected
+    return track_phase, phase_sequence, burst_phase_avg, burst_detected_line
 
 
 def process_chroma(
@@ -564,7 +585,8 @@ def process_chroma(
     outwidth = field.outlinelen
 
     uphet = np.zeros((linesout * outwidth), dtype=np.float32)
-    if not field.burst_detected:
+    if field.burst_detected_line == -1:
+        # skip chroma if the color killer is active for the whole field
         return uphet
 
     # Run TBC/downscale on chroma (if new field, else uses cache)
@@ -650,6 +672,10 @@ def process_chroma(
             uphet = comb_c_ntsc(uphet, outwidth)
         else:
             uphet = comb_c_pal(uphet, outwidth)
+
+    if field.burst_detected_line > 0:
+        # remove any stray color if the color killer was deactivated during this field
+        uphet[0:(field.burst_detected_line - lineoffset) * outwidth] = 0
 
     # Final automatic chroma gain.
     uphet, mean_rms = acc(

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -445,8 +445,8 @@ def upconvert_chroma(
     uphet,
     lineoffset,
     outwidth,
+    phase_rotation_sequence,
     chroma_heterodyne,
-    phase_rotation_sequence
 ):
     for linenumber, current_phase, _, _, _, _ in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
@@ -456,25 +456,41 @@ def upconvert_chroma(
         c = chroma[linestart:lineend]
         uphet[linestart:lineend] = c * heterodyne
 
+
 @njit(cache=True, nogil=True, fastmath=True)
-def adjust_phase(input_data, output_data, input_phase, target_phase):
-    # rotates the phase of the chroma signal
-    phase_adjustment = np.deg2rad(target_phase) - np.deg2rad(input_phase)
-    rotation = np.exp(1j * phase_adjustment)
+def upconvert_chroma_phase_comp(
+    chroma,
+    uphet,
+    lineoffset,
+    outwidth,
+    phase_rotation_sequence,
+    color_under_carrier_fs,
+    fsc,
+    target_phase
+):
+    deg2rad_scale = np.pi / 180.0
+    pi_over_two = np.pi / 2.0
 
-    for i in range(len(input_data)):
-        # Apply phase adjustment in baseband
-        # Convert back to real and store
-        output_data[i] = (input_data[i] * rotation).real
+    het_mhz = color_under_carrier_fs / 1e6
+    het_coefficient = pi_over_two * (1.0 + het_mhz / fsc)
 
+    target_phase_rad = target_phase * deg2rad_scale
 
-def ntsc_phase_comp(uphet, burst_phase_avg, target_phase=0):
-    # TODO: Can we use the Rust version here?
-    uphet_hilbert = sps.hilbert(uphet)
+    # check if there are other adjustments needed after this phase adjust
+    # chroma decoder seems to be correcting an amplitude problem
 
-    adjust_phase(uphet_hilbert, uphet, burst_phase_avg, target_phase)
+    for linenumber, phase_rotation, burst_phase, _, _, _ in phase_rotation_sequence:
+        linestart = (linenumber - lineoffset) * outwidth
+        lineend = linestart + outwidth
 
-    return uphet
+        theta = het_coefficient * linestart + (
+            phase_rotation * pi_over_two # heterodyne rotation
+            + target_phase_rad + burst_phase * deg2rad_scale # phase offset relative to line
+        )
+
+        for i in range(linestart, lineend):
+            uphet[i] = chroma[i] * -math.cos(theta)
+            theta += het_coefficient
 
 
 @njit(cache=True, nogil=True)
@@ -577,6 +593,13 @@ def decode_chroma_phase_rotation(
 
     return track_phase, phase_sequence, burst_phase_avg, burst_detected_line
 
+ntsc_color_framing_phase_shift = 33
+ntsc_color_framing_map = {
+    (1, 0): (1, 0 - ntsc_color_framing_phase_shift),
+    (0, 1): (2, 180 - ntsc_color_framing_phase_shift),
+    (1, 1): (3, 180 - ntsc_color_framing_phase_shift),
+    (0, 0): (4, 0 - ntsc_color_framing_phase_shift),
+}
 
 def process_chroma(
     field,
@@ -632,28 +655,40 @@ def process_chroma(
         if not disable_deemph:
             chroma = burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea)
 
-    chroma_heterodyne = (
-        field.rf.chroma_afc.getChromaHet()
-        if (field.rf.do_cafc and not disable_tracking_cafc)
-        else field.rf.chroma_heterodyne
-    )
-
-    upconvert_chroma(
-        chroma,
-        uphet,
-        lineoffset,
-        outwidth,
-        chroma_heterodyne,
-        field.phase_sequence,
-    )
-
     if (
         field.rf.color_system == "NTSC"
         and not field.rf.options.disable_phase_correction
     ):
-        # it's not possible to know the color framing, due to the color under heterodyne starting at an unknown rotation
-        # instead shift the color phase consistently to 0 degrees and let the chroma decoder fine tune it
-        uphet = ntsc_phase_comp(uphet, field.burst_phase_avg)
+        # regenerates the color framing
+        field.fieldPhaseID, target_phase = ntsc_color_framing_map[
+            (field.isFirstField, (field.field_number // 2) % 2)
+        ]
+
+        upconvert_chroma_phase_comp(
+            chroma,
+            uphet,
+            lineoffset,
+            outwidth,
+            field.phase_sequence,
+            field.rf.chroma_afc.color_under,
+            field.rf.chroma_afc.fsc_mhz,
+            target_phase
+        )
+    else:
+        chroma_heterodyne = (
+            field.rf.chroma_afc.getChromaHet()
+            if (field.rf.do_cafc and not disable_tracking_cafc)
+            else field.rf.chroma_heterodyne
+        )
+    
+        upconvert_chroma(
+            chroma,
+            uphet,
+            lineoffset,
+            outwidth,
+            field.phase_sequence,
+            chroma_heterodyne
+        )
 
     # Filter out unwanted frequencies from the final chroma signal.
     # Mixing the signals will produce waves at the difference and sum of the

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -267,7 +267,7 @@ def _get_phase_sequence(
             if color_system == "NTSC":
                 # check one line back
                 comparison_burst = current_burst_phase
-            elif color_system == "PAL":
+            else: # color_system in ("PAL", "PAL_M", "NLINHA", "MESECAM")
                 # check two lines back
                 comparison_burst = phase_sequence[-1][2]
 
@@ -407,46 +407,55 @@ def get_phase_rotation_sequence(
             color_system
         )
 
-    if color_system == "NTSC":
-        # find the phase of the color burst for the entire field
-        I_total = 0
-        Q_total = 0
-        avg_count = 0
-        magnitude_avg = 0
-        for line_number, _, _, magnitude, I, Q in phase_sequence:
-            if line_number > burst_check_start and line_number < burst_check_end:
-                if magnitude != 0:
-                    I_total += I / magnitude
-                    Q_total += Q / magnitude
-                    avg_count += 1
-                    magnitude_avg += magnitude
+    # calculate the average color phase for even and odd lines
+    even_I_total = 0
+    even_Q_total = 0
+    odd_I_total = 0
+    odd_Q_total = 0
 
-                    if enable_color_killer:
-                        # find the first line that might have a valid burst if the previous field had the burst disabled
-                        # broadcasters would sometime turn on the burst mid-field, so attempt to detect that transition here
-                        if (
-                            prev_burst_detected_line == -1 # previous field had color killer activated
-                            and burst_detected_line == 0 and magnitude > burst_magnitude_threshold # first burst that exceeds threshold
-                        ):
-                            # first burst that exceeds threshold
-                            # color killer will be active until this line, then it deactivates
-                            # it is only reactivated after an entire field is without color (below)
-                            burst_detected_line = line_number
+    avg_count = 0
+    burst_magnitude_avg = 0
 
-        magnitude_avg /= avg_count
-        burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
+    for line_number, _, _, magnitude, I, Q in phase_sequence:
+        if line_number > burst_check_start and line_number < burst_check_end:
+            if magnitude != 0:
+                I /= magnitude
+                Q /= magnitude
 
-        if enable_color_killer:
-            if magnitude_avg < burst_magnitude_threshold:
-                # (re)activate color killer for the entire field
-                burst_detected_line = -1
+                avg_count += 1
+                burst_magnitude_avg += magnitude
 
-    elif color_system in ("MPAL", "NLINHA"):
-        burst_phase_avg = None
-    else:
-        burst_phase_avg = None
+                if enable_color_killer:
+                    # find the first line that might have a valid burst if the previous field had the burst disabled
+                    # broadcasters would sometime turn on the burst mid-field, so attempt to detect that transition here
+                    if (
+                        prev_burst_detected_line == -1 # previous field had color killer activated
+                        and burst_detected_line == 0 and magnitude > burst_magnitude_threshold # first burst that exceeds threshold
+                    ):
+                        # first burst that exceeds threshold
+                        # color killer will be active until this line, then it deactivates
+                        # it is only reactivated after an entire field is without color (below)
+                        burst_detected_line = line_number
+            
+                if line_number % 2:
+                    odd_I_total += I
+                    odd_Q_total += Q
+                else:
+                    even_I_total += I
+                    even_Q_total += Q
+    
+    burst_magnitude_avg /= avg_count
 
-    return chroma_rotation_index, phase_sequence, burst_phase_avg, burst_detected_line
+    if enable_color_killer:
+        if burst_magnitude_avg < burst_magnitude_threshold:
+            # (re)activate color killer for the entire field
+            burst_detected_line = -1
+
+    burst_phase_avg = np.degrees(np.arctan2(even_Q_total + odd_Q_total, even_I_total + odd_I_total)) % 360
+    even_burst_phase_avg = np.degrees(np.arctan2(even_Q_total, even_I_total)) % 360
+    odd_burst_phase_avg = np.degrees(np.arctan2(odd_Q_total, odd_I_total)) % 360
+
+    return chroma_rotation_index, phase_sequence, burst_detected_line, burst_magnitude_avg, burst_phase_avg, even_burst_phase_avg, odd_burst_phase_avg
 
 
 @njit(cache=True, nogil=True, fastmath=True)
@@ -476,7 +485,8 @@ def upconvert_chroma_phase_comp(
     phase_rotation_sequence,
     color_under_carrier_fs,
     fsc,
-    target_phase
+    target_phase_even,
+    target_phase_odd
 ):
     deg2rad_scale = np.pi / 180.0
     pi_over_two = np.pi / 2.0
@@ -484,14 +494,13 @@ def upconvert_chroma_phase_comp(
     het_mhz = color_under_carrier_fs / 1e6
     het_coefficient = pi_over_two * (1.0 + het_mhz / fsc)
 
-    target_phase_rad = target_phase * deg2rad_scale
-
-    # check if there are other adjustments needed after this phase adjust
-    # chroma decoder seems to be correcting an amplitude problem
+    target_phase_even_rad = target_phase_even * deg2rad_scale
+    target_phase_odd_rad = target_phase_odd * deg2rad_scale
 
     for linenumber, phase_rotation, burst_phase, _, _, _ in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
         lineend = linestart + outwidth
+        target_phase_rad = target_phase_odd_rad if linenumber % 2 else target_phase_even_rad
 
         theta = het_coefficient * linestart + (
             phase_rotation * pi_over_two # heterodyne rotation
@@ -582,7 +591,7 @@ def decode_chroma_phase_rotation(
     if field.prevfield is not None:
         prev_burst_detected_line = field.prevfield.burst_detected_line
 
-    track_phase, phase_sequence, burst_phase_avg, burst_detected_line = get_phase_rotation_sequence(
+    track_phase, phase_sequence, burst_detected_line, burst_magnitude_avg, burst_phase_avg, even_burst_phase_avg, odd_burst_phase_avg = get_phase_rotation_sequence(
         chroma,
         chroma_heterodyne,
         field.rf.Filters["FChromaFinal"],
@@ -601,14 +610,41 @@ def decode_chroma_phase_rotation(
         field.rf.color_system,
     )
 
-    return track_phase, phase_sequence, burst_phase_avg, burst_detected_line
+    return track_phase, phase_sequence, burst_detected_line, burst_magnitude_avg, burst_phase_avg, even_burst_phase_avg, odd_burst_phase_avg
 
 ntsc_color_framing_phase_shift = 33
 ntsc_color_framing_map = {
+    # Color Frame I
     (1, 0): (1, 0 - ntsc_color_framing_phase_shift),
     (0, 1): (2, 180 - ntsc_color_framing_phase_shift),
+    # Color Frame II
     (1, 1): (3, 180 - ntsc_color_framing_phase_shift),
     (0, 0): (4, 0 - ntsc_color_framing_phase_shift),
+}
+
+# fieldPhaseID, even_burst_phase, odd_burst_phase
+pal_offset_I   = -90*1
+pal_offset_II  = -90*2
+pal_offset_III = -90*3
+pal_offset_IV  = -90*4
+pal_phase_swing = 135
+
+# Rec. ITU-R BT.1700, pp.6 (phase poliarity 525 and 625 PAL)
+# Field         |   1 |   2 |   3 |   4 |   5 |   6 |   7 |   8 |
+# Color frame   |   I |  II | III |  IV |   I |  II | III |  IV |
+# Even polarity |   - |   - |   + |   + |   - |   - |   + |   + |
+# Odd  polarity |   + |   + |   - |   - |   + |   + |   - |   - |
+
+# first_field, has_line_6_burst, frame_number 0-3 or 4-7
+pal_color_framing_map = {
+    (1, 0, 0): (1, -pal_phase_swing + pal_offset_I,    pal_phase_swing + pal_offset_I), #   field 1, Color Frame I
+    (0, 1, 0): (2, -pal_phase_swing + pal_offset_II,   pal_phase_swing + pal_offset_II), #  field 2, Color Frame II
+    (1, 1, 0): (3,  pal_phase_swing + pal_offset_III, -pal_phase_swing + pal_offset_III), # field 3, Color Frame III
+    (0, 0, 0): (4,  pal_phase_swing + pal_offset_IV,  -pal_phase_swing + pal_offset_IV), #  field 4, Color Frame IV
+    (1, 0, 1): (5, 180 + -pal_phase_swing + pal_offset_I,   180 +  pal_phase_swing + pal_offset_I), #   field 5, Color Frame I
+    (0, 1, 1): (6, 180 + -pal_phase_swing + pal_offset_II,  180 +  pal_phase_swing + pal_offset_II), #  field 6, Color Frame II
+    (1, 1, 1): (7, 180 +  pal_phase_swing + pal_offset_III, 180 + -pal_phase_swing + pal_offset_III), # field 7, Color Frame III
+    (0, 0, 1): (8, 180 +  pal_phase_swing + pal_offset_IV,  180 + -pal_phase_swing + pal_offset_IV), #  field 8, Color Frame IV
 }
 
 def process_chroma(
@@ -666,14 +702,24 @@ def process_chroma(
             chroma = burst_deemphasis(chroma, lineoffset, linesout, outwidth, burstarea)
 
     if (
-        field.rf.color_system == "NTSC"
-        and not field.rf.options.disable_phase_correction
+        not field.rf.options.disable_phase_correction
+        and field.rf.color_system == "NTSC"
     ):
-        # regenerates the color framing
         field.fieldPhaseID, target_phase = ntsc_color_framing_map[
             (field.isFirstField, (field.field_number // 2) % 2)
         ]
+        target_phase_even = target_phase
+        target_phase_odd = target_phase
 
+        # TODO: PAL color framing is disabled for now.
+        #       need to find a reliable way to detect if this is field 1,2 vs 3,4
+        # if field.rf.color_system == "PAL":
+        #     line_6_burst_present = field.phase_sequence[4 + lineoffset][3] > field.burst_magnitude_avg / 3
+        #     field.fieldPhaseID, target_phase_even, target_phase_odd = pal_color_framing_map[
+        #         (field.isFirstField, line_6_burst_present, (field.field_number // 4) % 2)
+        #     ]
+
+        # offset heterodyne for each line to correct color phase
         upconvert_chroma_phase_comp(
             chroma,
             uphet,
@@ -682,7 +728,8 @@ def process_chroma(
             field.phase_sequence,
             field.rf.chroma_afc.color_under,
             field.rf.chroma_afc.fsc_mhz,
-            target_phase
+            target_phase_even,
+            target_phase_odd
         )
     else:
         chroma_heterodyne = (

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -123,14 +123,21 @@ def _demod_burst(
         I += burst_sample * burst_cos[carrier_idx]
         Q += burst_sample * burst_sin[carrier_idx]
 
-    phase = np.arctan2(Q, I)
-
-    # correct phase measurement error due to line scaling
-    phase -= (burst_start - line_start) * (1.0 - line_scale) * (np.pi / 2.0)
-    burst_phase_deg = np.mod(np.degrees(phase), 360.0)
     burst_magnitude = np.hypot(I, Q)
 
-    return burst_phase_deg, burst_magnitude, I, Q
+    # correct phase measurement error due to line scaling
+    phase_error = (burst_start - line_start) * (1.0 - line_scale) * (np.pi / 2.0)
+    c = np.cos(phase_error)
+    s = np.sin(phase_error)
+
+    # subtract phase error
+    I_rot = I * c + Q * s
+    Q_rot = Q * c - I * s
+
+    measured_phase = np.arctan2(Q_rot, I_rot)
+    burst_phase_deg = np.mod(np.degrees(measured_phase), 360.0)
+
+    return burst_phase_deg, burst_magnitude, I_rot, Q_rot
 
 def _get_upconverted_burst(
     chroma,

--- a/vhsdecode/chroma.py
+++ b/vhsdecode/chroma.py
@@ -300,13 +300,16 @@ def get_phase_rotation_sequence(
     burst_cos,
     detect_chroma_track_phase,
     rotation_check_start_line,
+    enable_color_killer,
     color_system,
 ):
     # Detects the correct color-under heterodyne starting phase and rotation direction
     # Additional for NTSC, this function calculates the color burst average for burst-locked TBC later on
     track_change_threshold = 90
     burst_check_skip_lines = 16
-    coherence_threshold = 0.3
+
+    # TODO Expose as option, possible this needs to be relative to the sync pulse and level detection
+    burst_magnitude_threshold = 2.5e4
 
     end = linesout + lineoffset
 
@@ -329,6 +332,7 @@ def get_phase_rotation_sequence(
 
     burst_check_start = burst_check_skip_lines
     burst_check_end = end - burst_check_skip_lines
+    burst_detected = True
 
     if chroma_rotation:
         # detect relative phase difference between lines
@@ -392,33 +396,37 @@ def get_phase_rotation_sequence(
         I_total = 0
         Q_total = 0
         avg_count = 0
+        magnitude_avg = 0
         for line_number, _, _, magnitude, I, Q in phase_sequence:
             if line_number > burst_check_start and line_number < burst_check_end:
                 if magnitude != 0:
                     I_total += I / magnitude
                     Q_total += Q / magnitude
                     avg_count += 1
+                    magnitude_avg += magnitude
 
-        coherence = np.hypot(I_total, Q_total) / avg_count
-        burst_detected = coherence >= coherence_threshold
+        magnitude_avg /= avg_count
         burst_phase_avg = np.degrees(np.arctan2(Q_total, I_total)) % 360
 
-    elif color_system in ("PAL_M", "NLINHA"):
+        if enable_color_killer:
+            burst_detected = magnitude_avg >= burst_magnitude_threshold
+    elif color_system in ("MPAL", "NLINHA"):
         burst_phase_avg = None
-        burst_detected = None
     else:
         burst_phase_avg = None
-        burst_detected = None
 
     return chroma_rotation_index, phase_sequence, burst_phase_avg, burst_detected
 
 
 @njit(cache=True, nogil=True, fastmath=True)
 def upconvert_chroma(
-    chroma, lineoffset, outwidth, chroma_heterodyne, phase_rotation_sequence
+    chroma,
+    uphet,
+    lineoffset,
+    outwidth,
+    chroma_heterodyne,
+    phase_rotation_sequence
 ):
-    uphet = np.zeros(len(chroma), dtype=np.float32)
-
     for linenumber, current_phase, _, _, _, _ in phase_rotation_sequence:
         linestart = (linenumber - lineoffset) * outwidth
         lineend = linestart + outwidth
@@ -426,9 +434,6 @@ def upconvert_chroma(
         heterodyne = chroma_heterodyne[current_phase][linestart:lineend]
         c = chroma[linestart:lineend]
         uphet[linestart:lineend] = c * heterodyne
-
-    return uphet
-
 
 @njit(cache=True, nogil=True, fastmath=True)
 def adjust_phase(input_data, output_data, input_phase, target_phase):
@@ -526,23 +531,22 @@ def decode_chroma_phase_rotation(
         else field.rf.chroma_heterodyne
     )
 
-    track_phase, phase_sequence, burst_phase_avg, burst_detected = (
-        get_phase_rotation_sequence(
-            chroma,
-            chroma_heterodyne,
-            field.rf.Filters["FChromaFinal"],
-            chroma_rotation,
-            field.rf.track_phase,  # index for chroma rotation, and static if there is no chroma rotation
-            lineoffset,
-            linesout,
-            outwidth,
-            burstarea,
-            field.rf.fsc_wave,
-            field.rf.fsc_cos_wave,
-            detect_chroma_track_phase,
-            rotation_check_start_line,  # check for track phase rotation around the headswitching area (bottom of field)
-            field.rf.color_system,
-        )
+    track_phase, phase_sequence, burst_phase_avg, burst_detected = get_phase_rotation_sequence(
+        chroma,
+        chroma_heterodyne,
+        field.rf.Filters["FChromaFinal"],
+        chroma_rotation,
+        field.rf.track_phase, # index for chroma rotation, and static if there is no chroma rotation
+        lineoffset,
+        linesout,
+        outwidth,
+        burstarea,
+        field.rf.fsc_wave,
+        field.rf.fsc_cos_wave,
+        detect_chroma_track_phase,
+        rotation_check_start_line, # check for track phase rotation around the headswitching area (bottom of field)
+        field.rf.options.enable_color_killer,
+        field.rf.color_system,
     )
 
     return track_phase, phase_sequence, burst_phase_avg, burst_detected
@@ -555,6 +559,14 @@ def process_chroma(
     disable_tracking_cafc=False,
     do_chroma_deemphasis=False,
 ):
+    lineoffset = field.lineoffset + 1
+    linesout = field.outlinecount
+    outwidth = field.outlinelen
+
+    uphet = np.zeros((linesout * outwidth), dtype=np.float32)
+    if not field.burst_detected:
+        return uphet
+
     # Run TBC/downscale on chroma (if new field, else uses cache)
     # Cached if chroma process is run multiple times on one field due to track detection.
     if field.chroma_tbc_buffer is None:
@@ -585,10 +597,6 @@ def process_chroma(
     else:
         chroma = field.chroma_tbc_buffer
 
-    lineoffset = field.lineoffset + 1
-    linesout = field.outlinecount
-    outwidth = field.outlinelen
-
     burst_area_init = get_burst_area(field)
     burstarea = burst_area_init[0] - 5, burst_area_init[1] + 10
 
@@ -603,8 +611,9 @@ def process_chroma(
         else field.rf.chroma_heterodyne
     )
 
-    uphet = upconvert_chroma(
+    upconvert_chroma(
         chroma,
+        uphet,
         lineoffset,
         outwidth,
         chroma_heterodyne,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1140,7 +1140,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.burst_phase_avg, self.burst_detected_line = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.burst_detected_line, self.burst_magnitude_avg, self.burst_phase_avg, self.even_burst_phase_avg, self.odd_burst_phase_avg = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
@@ -1814,9 +1814,34 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         super(FieldPALShared, self).__init__(*args, **kwargs)
         self.track_phase_set = False
         self.ire0_backporch = (96, 160)
+        self.burst_detected_line = 0
+    
+    @staticmethod
+    def _sync_to_burst(
+        linelocs,
+        outlinelen,
+        even_burst_avg_phase,
+        odd_burst_avg_phase,
+        phase_sequence,
+        burst_detected_line
+    ):
+        burst_tbc_start = max(9, burst_detected_line)
+
+        for line_number, _, burst_phase, _, _, _ in phase_sequence[burst_tbc_start:]:
+            target_phase = odd_burst_avg_phase if line_number % 2 else even_burst_avg_phase
+
+            phase_delta = (target_phase - burst_phase + 180) % 360 - 180
+
+            # scale up burst fsc for each line
+            line_start = linelocs[line_number]
+            line_end = linelocs[line_number + 1]
+            line_length = line_end - line_start
+            scale = line_length / outlinelen
+
+            line_adjust = (phase_delta / 360.0 * 4)
+            linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_pilot(self, linelocs=None):
-        # Currently only supported with NTSC
         if linelocs is None:
             linelocs = self.linelocs2.copy()
         else:
@@ -1825,6 +1850,20 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         if not self.track_phase_set and self.rf.options.write_chroma:
             # only do this once, since this does not affect hsync currently
             self.lock_to_burst()
+
+            if (
+                not self.rf.options.disable_burst_hsync
+                and self.phase_sequence is not None
+                and self.burst_detected_line != -1 # color killer not active for entire field
+            ):
+                FieldPALShared._sync_to_burst(
+                    linelocs,
+                    self.outlinelen,
+                    self.even_burst_phase_avg,
+                    self.odd_burst_phase_avg,
+                    self.phase_sequence,
+                    self.burst_detected_line
+                )
 
         return linelocs
 
@@ -1840,6 +1879,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.track_phase_set = False
         self.fieldPhaseID = None
         self.ire0_backporch = (74, 124)
+        self.burst_detected_line = 0
 
     @staticmethod
     def _sync_to_burst(
@@ -1876,16 +1916,26 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             if (
                 not self.rf.options.disable_burst_hsync
                 and self.phase_sequence is not None
-                and self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
                 and self.burst_detected_line != -1 # color killer not active for entire field
             ):
-                FieldNTSCShared._sync_to_burst(
-                    linelocs,
-                    self.outlinelen,
-                    self.burst_phase_avg,
-                    self.phase_sequence,
-                    self.burst_detected_line
-                )
+                if self.rf.color_system == "NTSC":
+                    FieldNTSCShared._sync_to_burst(
+                        linelocs,
+                        self.outlinelen,
+                        self.burst_phase_avg,
+                        self.phase_sequence,
+                        self.burst_detected_line
+                    )
+                elif self.rf.color_system == "NLINHA":
+                    # NLINHA uses pal
+                    FieldPALShared._sync_to_burst(
+                        linelocs,
+                        self.outlinelen,
+                        self.even_burst_phase_avg,
+                        self.odd_burst_phase_avg,
+                        self.phase_sequence,
+                        self.burst_detected_line
+                    )
 
         return linelocs
 

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1873,7 +1873,8 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             if (
                 not self.rf.options.disable_burst_hsync and
                 self.phase_sequence is not None and
-                self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
+                self.rf.color_system == "NTSC" and # only enable for normal NTSC (disabled for NLINHA, etc.)
+                self.burst_detected # skip hsync when burst is not detected
             ):
                 FieldNTSCShared._sync_to_burst(
                     linelocs,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1816,11 +1816,13 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
         self.track_phase_set = False
         self.ire0_backporch = (96, 160)
         self.burst_detected_line = 0
+        self.fsc_ratio = self.rf.SysParams["outfreq"] / self.rf.SysParams["fsc_mhz"]
     
     @staticmethod
     def _sync_to_burst(
         linelocs,
         outlinelen,
+        fsc_ratio,
         even_burst_avg_phase,
         odd_burst_avg_phase,
         phase_sequence,
@@ -1839,7 +1841,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
             line_length = line_end - line_start
             scale = line_length / outlinelen
 
-            line_adjust = (phase_delta / 360.0 * 4)
+            line_adjust = phase_delta / 360.0 * fsc_ratio
             linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_pilot(self, linelocs=None):
@@ -1860,6 +1862,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
                 FieldPALShared._sync_to_burst(
                     linelocs,
                     self.outlinelen,
+                    self.fsc_ratio,
                     self.even_burst_phase_avg,
                     self.odd_burst_phase_avg,
                     self.phase_sequence,
@@ -1881,11 +1884,13 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         self.fieldPhaseID = None
         self.ire0_backporch = (74, 124)
         self.burst_detected_line = 0
+        self.fsc_ratio = self.rf.SysParams["outfreq"] / self.rf.SysParams["fsc_mhz"]
 
     @staticmethod
     def _sync_to_burst(
         linelocs,
         outlinelen,
+        fsc_ratio,
         burst_avg_phase,
         phase_sequence,
         burst_detected_line
@@ -1901,7 +1906,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             line_length = line_end - line_start
             scale = line_length / outlinelen
 
-            line_adjust = phase_delta / 360.0 * 4
+            line_adjust = phase_delta / 360.0 * fsc_ratio
             linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_burst(self, linelocs=None):
@@ -1923,6 +1928,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
                     FieldNTSCShared._sync_to_burst(
                         linelocs,
                         self.outlinelen,
+                        self.fsc_ratio,
                         self.burst_phase_avg,
                         self.phase_sequence,
                         self.burst_detected_line
@@ -1932,6 +1938,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
                     FieldPALShared._sync_to_burst(
                         linelocs,
                         self.outlinelen,
+                        self.fsc_ratio,
                         self.even_burst_phase_avg,
                         self.odd_burst_phase_avg,
                         self.phase_sequence,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1138,10 +1138,11 @@ class FieldShared:
             + 0.5
         )
 
-    def lock_to_burst(self):
+    def lock_to_burst(self, linelocs):
         self.chroma_tbc_buffer = None
         self.rf.track_phase, self.phase_sequence, self.burst_detected_line, self.burst_magnitude_avg, self.burst_phase_avg, self.even_burst_phase_avg, self.odd_burst_phase_avg = decode_chroma_phase_rotation(
             self,
+            linelocs,
             chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
         )
@@ -1849,7 +1850,7 @@ class FieldPALShared(FieldShared, ldd.FieldPAL):
 
         if not self.track_phase_set and self.rf.options.write_chroma:
             # only do this once, since this does not affect hsync currently
-            self.lock_to_burst()
+            self.lock_to_burst(linelocs)
 
             if (
                 not self.rf.options.disable_burst_hsync
@@ -1900,7 +1901,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             line_length = line_end - line_start
             scale = line_length / outlinelen
 
-            line_adjust = (phase_delta / 360.0 * 4)
+            line_adjust = phase_delta / 360.0 * 4
             linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_burst(self, linelocs=None):
@@ -1911,7 +1912,7 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
 
         # populates color burst info for hsync refinement the step below
         if self.rf.options.write_chroma:
-            self.lock_to_burst()
+            self.lock_to_burst(linelocs)
 
             if (
                 not self.rf.options.disable_burst_hsync

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1849,21 +1849,19 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         phase_sequence,
         burst_detected_line
     ):
-        for line_number, _, burst_phase, _, _, _ in phase_sequence[9:]:
-            if (
-                line_number >= burst_detected_line
-                and burst_detected_line != -1
-            ):
-                phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
+        burst_tbc_start = max(9, burst_detected_line)
 
-                # scale up burst fsc for each line
-                line_start = linelocs[line_number]
-                line_end = linelocs[line_number + 1]
-                line_length = line_end - line_start
-                scale = line_length / outlinelen
+        for line_number, _, burst_phase, _, _, _ in phase_sequence[burst_tbc_start:]:
+            phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
 
-                line_adjust = (phase_delta / 360.0 * 4)
-                linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
+            # scale up burst fsc for each line
+            line_start = linelocs[line_number]
+            line_end = linelocs[line_number + 1]
+            line_length = line_end - line_start
+            scale = line_length / outlinelen
+
+            line_adjust = (phase_delta / 360.0 * 4)
+            linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_burst(self, linelocs=None):
         if linelocs is None:
@@ -1876,9 +1874,10 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             self.lock_to_burst()
 
             if (
-                not self.rf.options.disable_burst_hsync and
-                self.phase_sequence is not None and
-                self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
+                not self.rf.options.disable_burst_hsync
+                and self.phase_sequence is not None
+                and self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
+                and self.burst_detected_line != -1 # color killer not active for entire field
             ):
                 FieldNTSCShared._sync_to_burst(
                     linelocs,

--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1140,7 +1140,7 @@ class FieldShared:
 
     def lock_to_burst(self):
         self.chroma_tbc_buffer = None
-        self.rf.track_phase, self.phase_sequence, self.burst_phase_avg, self.burst_detected = decode_chroma_phase_rotation(
+        self.rf.track_phase, self.phase_sequence, self.burst_phase_avg, self.burst_detected_line = decode_chroma_phase_rotation(
             self,
             chroma_rotation=self.rf.DecoderParams.get("chroma_rotation", None),
             detect_chroma_track_phase=self.rf.options.detect_chroma_track_phase
@@ -1846,19 +1846,24 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
         linelocs,
         outlinelen,
         burst_avg_phase,
-        phase_sequence
+        phase_sequence,
+        burst_detected_line
     ):
         for line_number, _, burst_phase, _, _, _ in phase_sequence[9:]:
-            phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
+            if (
+                line_number >= burst_detected_line
+                and burst_detected_line != -1
+            ):
+                phase_delta = (burst_avg_phase - burst_phase + 180) % 360 - 180
 
-            # scale up burst fsc for each line
-            line_start = linelocs[line_number]
-            line_end = linelocs[line_number + 1]
-            line_length = line_end - line_start
-            scale = line_length / outlinelen
+                # scale up burst fsc for each line
+                line_start = linelocs[line_number]
+                line_end = linelocs[line_number + 1]
+                line_length = line_end - line_start
+                scale = line_length / outlinelen
 
-            line_adjust = (phase_delta / 360.0 * 4)
-            linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
+                line_adjust = (phase_delta / 360.0 * 4)
+                linelocs[line_number] += line_adjust * scale # 4fsc, then scaled up to the input line length
 
     def refine_linelocs_burst(self, linelocs=None):
         if linelocs is None:
@@ -1873,14 +1878,14 @@ class FieldNTSCShared(FieldShared, ldd.FieldNTSC):
             if (
                 not self.rf.options.disable_burst_hsync and
                 self.phase_sequence is not None and
-                self.rf.color_system == "NTSC" and # only enable for normal NTSC (disabled for NLINHA, etc.)
-                self.burst_detected # skip hsync when burst is not detected
+                self.rf.color_system == "NTSC" # only enable for normal NTSC (disabled for NLINHA, etc.)
             ):
                 FieldNTSCShared._sync_to_burst(
                     linelocs,
                     self.outlinelen,
                     self.burst_phase_avg,
                     self.phase_sequence,
+                    self.burst_detected_line
                 )
 
         return linelocs

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -272,6 +272,14 @@ def main(args=None, use_gui=False):
         help="Disables using the color burst phase to refine hsync. (currently only applicable to NTSC)",
     )
     chroma_group.add_argument(
+        "--ck",
+        "--enable_color_killer",
+        dest="enable_color_killer",
+        action="store_true",
+        default=False,
+        help="Enables color killer, i.e. burst detection to enable/disable chroma decoding and hsync refinement. (currently only applicable to NTSC)"
+    )
+    chroma_group.add_argument(
         "--no_comb",
         dest="disable_comb",
         action="store_true",
@@ -543,6 +551,7 @@ def main(args=None, use_gui=False):
     rf_options["tape_speed"] = args.tape_speed
     rf_options["ire0_adjust"] = args.ire0_adjust
     rf_options["detect_chroma_track_phase"] = args.detect_chroma_track_phase
+    rf_options["enable_color_killer"] = args.enable_color_killer
     rf_options["disable_burst_hsync"] = args.disable_burst_hsync
     rf_options["disable_phase_correction"] = args.disable_phase_correction
     rf_options["gnrc_afe"] = args.gnrc_afe

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -269,7 +269,7 @@ def main(args=None, use_gui=False):
         dest="disable_burst_hsync",
         action="store_true",
         default=False,
-        help="Disables using the color burst phase to refine hsync. (currently only applicable to NTSC)",
+        help="Disables using the color burst phase to refine hsync.",
     )
     chroma_group.add_argument(
         "--ck",
@@ -277,7 +277,7 @@ def main(args=None, use_gui=False):
         dest="enable_color_killer",
         action="store_true",
         default=False,
-        help="Enables color killer, i.e. burst detection to enable/disable chroma decoding and hsync refinement. (currently only applicable to NTSC)"
+        help="Enables color killer, i.e. burst detection to enable/disable chroma decoding and hsync refinement."
     )
     chroma_group.add_argument(
         "--no_comb",

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -710,6 +710,7 @@ class VHSRFDecode(ldd.RFDecode):
                 "gnrc_afe",
                 "relaxed_line0",
                 "detect_chroma_track_phase",
+                "enable_color_killer",
                 "disable_burst_hsync",
                 "disable_phase_correction",
             ],
@@ -751,6 +752,7 @@ class VHSRFDecode(ldd.RFDecode):
             rf_options.get("gnrc_afe", False),
             rf_options.get("relaxed_line0", False),
             rf_options.get("detect_chroma_track_phase", False),
+            rf_options.get("enable_color_killer", False),
             rf_options.get("disable_burst_hsync", False),
             rf_options.get("disable_phase_correction", False),
         )

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -215,6 +215,11 @@ class VHSDecode(ldd.LDdecode):
             "isFirstField": True if f.isFirstField else False,
             "detectedFirstField": True if f.isFirstField else False,
             "isDuplicateField": False,
+            # burstStartLine description:
+            # -1                    -> Color killer is active, no color for entire field
+            #  0                    -> Color killer is inactive, color for the entire field
+            #  1 to num_field_lines -> Color killer is active until this line, then it is deactivated and color is returned for this and all following lines (only used internally for now)
+            "burstStartLine": f.burst_detected_line,
             "syncConf": f.compute_syncconf(),
             "seqNo": len(self.fieldinfo) + 1,
             "diskLoc": np.round((f.readloc / self.bytes_per_field) * 10) / 10,

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -218,7 +218,7 @@ class VHSDecode(ldd.LDdecode):
             # burstStartLine description:
             # -1                    -> Color killer is active, no color for entire field
             #  0                    -> Color killer is inactive, color for the entire field
-            #  1 to num_field_lines -> Color killer is active until this line, then it is deactivated and color is returned for this and all following lines (only used internally for now)
+            #  1 to num_field_lines -> Color killer is active until this line, then it is deactivated and color is returned for this and all following lines
             "burstStartLine": f.burst_detected_line,
             "syncConf": f.compute_syncconf(),
             "seqNo": len(self.fieldinfo) + 1,


### PR DESCRIPTION
### Color Killer
  * Add `--enable-color-killer`, `--ck` that uses the measured magnitude of the color burst to enable / disable chroma decoding and burst hsync. Resolves #218.
  * Add `burstStartLine` to metadata JSON, so it can be used by the chroma decoder to enable / disable color filtering. (probably won't be used until we move to SQLite)
    * `burstStartLine` description:
      * `-1`: Color killer is active, no color for entire field
      * `0`:  Color killer is inactive, color for the entire field
      * `1 to num_field_lines`: Color killer is active until this line, then it is deactivated and color is returned for this and all following lines

### PAL Color-Under Burst TBC
  * Enable color burst time base correction for PAL and PAL-based formats (i.e. PAL-M, NLINHA):
    * This uses the same logic as the NTSC color burst TBC, but splits the reference phase between even and odd lines.
    * This results in a very minor improvement with my test media, but this can cause distortion around the head switching area. I suspect that if the headswitching point is moved into the vsync area, the distortion will not show up.
    * https://compare.promptingpixels.com/a/cO4MEWe?v=swap&sa=1
  * Enable `--detect_chroma_track_phase` for PAL color-under
    * This uses the same logic as the NTSC track detection, but changes the comparison line to line_number - 2

### Burst TBC improvements
* Use scaled distance (i.e. wow) from hsync start to burst start to compensate for phase measurement error. This uses the wow calculated from the hsync pulses as a correction factor when the color burst phase is measured. A more correct burst phase measurement helps to better align burst tbc and color-under phase compensation.

### NTSC Color-Under Per-Line Phase Compensation using Heterodyne
  * NTSC phase comp now corrects per-line phase errors by rotating the phase of the color-under heterodyne when up-converting the signal.
    * This results in a phase locked color signal and will help the NTSC 3D decoder to work for U-matic, or sources with unstable phase.
    * Additionally, the target phase for phase correction is now informed by the color framing sequence, so the color is guaranteed to be in the correct phase given the `fieldPhaseID` in the metadata.
