### PR TITLE
Install ld-ldf-reader-py as a console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [ "pytest>=7.0" ]
 
 [project.scripts]
 ld-decode = "lddecode.main:main"
+ld-ldf-reader-py = "lddecode.ldf_reader:main"
 vhs-decode = "vhsdecode.main:main"
 cvbs-decode = "cvbsdecode.main:main"
 hifi-decode = "vhsdecode.hifi.main:main"


### PR DESCRIPTION
## Summary

- add ld-ldf-reader-py to [project.scripts] in pyproject.toml
- ensure pip and pipx installs expose ld-ldf-reader-py on PATH without a manual wrapper

## Validation

- before change, pipx list --json for local vhs-decode package did not include ld-ldf-reader-py
- after reinstall from this branch, pipx app list includes ld-ldf-reader-py
- ld-ldf-reader-py --version runs successfully
- LoadLDF._find_ldf_reader() resolves ld-ldf-reader-py

