### PR TITLE
Upstream changes - fix the nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,14 +34,14 @@
           ps.mkdocs-awesome-nav
         ]);
 
-        cargoDeps = pkgs.rust.rustPlatform.fetchCargoVendor {
-          name = "${pname}-${version}";
-          hash = "sha256-miW//pnOmww2i6SOGbkrAIdc/JMDT4FJLqdMFojZeoY=";
+        cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+          inherit pname version;
+          src = ./.;
+          hash = "sha256-yryE7R0A95Uok6Pv6/UBsIG8p9pvaP3Nv8AGQugrEOc=";
         };
 
         vhs-decode = pythonPackages.buildPythonPackage {
-          inherit pname;
-          inherit version;
+          inherit pname version cargoDeps;
           
           src = ./.;
           
@@ -62,6 +62,7 @@
           propagatedBuildInputs = with pythonPackages; [
             av
             matplotlib
+            noisereduce
             numba
             numpy
             scipy
@@ -71,6 +72,12 @@
             soxr
           ];
           
+          # static-ffmpeg is not in nixpkgs; ffmpeg is provided via pkgs.ffmpeg
+          postPatch = ''
+            substituteInPlace pyproject.toml \
+              --replace-fail '    "static-ffmpeg",' ""
+          '';
+
           # Write PEP-440 compliant version file with git info
           preBuild = ''
             echo "${fullVersion}" > lddecode/version

--- a/flake.nix
+++ b/flake.nix
@@ -21,17 +21,16 @@
         # Use flake's built-in git properties
         # dirtyShortRev already includes "-dirty" suffix, so we need to handle it
         gitCommit = if self ? dirtyShortRev then self.dirtyShortRev else self.shortRev;
-        gitDirty = self ? dirtyRev;
         
         # Build PEP-440 compliant version string with git info
         # Format: base_version+git.commit[.dirty]
         # dirtyShortRev format is "abc1234-dirty", so replace "-" with "."
         fullVersion = "${version}+git.${builtins.replaceStrings ["-"] ["."] gitCommit}";
         
-        docsEnv = pkgs.python3.withPackages (ps: with ps; [
-          ps.mkdocs
-          ps.mkdocs-material
-          ps.mkdocs-awesome-nav
+        docsEnv = python.withPackages (ps: with ps; [
+          mkdocs
+          mkdocs-material
+          mkdocs-awesome-nav
         ]);
 
         cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
@@ -54,13 +53,13 @@
             setuptools-rust
             setuptools-scm
             wheel
-            pkgs.git
             cython
             pkgs.rustc
           ];
           
           propagatedBuildInputs = with pythonPackages; [
             av
+            cython
             matplotlib
             noisereduce
             numba
@@ -90,7 +89,6 @@
             description = "Software defined LaserDisc and videotape decoder";
             homepage = "https://github.com/oyvindln/vhs-decode";
             license = licenses.gpl3Plus;
-            maintainers = [ ];
           };
         };
       in
@@ -100,7 +98,7 @@
           vhs-decode = vhs-decode;
           docs = pkgs.stdenv.mkDerivation {
             pname = "ld-decode-docs";
-            version = version;
+            inherit version;
             src = ./.;
             nativeBuildInputs = [ docsEnv ];
             buildPhase = ''mkdocs build'';
@@ -115,7 +113,7 @@
           };
           vhs-decode = {
             type = "app";
-            program = "${vhs-decode}/bin/ld-decode";
+            program = "${vhs-decode}/bin/vhs-decode";
           };
           cvbs-decode = {
             type = "app";
@@ -136,12 +134,6 @@
             pkgs.cmake
             pkgs.ffmpeg
             vhs-decode
-            python
-            pythonPackages.av
-            pythonPackages.matplotlib
-            pythonPackages.numba
-            pythonPackages.numpy
-            pythonPackages.scipy
             pythonPackages.jupyter
             pythonPackages.pandas
             pythonPackages.pytest

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         "ld-cut",
         "scripts/cx-expander",
         "decode.py",
-        "decode-launcher",
     ],
     # scripts=[
     #    'cx-expander',


### PR DESCRIPTION
### Checklist

- [ ] I have searched the open pull requests to confirm this change has not already been submitted.
- [ ] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [ ] I have updated documentation where necessary.
- [x] My code follows the project's coding standards (see CONTRIBUTING.md).

Note: There are some qt5/qt6 actions in there that are failing, but I don't think they have anything to do with the issue the PR is focused on.

### Description

Fixes the `nix develop` / `nix run` / `nix build` flow which was broken due to several issues in flake.nix and a duplicate entry point in setup.py.

### Motivation

`nix develop` failed entirely — the flake could not build the vhs-decode Python package, making the Nix dev environment unusable.

### Related Issues

N/A

### Changes Made

**flake.nix**
- Fix `fetchCargoVendor`: changed `pkgs.rust.rustPlatform` → `pkgs.rustPlatform`, added missing `src = ./.;` so Cargo.lock is found, and updated the vendor hash
- Add `inherit cargoDeps;` to `buildPythonPackage` so `cargoSetupHook` can locate the vendored sources at build time
- Add `noisereduce` to `propagatedBuildInputs` (was declared as a runtime dep in pyproject.toml but absent from the flake)
- Add `cython` to `propagatedBuildInputs` (required at runtime — main.py imports `pyximport`)
- Add `postPatch` to strip `static-ffmpeg` from pyproject.toml at build time (no nixpkgs equivalent; ffmpeg is already available via `pkgs.ffmpeg`)
- Fix `apps.vhs-decode` to point to `bin/vhs-decode` instead of `bin/ld-decode`
- Remove dead `gitDirty` let-binding
- Remove `pkgs.git` from `nativeBuildInputs` (not needed since version is written manually in `preBuild`)
- Remove empty `maintainers = [ ]` from `meta`
- Use `inherit version` in docs derivation
- Fix `docsEnv` to use the pinned `python312` instead of `pkgs.python3`
- Fix `docsEnv` `withPackages` to not double-prefix with `ps.` inside `with ps;`
- Remove redundant transitive deps from `devShells` (already pulled in via vhs-decode)

**setup.py**
- Remove decode-launcher from `scripts=` — it is already declared as a console entry point in pyproject.toml, causing a `FileExistsError` during install

### Testing

- [x] All existing tests pass (`pytest --output-on-failure`)
- [x] Tested manually with: `nix develop`, `nix run`, `nix build .#vhs-decode`
- [ ] New tests added for: N/A

### Additional Notes

`static-ffmpeg` is a PyPI convenience package that bundles a static ffmpeg binary for non-Nix environments. On Nix, `pkgs.ffmpeg` serves this role and `static-ffmpeg` has no nixpkgs package, so it is patched out of pyproject.toml during the build rather than being added as a dependency.