### PR TITLE
Fix unit-test compatibility and GH Actions deprecation annotations

### DIFF
--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           dnf install --assumeyes git python3.12-pip gcc-c++ file
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -40,7 +40,7 @@ jobs:
           python-appimage build app -p 3.12 _build_appimage
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vhs-decode_linux_x86_64
           path: vhs-decode-x86_64.AppImage

--- a/.github/workflows/build_linux_tools.yml
+++ b/.github/workflows/build_linux_tools.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Set up DNF download cache
         id: dnf-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /var/cache/dnf
           key: dnfcache
@@ -37,7 +37,7 @@ jobs:
           FORCE_DNF=1 /usr/bin/crb enable
           dnf --assumeyes install git file xz qt5-qtbase-devel qwt-qt5-devel fftw-devel ffmpeg-devel ffmpeg pkgconf-pkg-config make cmake sox python3-pip gcc-c++ python3-devel
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -88,7 +88,7 @@ jobs:
         run: tar -cvJSf tbc-tools.tar.xz --transform s/release/tbc-tools/ release/
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tbc-tools_linux_x86_64
           path: tbc-tools.tar.xz

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
 
@@ -83,7 +83,7 @@ jobs:
           "dist/vhs-decode.app"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vhs-decode_macos_${{ matrix.arch }}
           path: vhs-decode.dmg

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -90,7 +90,7 @@ jobs:
           "dist/tbc-tools.app"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tbc-tools_macos_${{ matrix.arch }}
           path: tbc-tools.dmg

--- a/.github/workflows/build_windows_decode.yml
+++ b/.github/workflows/build_windows_decode.yml
@@ -10,12 +10,12 @@ jobs:
     env:
         SETUPTOOLS_RUST_CARGO_PROFILE: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -31,7 +31,7 @@ jobs:
           python .\scripts\ci\build-windows-decode-bin.py
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vhs-decode_windows_x86_64
           path: dist/decode.exe

--- a/.github/workflows/build_windows_tools.yml
+++ b/.github/workflows/build_windows_tools.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -98,7 +98,7 @@ jobs:
       #    Compress-Archive -Path .\tbc-tools -DestinationPath tbc-tools.zip
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tbc-tools_windows_x86_64
           path: release

--- a/.github/workflows/push_pypi.yml
+++ b/.github/workflows/push_pypi.yml
@@ -21,17 +21,17 @@ jobs:
       CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: vhs-decode-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -52,7 +52,7 @@ jobs:
           pipx run build --sdist
 
       - name: Store the sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vhs-decode-sdist
           path: dist/*.tar.gz
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Download all the artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: vhs-decode-*
           path: dist

--- a/.github/workflows/push_testpypi.yml
+++ b/.github/workflows/push_testpypi.yml
@@ -18,18 +18,18 @@ jobs:
       CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: vhs-decode-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -49,7 +49,7 @@ jobs:
           pipx run build --sdist
 
       - name: Store the sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vhs-decode-sdist
           path: dist/*.tar.gz
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download all the artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: vhs-decode-*
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,12 @@ jobs:
     name: test_python_unit
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         fetch-tags: true
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -45,12 +45,12 @@ jobs:
       matrix:
         qt: [5, 6]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: true
         fetch-depth: 0
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         repository: happycube/ld-decode-testdata
         path: testdata
@@ -96,12 +96,12 @@ jobs:
     name: test_real_data
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: true
         fetch-depth: 0
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         repository: happycube/ld-decode-testdata
         path: testdata

--- a/tests/unit/test_rust_math.py
+++ b/tests/unit/test_rust_math.py
@@ -13,7 +13,7 @@ class TestRustAngle:
 
         expected = np.angle(hilbert_data)
         result = complex_angle_py(hilbert_data)
-        assert (expected == result).all()
+        assert np.isclose(result, expected, atol=1e-15, rtol=1e-14).all()
 
 
 class TestRustUnwrap:

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -582,7 +582,7 @@ class VHSDecode(ldd.LDdecode):
 class VHSRFDecode(ldd.RFDecode):
     def __init__(
         self,
-        processing_thread_pool,
+        processing_thread_pool=None,
         inputfreq=40,
         system="NTSC",
         tape_format="VHS",
@@ -599,6 +599,9 @@ class VHSRFDecode(ldd.RFDecode):
             has_analog_audio=False,
             extra_options=extra_options,
         )
+        if processing_thread_pool is None:
+            processing_thread_pool = ThreadPoolExecutor(max_workers=1)
+        self._processing_thread_pool = processing_thread_pool
 
         # Store a separate setting for *color* system as opposed to 525/625 line here.
         # TODO: Fix upstream so we don't have to fake tell ld-decode code that we are using ntsc for
@@ -892,7 +895,7 @@ class VHSRFDecode(ldd.RFDecode):
             self.freq_hz,
             self.SysParams,
             self._sysparams_const,
-            processing_thread_pool,
+            self._processing_thread_pool,
             divisor=level_detect_divisor,
             debug=self.debug,
         )


### PR DESCRIPTION
## Summary

- make `VHSRFDecode` constructor backward-compatible for unit-test and direct-call usage by providing a default processing thread pool
- stabilize Rust angle unit test assertion by comparing with tight floating-point tolerance instead of exact equality
- update GitHub Actions workflow action versions (`checkout`, `setup-python`, `cache`, `upload-artifact`, `download-artifact`) to clean Node deprecation annotations

## Validation

- local unit tests pass
- branch workflow validation on fork passes (`Tests` workflow)