### PR TITLE
upgrade downscaling from cubic to kaiser windowed sinc

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -26,7 +26,7 @@ from scipy import interpolate
 from . import efm_pll
 from .utils import ac3_pipe, ldf_pipe, traceback
 from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_abs, nb_absmax, nb_diff, n_orgt, n_orlt
-from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms
+from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms, sinc_lut_future
 from .utils import findpeaks, findpulses, calczc, inrange, roundfloat
 from .utils import LRUupdate, clb_findbursts, angular_mean_helper, phase_distance
 from .utils import build_hilbert, unwrap_hilbert, emphasis_iir, filtfft
@@ -2564,6 +2564,7 @@ class Field:
             dsout,
             interpolated_pixel_locs,
             wowfactors,
+            sinc_lut_future.result(),
             self.lineoffset,
             outwidth,
             wow_level_adjust_smoothing=self.wow_level_adjust_smoothing

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -144,10 +144,10 @@ kaiser_beta = 5
 sinc_tap_count = 16 # must be multiple of 2
 sinc_phase_count = 2**16
 # pre-compute sinc
-kaiser_table = build_kaiser_lut(kaiser_beta, sinc_tap_count, sinc_phase_count)
+sinc_lut = build_kaiser_lut(kaiser_beta, sinc_tap_count, sinc_phase_count)
 
 @njit(nogil=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, sinc_lut=kaiser_table, sinc_taps=sinc_tap_count, sinc_phases=sinc_phase_count):
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line
@@ -170,7 +170,7 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         for i in range(1, len(level_adjusts)):
             level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
 
