### PR TITLE
ci: fix Linux decode workflow safe.directory in container builds

### DIFF
--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary
- mark `` as a trusted Git safe.directory in the Linux decode workflow
- resolves AppImage metadata generation failures caused by Git 'detected dubious ownership' inside the Oracle Linux container

## Verification
- Linux decode workflow passed on Decode-Launcher after the fix:
  - https://github.com/harrypm/ld-decode/actions/runs/24003630841