-    half_taps_m1 = (sinc_taps // 2) - 1
+    half_taps_m1 = (sinc_tap_count // 2) - 1
 
     dsout_start = outwidth * (lineoffset + 1)
     dsout_end = len(dsout) + dsout_start
@@ -185,12 +185,11 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         # fractional phase
         frac = coord - coord_int
 
-        phase_pos = frac * sinc_phases
+        phase_pos = frac * sinc_phase_count
         phase_start = int(phase_pos)
         phase_end = phase_start + 1
 
-        alpha = phase_pos - phase_start
-        alpha_m1 = 1 - alpha
+        alpha = np.float32(phase_pos - phase_start)
 
         w_start = sinc_lut[phase_start]
         w_end = sinc_lut[phase_end]
@@ -198,10 +197,10 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         start = coord_int - half_taps_m1
 
         result = 0.0
-        for t in range(sinc_taps):
+        for t in range(sinc_tap_count):
             # do linear interpolation between pre-computed phases
-            w = alpha_m1 * w_start[t] + alpha * w_end[t]
-            result += buf[start + t] * w
+            ws = w_start[t]
+            result += buf[start + t] * (ws + alpha * (w_end[t] - ws))
 
         dsout[i - dsout_start] = level_adjust * result
 

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -109,33 +109,31 @@ def kaiser_sinc(x, a, beta):
     return sinc(x) * kaiser_window(x, a, beta)
 
 # https://ccrma.stanford.edu/~jos/sasp/Kaiser_Windows_Transforms.html
-def build_kaiser_lut(beta):
-    phases = 65536
-    taps = 6
-    a = 3.0
+def build_kaiser_lut(beta, taps, phases):
+    a = taps // 2
 
-    table = np.zeros((phases, taps), dtype=np.float32)
+    offsets = np.arange(a - 1, -a - 1, -1)
+    offsets_len = len(offsets)
+
+    table = np.zeros((phases + 1, taps), dtype=np.float32)
+    weights = np.empty(offsets_len, dtype=np.float32)
 
     for i in range(phases):
         x = i / phases
 
-        w0 = kaiser_sinc(x + 2.0, a, beta)
-        w1 = kaiser_sinc(x + 1.0, a, beta)
-        w2 = kaiser_sinc(x + 0.0, a, beta)
-        w3 = kaiser_sinc(x - 1.0, a, beta)
-        w4 = kaiser_sinc(x - 2.0, a, beta)
-        w5 = kaiser_sinc(x - 3.0, a, beta)
+        s = 0.0
+        for j in range(offsets_len):
+            offset = offsets[j]
+            weight = kaiser_sinc(x + offset, a, beta)
 
-        s = w0 + w1 + w2 + w3 + w4 + w5
+            weights[j] = weight
+            s += weight
 
         if s != 0.0:
-            inv = 1.0 / s
-            table[i, 0] = w0 * inv
-            table[i, 1] = w1 * inv
-            table[i, 2] = w2 * inv
-            table[i, 3] = w3 * inv
-            table[i, 4] = w4 * inv
-            table[i, 5] = w5 * inv
+            table[i, :] = weights / s
+
+    # copy the last phase to avoid bounds checking later on when we do linear interpolation
+    table[phases] = table[phases - 1]
 
     return table
 
@@ -143,14 +141,13 @@ def build_kaiser_lut(beta):
 # Small Beta = more sharpness / more ringing (narrow main lobe (more sharp), less side lobe cutoff (more ringing))
 # Large Beta = less sharpness / less ringing (wide main lobe (less sharp), more side lobe cutoff (less ringing))
 kaiser_beta = 5
+sinc_tap_count = 16 # must be multiple of 2
+sinc_phase_count = 2**16
 # pre-compute sinc
-kaiser_table = build_kaiser_lut(kaiser_beta)
+kaiser_table = build_kaiser_lut(kaiser_beta, sinc_tap_count, sinc_phase_count)
 
 @njit(nogil=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, sinc_lut=kaiser_table):
-    lineoffset += 1
-    lineoffset_out_samples = outwidth * lineoffset
-
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, sinc_lut=kaiser_table, sinc_taps=sinc_tap_count, sinc_phases=sinc_phase_count):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line
@@ -173,7 +170,11 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         for i in range(1, len(level_adjusts)):
             level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
 
-    for i in range(lineoffset_out_samples, len(dsout) + lineoffset_out_samples):
+    half_taps_m1 = (sinc_taps // 2) - 1
+
+    dsout_start = outwidth * (lineoffset + 1)
+    dsout_end = len(dsout) + dsout_start
+    for i in range(dsout_start, dsout_end):
         # compensates for the amplitude/frequency shift caused by FM demodulation under varying playback speed.
         level_adjust = level_adjusts[i]
 
@@ -183,27 +184,26 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
 
         # fractional phase
         frac = coord - coord_int
-        phase = int(frac * 65536.0)
 
-        w = sinc_lut[phase]
+        phase_pos = frac * sinc_phases
+        phase_start = int(phase_pos)
+        phase_end = phase_start + 1
 
-        i0 = coord_int - 2
-        i1 = coord_int - 1
-        i2 = coord_int
-        i3 = coord_int + 1
-        i4 = coord_int + 2
-        i5 = coord_int + 3
+        alpha = phase_pos - phase_start
+        alpha_m1 = 1 - alpha
 
-        result = (
-            buf[i0] * w[0] +
-            buf[i1] * w[1] +
-            buf[i2] * w[2] +
-            buf[i3] * w[3] +
-            buf[i4] * w[4] +
-            buf[i5] * w[5]
-        )
+        w_start = sinc_lut[phase_start]
+        w_end = sinc_lut[phase_end]
 
-        dsout[i - lineoffset_out_samples] = level_adjust * result
+        start = coord_int - half_taps_m1
+
+        result = 0.0
+        for t in range(sinc_taps):
+            # do linear interpolation between pre-computed phases
+            w = alpha_m1 * w_start[t] + alpha * w_end[t]
+            result += buf[start + t] * w
+
+        dsout[i - dsout_start] = level_adjust * result
 
 frequency_suffixes = [
     ("ghz", 1.0e9),

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -109,15 +109,6 @@ def kaiser_sinc(x, a, beta):
     return sinc(x) * kaiser_window(x, a, beta)
 
 # https://ccrma.stanford.edu/~jos/sasp/Kaiser_Windows_Transforms.html
-# https://ccrma.stanford.edu/~jos/sasp/Hood_kaiserord.html
-def kaiser_window_beta(side_lobe_attenuation_db):
-    if side_lobe_attenuation_db < 13.26:
-        return 0
-    if side_lobe_attenuation_db < 60:
-        return 0.76609 * (side_lobe_attenuation_db - 13.26) ** 0.4 + 0.09834 * (side_lobe_attenuation_db - 13.26)
-    if side_lobe_attenuation_db < 120:
-        return 0.12438 * (side_lobe_attenuation_db + 6.3)
-
 def build_kaiser_lut(beta):
     phases = 65536
     taps = 6
@@ -151,7 +142,7 @@ def build_kaiser_lut(beta):
 # Kaiser Beta parameter controls trade-off between sharpness and ringing
 # Small Beta = more sharpness / more ringing (narrow main lobe (more sharp), less side lobe cutoff (more ringing))
 # Large Beta = less sharpness / less ringing (wide main lobe (less sharp), more side lobe cutoff (less ringing))
-kaiser_beta = kaiser_window_beta(80) # db cutoff of side-lobes
+kaiser_beta = 5
 # pre-compute sinc
 kaiser_table = build_kaiser_lut(kaiser_beta)
 

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -15,6 +15,7 @@ import warnings
 
 import threading
 from queue import Queue
+from concurrent.futures import ProcessPoolExecutor
 
 from numba import jit, njit
 import numba
@@ -91,22 +92,20 @@ def scale(buf, begin, end, tgtlen, mult=1):
 
     return output
 
+@njit
 def sinc(x):
     if x == 0.0:
         return 1.0
     x_pi = np.pi * x
-    return np.sin(x_pi) / x_pi
+    return math.sin(x_pi) / x_pi
 
-def kaiser_window(x, a, beta):
+def kaiser_window(x, a, beta, i0_beta):
     r = x / a
     if r < -1.0 or r > 1.0:
         return 0.0
 
-    t = np.sqrt(1.0 - r * r)
-    return i0(beta * t) / i0(beta)
-
-def kaiser_sinc(x, a, beta):
-    return sinc(x) * kaiser_window(x, a, beta)
+    t = math.sqrt(1.0 - r * r)
+    return i0(beta * t) / i0_beta
 
 # https://ccrma.stanford.edu/~jos/sasp/Kaiser_Windows_Transforms.html
 def build_kaiser_lut(beta, taps, phases):
@@ -117,20 +116,20 @@ def build_kaiser_lut(beta, taps, phases):
 
     table = np.zeros((phases + 1, taps), dtype=np.float32)
     weights = np.empty(offsets_len, dtype=np.float32)
+    i0_beta = i0(beta)
 
     for i in range(phases):
-        x = i / phases
+        phase = i / phases
 
         s = 0.0
         for j in range(offsets_len):
-            offset = offsets[j]
-            weight = kaiser_sinc(x + offset, a, beta)
+            x = offsets[j] + phase
+            weight = sinc(x) * kaiser_window(x, a, beta, i0_beta)
 
             weights[j] = weight
             s += weight
 
-        if s != 0.0:
-            table[i, :] = weights / s
+        table[i, :] = weights / s
 
     # copy the last phase to avoid bounds checking later on when we do linear interpolation
     table[phases] = table[phases - 1]
@@ -143,11 +142,14 @@ def build_kaiser_lut(beta, taps, phases):
 kaiser_beta = 5
 sinc_tap_count = 16 # must be multiple of 2
 sinc_phase_count = 2**16
-# pre-compute sinc
-sinc_lut = build_kaiser_lut(kaiser_beta, sinc_tap_count, sinc_phase_count)
+
+# compute sinc table in a process to so it doesn't block other startup tasks
+sinc_lut_future = ProcessPoolExecutor().submit(
+    build_kaiser_lut, kaiser_beta, sinc_tap_count, sinc_phase_count
+)
 
 @njit(nogil=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -23,6 +23,7 @@ import numba
 import numpy as np
 import scipy.signal as sps
 from scipy import interpolate
+from scipy.special import i0
 
 def _ensure_ffmpeg_on_path():
     try:
@@ -90,17 +91,72 @@ def scale(buf, begin, end, tgtlen, mult=1):
 
     return output
 
+def sinc(x):
+    if x == 0.0:
+        return 1.0
+    x_pi = np.pi * x
+    return np.sin(x_pi) / x_pi
 
-# Scales and compensates for wow-induced playback-speed variations
-@njit(nogil=True, cache=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
-    # Constants preserved as float32
-    point_5 = np.float32(0.5)
-    two = np.float32(2)
-    three = np.float32(3)
-    four = np.float32(4)
-    five = np.float32(5)
+def kaiser_window(x, a, beta):
+    r = x / a
+    if r < -1.0 or r > 1.0:
+        return 0.0
 
+    t = np.sqrt(1.0 - r * r)
+    return i0(beta * t) / i0(beta)
+
+def kaiser_sinc(x, a, beta):
+    return sinc(x) * kaiser_window(x, a, beta)
+
+# https://ccrma.stanford.edu/~jos/sasp/Kaiser_Windows_Transforms.html
+# https://ccrma.stanford.edu/~jos/sasp/Hood_kaiserord.html
+def kaiser_window_beta(side_lobe_attenuation_db):
+    if side_lobe_attenuation_db < 13.26:
+        return 0
+    if side_lobe_attenuation_db < 60:
+        return 0.76609 * (side_lobe_attenuation_db - 13.26) ** 0.4 + 0.09834 * (side_lobe_attenuation_db - 13.26)
+    if side_lobe_attenuation_db < 120:
+        return 0.12438 * (side_lobe_attenuation_db + 6.3)
+
+def build_kaiser_lut(beta):
+    phases = 65536
+    taps = 6
+    a = 3.0
+
+    table = np.zeros((phases, taps), dtype=np.float32)
+
+    for i in range(phases):
+        x = i / phases
+
+        w0 = kaiser_sinc(x + 2.0, a, beta)
+        w1 = kaiser_sinc(x + 1.0, a, beta)
+        w2 = kaiser_sinc(x + 0.0, a, beta)
+        w3 = kaiser_sinc(x - 1.0, a, beta)
+        w4 = kaiser_sinc(x - 2.0, a, beta)
+        w5 = kaiser_sinc(x - 3.0, a, beta)
+
+        s = w0 + w1 + w2 + w3 + w4 + w5
+
+        if s != 0.0:
+            inv = 1.0 / s
+            table[i, 0] = w0 * inv
+            table[i, 1] = w1 * inv
+            table[i, 2] = w2 * inv
+            table[i, 3] = w3 * inv
+            table[i, 4] = w4 * inv
+            table[i, 5] = w5 * inv
+
+    return table
+
+# Kaiser Beta parameter controls trade-off between sharpness and ringing
+# Small Beta = more sharpness / more ringing (narrow main lobe (more sharp), less side lobe cutoff (more ringing))
+# Large Beta = less sharpness / less ringing (wide main lobe (less sharp), more side lobe cutoff (less ringing))
+kaiser_beta = kaiser_window_beta(80) # db cutoff of side-lobes
+# pre-compute sinc
+kaiser_table = build_kaiser_lut(kaiser_beta)
+
+@njit(nogil=True, fastmath=True)
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15, sinc_lut=kaiser_table):
     lineoffset += 1
     lineoffset_out_samples = outwidth * lineoffset
 
@@ -124,7 +180,7 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         one_minus_alpha = 1 - alpha
 
         for i in range(1, len(level_adjusts)):
-            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]       
+            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
 
     for i in range(lineoffset_out_samples, len(dsout) + lineoffset_out_samples):
         # compensates for the amplitude/frequency shift caused by FM demodulation under varying playback speed.
@@ -134,19 +190,29 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         coord = np.float32(interpolated_pixel_locs[i])
         coord_int = int(coord)
 
-        # get the data from the buffer that aligns to the wow factor index
-        p0 = buf[coord_int - 1]
-        p1 = buf[coord_int]
-        p2 = buf[coord_int + 1]
-        p3 = buf[coord_int + 2]
-        x = np.float32(coord - coord_int)
+        # fractional phase
+        frac = coord - coord_int
+        phase = int(frac * 65536.0)
 
-        # perform cubic scaling
-        a = p2 - p0
-        b = two * p0 - five * p1 + four * p2 - p3
-        c = three * (p1 - p2) + p3 - p0
-        dsout[i-lineoffset_out_samples] = level_adjust * (p1 + point_5 * x * (a + x * (b + x * c)))
+        w = sinc_lut[phase]
 
+        i0 = coord_int - 2
+        i1 = coord_int - 1
+        i2 = coord_int
+        i3 = coord_int + 1
+        i4 = coord_int + 2
+        i5 = coord_int + 3
+
+        result = (
+            buf[i0] * w[0] +
+            buf[i1] * w[1] +
+            buf[i2] * w[2] +
+            buf[i3] * w[3] +
+            buf[i4] * w[4] +
+            buf[i5] * w[5]
+        )
+
+        dsout[i - lineoffset_out_samples] = level_adjust * result
 
 frequency_suffixes = [
     ("ghz", 1.0e9),


### PR DESCRIPTION
Replaces the existing cubic downscaler with Kaiser windowed sinc interpolation. This reduces scaling errors and aliasing over the existing cubic method. This change is very subtle. It is only visually perceptible with high quality CVBS captures but it should help with other measurements that happen after downscaling, like burst phase, and SNR.

Performance is unchanged (maybe a bit faster) since the sinc phases are pre-calculated and stored in a look up table.

### HackTV Example (cvbs-decode)
#### Cubic (left) vs. Kaiser Windowed Sinc (right)
* Hack TV command
  * `hacktv -o hack_pal_16.s16 -m pal --vits -r test`
* `cvhs-decode` commands
  * `cvbs-decode -l 250 -p -f 16 -t 3 hack_pal_16.s16 cubic` (done with vhs_decode branch)
  * `cvbs-decode -l 250 -p -f 16 -t 3 hack_pal_16.s16 kaiser` (done with this branch)
* `tbc-video-export` commands
  * `tbc-video-export --yuv444 --8bit -t 16 --video-system pal cubic.tbc cubic.mkv`
  * `tbc-video-export --yuv444 --8bit -t 16 --video-system pal kaiser.tbc kaiser.mkv`
* Side by side video command
  * `ffmpeg -i cubic.mkv -i kaiser.mkv -filter_complex hstack -c:v libx265 -x265-params lossless=1 -preset veryslow -pix_fmt yuv420p -t 8 cubic_vs_kaiser_sinc.mp4`

https://github.com/user-attachments/assets/23d2a052-5e6c-4275-a1b3-b83050eb2d8e

### CVBS Example
#### Cubic down-scaling (existing)
<img width="910" height="525" alt="scaling_test_cubic" src="https://github.com/user-attachments/assets/355fa007-20e3-4595-a5fd-6b7c7cb261df" />

#### Kaiser Windowed Sinc (new)
<img width="910" height="525" alt="scaling_test_kaiser" src="https://github.com/user-attachments/assets/d66e5634-59ef-456d-83f3-62c7ad309f60" />

#### Difference using [`odiff`](https://github.com/dmtrKovalenko/odiff)
```sh
$ odiff -t 0.005 scaling_test_cubic.png scaling_test_kaiser.png diff.png
Found 5807 different pixels (1.22%)
```
<img width="910" height="525" alt="diff" src="https://github.com/user-attachments/assets/3fe58c99-3f47-46e8-98c4-7b1da9b664e4" />

### VHS Example
#### Cubic down-scaling (existing)
<img width="760" height="525" alt="scaling_test_cubic_zone" src="https://github.com/user-attachments/assets/fddd5596-1479-4401-8523-4c1a2af618d2" />

#### Kaiser Windowed Sinc (new)
<img width="760" height="525" alt="scaling_test_kaiser_zone" src="https://github.com/user-attachments/assets/f24a0023-1182-44c3-aa2b-3c2c40909005" />


#### Difference using odiff
```sh
$ odiff -t 0.002 scaling_test_kaiser_zone.png scaling_test_cubic_zone.png diff.png
Found 11181 different pixels (2.80%)
```
<img width="760" height="525" alt="diff" src="https://github.com/user-attachments/assets/f837728a-4005-437e-a077-7410a4b02b3d" />