### PR TITLE
MacOS x86 & Windows build fixes

### DIFF
--- a/.github/workflows/build_linux_decode.yml
+++ b/.github/workflows/build_linux_decode.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-decode:
-    name: Build vhs-decode (x86_64)
+    name: Build decode (x86_64)
     runs-on: ubuntu-latest
     container:
       image: oraclelinux:8
@@ -40,10 +40,12 @@ jobs:
           echo "$(pwd)[hifi_gui,hifi_gnuradio]" > _build_appimage/requirements.txt
 
           python-appimage build app -p 3.12 _build_appimage
+          APPIMAGE_SRC="$(ls -1 ./*-x86_64.AppImage | head -n 1)"
+          mv "${APPIMAGE_SRC}" ./decode-x86_64.AppImage
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: vhs-decode_linux_x86_64
-          path: vhs-decode-x86_64.AppImage
+          name: decode_linux_x86_64
+          path: decode-x86_64.AppImage
           if-no-files-found: error

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -51,7 +51,10 @@ jobs:
           echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Upgrade pip tooling
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: |
+          # setuptools>=82 removes pkg_resources.NullProvider, which breaks
+          # PyInstaller's pyi_rth_pkgres runtime hook in the bundled binary.
+          python3 -m pip install --upgrade pip "setuptools<82" wheel
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -86,30 +86,56 @@ jobs:
       - name: Build binary
         run: |
           python3 scripts/ci/build-macos-decode-bin.py
-      - name: Smoke test bundled binary
+      - name: Configure x86 runtime library path
+        if: matrix.arch == 'x86_64'
         shell: bash
         run: |
           set -euxo pipefail
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix libomp)/lib:$(brew --prefix llvm@20)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
-          fi
+          echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix libomp)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
 
+      - name: Smoke test bundled binary path and architecture
+        shell: bash
+        run: |
+          set -euxo pipefail
           APP_BIN="dist/decode.app/Contents/MacOS/decode"
           file "${APP_BIN}"
           BIN_ARCHS="$(lipo -archs "${APP_BIN}")"
           echo "Detected architectures: ${BIN_ARCHS}"
-
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             [[ "${BIN_ARCHS}" == *"x86_64"* ]]
           else
             [[ "${BIN_ARCHS}" == *"arm64"* ]]
           fi
+
+      - name: Smoke test bundled binary ld version
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/decode.app/Contents/MacOS/decode"
           VERSION_OUTPUT="$("${APP_BIN}" ld --version)"
           echo "ld --version: ${VERSION_OUTPUT}"
           [[ "${VERSION_OUTPUT}" != "unknown" ]]
           "${APP_BIN}" ld --version
+
+      - name: Smoke test bundled binary vhs cli
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/decode.app/Contents/MacOS/decode"
           "${APP_BIN}" vhs --help >/dev/null
+
+      - name: Smoke test bundled binary hifi cli
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/decode.app/Contents/MacOS/decode"
           "${APP_BIN}" hifi --help >/dev/null
+
+      - name: Smoke test bundled binary decode launcher cli
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/decode.app/Contents/MacOS/decode"
           "${APP_BIN}" decode-launcher --help >/dev/null
 
       - name: Build DMG file

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -6,12 +6,15 @@ on:
 
 jobs:
   build-decode:
+    timeout-minutes: 90
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-15-intel]
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
             python: "3.12"
           - os: macos-15-intel
@@ -33,12 +36,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
       - name: Generate version metadata
         shell: bash
         run: |
           set -euxo pipefail
           VERSION="$(python3 scripts/generate_version.py)"
-          SAFE_VERSION="${VERSION//:/-}"
+          SAFE_VERSION="$(printf '%s' "${VERSION}" | tr ':/ ' '---')"
           printf '%s\n' "${VERSION}" > lddecode/version
           echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
           echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
@@ -72,7 +79,7 @@ jobs:
           fi
 
           python3 -m pip install -r ./requirements.txt
-          python3 -m pip install pyinstaller
+          python3 -m pip install "pyinstaller>=6.20"
           python3 -m pip install -e ".[hifi_gui_qt6,hifi_gnuradio]"
 
       - name: Build binary
@@ -98,6 +105,7 @@ jobs:
           [[ "${VERSION_OUTPUT}" != "unknown" ]]
           "${APP_BIN}" ld --version
           "${APP_BIN}" vhs --help >/dev/null
+          "${APP_BIN}" hifi --help >/dev/null
           "${APP_BIN}" decode-launcher --help >/dev/null
 
       - name: Build DMG file

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -2,6 +2,7 @@ name: "Build macOS decode"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-decode:
@@ -20,6 +21,8 @@ jobs:
 
     name: Build vhs-decode (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v5
@@ -30,6 +33,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
+      - name: Generate version metadata
+        shell: bash
+        run: |
+          set -euxo pipefail
+          VERSION="$(python3 scripts/generate_version.py)"
+          SAFE_VERSION="${VERSION//:/-}"
+          printf '%s\n' "${VERSION}" > lddecode/version
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Upgrade pip tooling
         run: python3 -m pip install --upgrade pip setuptools wheel
@@ -66,25 +78,57 @@ jobs:
       - name: Build binary
         run: |
           python3 scripts/ci/build-macos-decode-bin.py
+      - name: Smoke test bundled binary
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          APP_BIN="dist/vhs-decode.app/Contents/MacOS/decode"
+          file "${APP_BIN}"
+          BIN_ARCHS="$(lipo -archs "${APP_BIN}")"
+          echo "Detected architectures: ${BIN_ARCHS}"
+
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            [[ "${BIN_ARCHS}" == *"x86_64"* ]]
+          else
+            [[ "${BIN_ARCHS}" == *"arm64"* ]]
+          fi
+          VERSION_OUTPUT="$("${APP_BIN}" ld --version)"
+          echo "ld --version: ${VERSION_OUTPUT}"
+          [[ "${VERSION_OUTPUT}" != "unknown" ]]
+          "${APP_BIN}" ld --version
+          "${APP_BIN}" vhs --help >/dev/null
+          "${APP_BIN}" decode-launcher --help >/dev/null
 
       - name: Build DMG file
-        run: >-
-          create-dmg
-          --volname "vhs-decode"
-          --volicon "assets/icons/vhs-decode.icns"
-          --window-pos 200 128
-          --window-size 600 300
-          --icon-size 100
-          --icon "vhs-decode.app" 172 120
-          --app-drop-link 425 128
-          --skip-jenkins
-          --hide-extension "vhs-decode.app"
-          "vhs-decode.dmg"
-          "dist/vhs-decode.app"
+        shell: bash
+        run: |
+          set -euxo pipefail
+          DMG_NAME="vhs-decode-${SAFE_VERSION}-${{ matrix.arch }}-macos.dmg"
+          echo "DMG_NAME=${DMG_NAME}" >> "${GITHUB_ENV}"
+          create-dmg \
+            --volname "vhs-decode" \
+            --volicon "assets/icons/vhs-decode.icns" \
+            --window-pos 200 128 \
+            --window-size 600 300 \
+            --icon-size 100 \
+            --icon "vhs-decode.app" 172 120 \
+            --app-drop-link 425 128 \
+            --skip-jenkins \
+            --hide-extension "vhs-decode.app" \
+            "${DMG_NAME}" \
+            "dist/vhs-decode.app"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
           name: vhs-decode_macos_${{ matrix.arch }}
-          path: vhs-decode.dmg
+          path: ${{ env.DMG_NAME }}
           if-no-files-found: error
+      - name: Upload DMG to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.DMG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_macos_decode.yml
+++ b/.github/workflows/build_macos_decode.yml
@@ -22,7 +22,7 @@ jobs:
             # Use a Python version with reliable wheels for llvmlite/numba on Intel macOS
             python: "3.11"
 
-    name: Build vhs-decode (${{ matrix.arch }})
+    name: Build decode (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -56,7 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
-        run: brew install create-dmg libsndfile
+        run: brew install create-dmg libsndfile libomp
 
       - name: Install LLVM (Intel only)
         if: matrix.arch == 'x86_64'
@@ -73,6 +73,7 @@ jobs:
           if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
             export LLVM_CONFIG="$(brew --prefix llvm@20)/bin/llvm-config"
             export CMAKE_PREFIX_PATH="$(brew --prefix llvm@20)"
+            export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix libomp)/lib:$(brew --prefix llvm@20)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
             # Keep Intel on a numba/llvmlite pair with published x86_64 wheels.
             # Installing this first avoids llvmlite source builds with setuptools API incompatibilities.
             python3 -m pip install "numba==0.60.0"
@@ -89,8 +90,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix libomp)/lib:$(brew --prefix llvm@20)/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+          fi
 
-          APP_BIN="dist/vhs-decode.app/Contents/MacOS/decode"
+          APP_BIN="dist/decode.app/Contents/MacOS/decode"
           file "${APP_BIN}"
           BIN_ARCHS="$(lipo -archs "${APP_BIN}")"
           echo "Detected architectures: ${BIN_ARCHS}"
@@ -112,25 +116,25 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          DMG_NAME="vhs-decode-${SAFE_VERSION}-${{ matrix.arch }}-macos.dmg"
+          DMG_NAME="decode-${SAFE_VERSION}-${{ matrix.arch }}-macos.dmg"
           echo "DMG_NAME=${DMG_NAME}" >> "${GITHUB_ENV}"
           create-dmg \
-            --volname "vhs-decode" \
+            --volname "decode" \
             --volicon "assets/icons/vhs-decode.icns" \
             --window-pos 200 128 \
             --window-size 600 300 \
             --icon-size 100 \
-            --icon "vhs-decode.app" 172 120 \
+            --icon "decode.app" 172 120 \
             --app-drop-link 425 128 \
             --skip-jenkins \
-            --hide-extension "vhs-decode.app" \
+            --hide-extension "decode.app" \
             "${DMG_NAME}" \
-            "dist/vhs-decode.app"
+            "dist/decode.app"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: vhs-decode_macos_${{ matrix.arch }}
+          name: decode_macos_${{ matrix.arch }}
           path: ${{ env.DMG_NAME }}
           if-no-files-found: error
       - name: Upload DMG to Release

--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -2,6 +2,7 @@ name: "Build macOS tools"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 env:
   FLALDF_FILE: "FlaLDF-v0.1-2-macos-x64.tar.gz"
@@ -9,12 +10,17 @@ env:
 
 jobs:
   build-tbc-tools:
+    timeout-minutes: 90
+    permissions:
+      contents: write
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-15-intel]
+        os: [macos-15, macos-15-intel]
         include:
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
           - os: macos-15-intel
             arch: x86_64
@@ -27,6 +33,14 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Generate version metadata
+        shell: bash
+        run: |
+          set -euxo pipefail
+          VERSION="$(python3 scripts/generate_version.py)"
+          SAFE_VERSION="$(printf '%s' "${VERSION}" | tr ':/ ' '---')"
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "SAFE_VERSION=${SAFE_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Install dependencies
         run: brew install create-dmg cmake pkg-config qt qwt ffmpeg fftw
@@ -73,25 +87,50 @@ jobs:
           BREW_PREFIX="$(brew --prefix)"
           QT_PREFIX="$(brew --prefix qt)"
           "$QT_PREFIX/bin/macdeployqt" dist/tbc-tools.app -libpath="$BREW_PREFIX/lib"
+      - name: Smoke test bundled tools
+        shell: bash
+        run: |
+          set -euxo pipefail
+          APP_BIN="dist/tbc-tools.app/Contents/MacOS/ld-analyse"
+          test -x "${APP_BIN}"
+          BIN_ARCHS="$(lipo -archs "${APP_BIN}")"
+          echo "Detected architectures: ${BIN_ARCHS}"
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            [[ "${BIN_ARCHS}" == *"x86_64"* ]]
+          else
+            [[ "${BIN_ARCHS}" == *"arm64"* ]]
+          fi
+          "${APP_BIN}" --help >/dev/null
 
       - name: Build DMG file
-        run: >-
-          create-dmg
-          --volname "tbc-tools"
-          --volicon "assets/icons/tbc-tools.icns"
-          --window-pos 200 128
-          --window-size 600 300
-          --icon-size 100
-          --icon "tbc-tools.app" 172 120
-          --app-drop-link 425 128
-          --skip-jenkins
-          --hide-extension "tbc-tools.app"
-          "tbc-tools.dmg"
-          "dist/tbc-tools.app"
+        shell: bash
+        run: |
+          set -euxo pipefail
+          DMG_NAME="tbc-tools-${SAFE_VERSION}-${{ matrix.arch }}-macos.dmg"
+          echo "DMG_NAME=${DMG_NAME}" >> "${GITHUB_ENV}"
+          create-dmg \
+            --volname "tbc-tools" \
+            --volicon "assets/icons/tbc-tools.icns" \
+            --window-pos 200 128 \
+            --window-size 600 300 \
+            --icon-size 100 \
+            --icon "tbc-tools.app" 172 120 \
+            --app-drop-link 425 128 \
+            --skip-jenkins \
+            --hide-extension "tbc-tools.app" \
+            "${DMG_NAME}" \
+            "dist/tbc-tools.app"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
           name: tbc-tools_macos_${{ matrix.arch }}
-          path: tbc-tools.dmg
+          path: ${{ env.DMG_NAME }}
           if-no-files-found: error
+      - name: Upload DMG to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.DMG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_windows_decode.yml
+++ b/.github/workflows/build_windows_decode.yml
@@ -23,12 +23,17 @@ jobs:
 
       - name: Build Python module
         run: |
+          python -m pip install --upgrade pip "setuptools<82" wheel
           pip install pyinstaller pyinstaller-versionfile
           pip install -e ".[hifi_gui_qt6]"
 
       - name: Build Windows binary
         run: |
           python .\scripts\ci\build-windows-decode-bin.py
+
+      - name: Smoke test binary startup
+        run: |
+          .\dist\decode.exe vhs --help
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build_windows_decode.yml
+++ b/.github/workflows/build_windows_decode.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-decode:
-    name: Build vhs-decode (x86_64)
+    name: Build decode (x86_64)
     runs-on: windows-2022
     env:
         SETUPTOOLS_RUST_CARGO_PROFILE: release
@@ -33,6 +33,6 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
-          name: vhs-decode_windows_x86_64
+          name: decode_windows_x86_64
           path: dist/decode.exe
           if-no-files-found: error

--- a/lddecode/__init__.py
+++ b/lddecode/__init__.py
@@ -6,15 +6,28 @@ import os
 # Read PEP-440 compliant version from version file
 # Format: base_version[+local.identifiers]
 # Examples: 7.2.0, 7.2.0+git.abc123, 7.2.0+branch.main.abc123.dirty
+def _fallback_version() -> str:
+    try:
+        from vhsdecode._version import __version__ as pkg_version
+        from vhsdecode._version import __commit_id__ as commit_id
+
+        if commit_id:
+            return f"vhs_decode:{commit_id}"
+        if pkg_version:
+            return str(pkg_version)
+    except Exception:
+        pass
+    return "unknown"
+
 try:
     _version_file = os.path.join(os.path.dirname(__file__), "version")
     if os.path.exists(_version_file):
         with open(_version_file, 'r') as f:
-            __version__ = f.read().strip()
+            __version__ = f.read().strip() or _fallback_version()
     else:
-        __version__ = "unknown"
+        __version__ = _fallback_version()
 except Exception:
-    __version__ = "unknown"
+    __version__ = _fallback_version()
 
 __all__ = [
     "audio",

--- a/lddecode/__init__.py
+++ b/lddecode/__init__.py
@@ -2,11 +2,55 @@
 # Initialisation for the lddecode package.
 
 import os
+import sys
+from pathlib import Path
 
 # Read PEP-440 compliant version from version file
 # Format: base_version[+local.identifiers]
 # Examples: 7.2.0, 7.2.0+git.abc123, 7.2.0+branch.main.abc123.dirty
+def _candidate_version_files() -> list[Path]:
+    package_dir = Path(__file__).resolve().parent
+    candidates = [package_dir / "version"]
+
+    meipass = getattr(sys, "_MEIPASS", "")
+    if meipass:
+        meipass_path = Path(meipass)
+        candidates.append(meipass_path / "lddecode" / "version")
+        candidates.append(meipass_path / "Resources" / "lddecode" / "version")
+
+    if getattr(sys, "frozen", False):
+        exe_path = Path(sys.executable).resolve()
+        candidates.append(exe_path.parent / "lddecode" / "version")
+        candidates.append(exe_path.parent.parent / "Resources" / "lddecode" / "version")
+        candidates.append(exe_path.parent.parent.parent / "Resources" / "lddecode" / "version")
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def _read_version_file() -> str:
+    for version_file in _candidate_version_files():
+        try:
+            if version_file.is_file():
+                version_text = version_file.read_text(encoding="utf-8").strip()
+                if version_text:
+                    return version_text
+        except Exception:
+            continue
+    return ""
+
+
 def _fallback_version() -> str:
+    env_version = os.environ.get("VERSION", "").strip()
+    if env_version:
+        return env_version
     try:
         from vhsdecode._version import __version__ as pkg_version
         from vhsdecode._version import __commit_id__ as commit_id
@@ -19,15 +63,8 @@ def _fallback_version() -> str:
         pass
     return "unknown"
 
-try:
-    _version_file = os.path.join(os.path.dirname(__file__), "version")
-    if os.path.exists(_version_file):
-        with open(_version_file, 'r') as f:
-            __version__ = f.read().strip() or _fallback_version()
-    else:
-        __version__ = _fallback_version()
-except Exception:
-    __version__ = _fallback_version()
+
+__version__ = _read_version_file() or _fallback_version()
 
 __all__ = [
     "audio",

--- a/lddecode/main.py
+++ b/lddecode/main.py
@@ -4,11 +4,6 @@ import sys
 import argparse
 import traceback
 import subprocess
-import numpy as np
-
-from lddecode.core import *
-from lddecode.utils import *
-from lddecode.utils_logging import init_logging
 
 
 def main(args=None):
@@ -18,6 +13,12 @@ def main(args=None):
         from lddecode import __version__
         print(__version__)
         sys.exit(0)
+
+    # Delay heavy scientific imports so `ld --version` can run even if
+    # decode/runtime dependencies are unavailable in the current environment.
+    from lddecode.core import LDdecode
+    from lddecode.utils import JSONDumper, make_loader, parse_frequency
+    from lddecode.utils_logging import init_logging
     options_epilog = """FREQ can be a bare number in MHz, or a number with one of the case-insensitive suffixes Hz, kHz, MHz, GHz, fSC (meaning NTSC) or fSCPAL."""
     parser = argparse.ArgumentParser(
         description="Extracts audio and video from raw RF laserdisc captures",
@@ -511,6 +512,8 @@ def write_input_ldf_file(ldd, output_filename, start_sample, end_sample, input_f
     Write the input samples that were decoded to a .ldf file.
     This creates a reproducible test case for bug reporting.
     """
+    import numpy as np
+    from lddecode.utils import ldf_pipe, make_loader
     print(f"\nWriting input samples to {output_filename}...", file=sys.stderr)
     print(f"  Start sample: {start_sample}", file=sys.stderr)
     print(f"  End sample: {end_sample}", file=sys.stderr)

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 import PyInstaller.__main__
 import PyInstaller.utils.osx as osxutils
 import plistlib
@@ -8,19 +10,68 @@ from shutil import move
 # debug Rust profile when invoked locally outside CI.
 os.environ.setdefault("SETUPTOOLS_RUST_CARGO_PROFILE", "release")
 
+def _ensure_lddecode_version_file() -> None:
+    version_path = Path("lddecode/version")
+    if version_path.is_file() and version_path.read_text(encoding="utf-8").strip():
+        return
+
+    version = "unknown"
+    version_script = Path("scripts/generate_version.py")
+    if version_script.is_file():
+        try:
+            version = (
+                subprocess.check_output([sys.executable, str(version_script)], text=True)
+                .strip()
+                or "unknown"
+            )
+        except Exception:
+            version = "unknown"
+
+    version_path.parent.mkdir(parents=True, exist_ok=True)
+    version_path.write_text(f"{version}\n", encoding="utf-8")
+    print(f"Wrote {version_path} = {version}")
+
+
 print("Building macOS binary version")
+_ensure_lddecode_version_file()
 
 PyInstaller.__main__.run(
     [
         "decode.py",
-        "--collect-submodules",
-        "application",
         "--collect-all",
         "vhsd_rust",
+        "--collect-all",
+        "PyQt6",
+        "--collect-all",
+        "numba",
+        "--collect-all",
+        "llvmlite",
         "--add-data",
         "vhsdecode/format_defs:vhsdecode/format_defs",
+        "--add-data",
+        "assets:assets",
+        "--hidden-import",
+        "vhsdecode.windows_bootstrap",
+        "--hidden-import",
+        "vhsdecode.decode_launcher",
+        "--hidden-import",
+        "vhsdecode.main",
+        "--hidden-import",
+        "cvbsdecode.main",
+        "--hidden-import",
+        "lddecode.main",
+        "--hidden-import",
+        "vhsdecode.hifi.main",
+        "--hidden-import",
+        "filter_tune.filter_tune",
+        "--hidden-import",
+        "numba._dispatcher",
+        "--hidden-import",
+        "numba.core.runtime._nrt_python",
         "--icon",
         "assets/icons/vhs-decode.icns",
+        "--add-data",
+        "lddecode/version:lddecode",
         "--onefile",
         "--windowed",
         "--name",

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -80,20 +80,20 @@ PyInstaller.__main__.run(
         "--onedir",
         "--windowed",
         "--name",
-        "vhs-decode",
+        "decode",
     ]
 )
-macos_dir = Path("dist/vhs-decode.app/Contents/MacOS")
-source_binary = macos_dir / "vhs-decode"
+macos_dir = Path("dist/decode.app/Contents/MacOS")
 target_binary = macos_dir / "decode"
-if source_binary.exists():
+legacy_binary = macos_dir / "vhs-decode"
+if legacy_binary.exists():
     if target_binary.exists():
         target_binary.unlink()
-    move(str(source_binary), str(target_binary))
+    move(str(legacy_binary), str(target_binary))
 elif not target_binary.exists():
-    raise FileNotFoundError(f"Expected bundled binary at {source_binary} or {target_binary}")
+    raise FileNotFoundError(f"Expected bundled binary at {target_binary} or {legacy_binary}")
 
-with Path("dist/vhs-decode.app/Contents/Info.plist").open(mode="rb+") as file:
+with Path("dist/decode.app/Contents/Info.plist").open(mode="rb+") as file:
     plist = plistlib.load(file)
 
     # update binary location
@@ -104,4 +104,4 @@ with Path("dist/vhs-decode.app/Contents/Info.plist").open(mode="rb+") as file:
     file.truncate()
 
 # re-sign
-osxutils.sign_binary("dist/vhs-decode.app", deep=True)
+osxutils.sign_binary("dist/decode.app", deep=True)

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -9,23 +9,27 @@ from shutil import move
 # Release/performance safety: never default macOS release artifacts to a
 # debug Rust profile when invoked locally outside CI.
 os.environ.setdefault("SETUPTOOLS_RUST_CARGO_PROFILE", "release")
+def _generate_build_version() -> str:
+    version_script = Path("scripts/generate_version.py")
+    if not version_script.is_file():
+        return ""
+    try:
+        return subprocess.check_output([sys.executable, str(version_script)], text=True).strip()
+    except Exception:
+        return ""
+
 
 def _ensure_lddecode_version_file() -> None:
     version_path = Path("lddecode/version")
-    if version_path.is_file() and version_path.read_text(encoding="utf-8").strip():
-        return
+    current_version = ""
+    if version_path.is_file():
+        current_version = version_path.read_text(encoding="utf-8").strip()
 
-    version = "unknown"
-    version_script = Path("scripts/generate_version.py")
-    if version_script.is_file():
-        try:
-            version = (
-                subprocess.check_output([sys.executable, str(version_script)], text=True)
-                .strip()
-                or "unknown"
-            )
-        except Exception:
-            version = "unknown"
+    generated_version = _generate_build_version()
+    version = generated_version or current_version or "unknown"
+    if current_version == version:
+        print(f"Using {version_path} = {version}")
+        return
 
     version_path.parent.mkdir(parents=True, exist_ok=True)
     version_path.write_text(f"{version}\n", encoding="utf-8")
@@ -72,14 +76,22 @@ PyInstaller.__main__.run(
         "assets/icons/vhs-decode.icns",
         "--add-data",
         "lddecode/version:lddecode",
-        "--onefile",
+        # onefile + .app is deprecated on macOS in newer PyInstaller releases.
+        "--onedir",
         "--windowed",
         "--name",
         "vhs-decode",
     ]
 )
-
-move(r"dist/vhs-decode.app/Contents/MacOS/vhs-decode", r"dist/vhs-decode.app/Contents/MacOS/decode")
+macos_dir = Path("dist/vhs-decode.app/Contents/MacOS")
+source_binary = macos_dir / "vhs-decode"
+target_binary = macos_dir / "decode"
+if source_binary.exists():
+    if target_binary.exists():
+        target_binary.unlink()
+    move(str(source_binary), str(target_binary))
+elif not target_binary.exists():
+    raise FileNotFoundError(f"Expected bundled binary at {source_binary} or {target_binary}")
 
 with Path("dist/vhs-decode.app/Contents/Info.plist").open(mode="rb+") as file:
     plist = plistlib.load(file)

--- a/scripts/ci/build-windows-decode-bin.py
+++ b/scripts/ci/build-windows-decode-bin.py
@@ -16,9 +16,9 @@ if not os.path.isdir(build_path):
 
 create_versionfile(
     output_file="build\\versionfile.txt",
-    product_name="vhs-decode",
+    product_name="decode",
     original_filename="decode.exe",
-    file_description="Software defined VHS decoder",
+    file_description="Software defined decoder",
     # version=version,
 )
 

--- a/tests/unit/test_drop_paths.py
+++ b/tests/unit/test_drop_paths.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vhsdecode.drop_paths import extract_dropped_file_paths
+
+
+class _DummyUrl:
+    def __init__(self, *, local_file: str | None = None, uri: str = ""):
+        self._local_file = local_file
+        self._uri = uri
+
+    def isLocalFile(self) -> bool:
+        return self._local_file is not None
+
+    def toLocalFile(self) -> str:
+        return self._local_file or ""
+
+    def toString(self) -> str:
+        return self._uri
+
+
+class _DummyMimeData:
+    def __init__(self, *, urls: list[_DummyUrl] | None = None, text: str = ""):
+        self._urls = urls or []
+        self._text = text
+
+    def hasUrls(self) -> bool:
+        return bool(self._urls)
+
+    def urls(self) -> list[_DummyUrl]:
+        return list(self._urls)
+
+    def hasText(self) -> bool:
+        return bool(self._text)
+
+    def text(self) -> str:
+        return self._text
+
+
+def test_extract_paths_merges_urls_and_text_and_filters_directories(tmp_path: Path):
+    rf_path = tmp_path / "capture.rf"
+    json_path = tmp_path / "params.json"
+    dropped_dir = tmp_path / "drop-folder"
+    rf_path.write_text("rf")
+    json_path.write_text("{}")
+    dropped_dir.mkdir()
+
+    mime_data = _DummyMimeData(
+        urls=[
+            _DummyUrl(local_file=str(rf_path)),
+            _DummyUrl(local_file=str(dropped_dir)),
+        ],
+        text="\n".join([rf_path.as_uri(), json_path.as_uri()]),
+    )
+
+    assert extract_dropped_file_paths(mime_data) == [str(rf_path), str(json_path)]
+
+
+def test_extract_paths_handles_uppercase_file_uri_and_clipboard_metadata(
+    tmp_path: Path,
+):
+    rf_path = tmp_path / "capture one.rf"
+    rf_path.write_text("rf")
+    uri_text = rf_path.as_uri().replace("file://", "FILE://", 1)
+    mime_data = _DummyMimeData(
+        text=f"# ignored metadata\ncopy\n\"{uri_text}\"",
+    )
+
+    assert extract_dropped_file_paths(mime_data) == [str(rf_path)]
+
+
+def test_extract_paths_handles_null_delimited_plain_text(tmp_path: Path):
+    first = tmp_path / "first.rf"
+    second = tmp_path / "second.rf"
+    first.write_text("1")
+    second.write_text("2")
+
+    mime_data = _DummyMimeData(text=f"{first}\x00{second}\x00")
+
+    assert extract_dropped_file_paths(mime_data) == [str(first), str(second)]
+
+
+def test_extract_paths_normalizes_windows_drive_file_uri():
+    mime_data = _DummyMimeData(text="file:///C:/Users/Harry/Capture%201.rf")
+
+    assert extract_dropped_file_paths(
+        mime_data,
+        os_name="nt",
+        platform="win32",
+    ) == ["C:/Users/Harry/Capture 1.rf"]
+
+
+def test_extract_paths_keeps_windows_unc_paths():
+    mime_data = _DummyMimeData(text="file://server/share/Capture%201.rf")
+
+    assert extract_dropped_file_paths(
+        mime_data,
+        os_name="nt",
+        platform="win32",
+    ) == ["//server/share/Capture 1.rf"]
+
+
+def test_extract_paths_ignores_non_file_uris(tmp_path: Path):
+    rf_path = tmp_path / "capture.rf"
+    rf_path.write_text("rf")
+    mime_data = _DummyMimeData(
+        text="\n".join(["https://example.com/capture.rf", str(rf_path)]),
+    )
+
+    assert extract_dropped_file_paths(mime_data) == [str(rf_path)]

--- a/vhsdecode/decode_launcher.py
+++ b/vhsdecode/decode_launcher.py
@@ -105,7 +105,7 @@ SYSTEM_OPTIONS_DECODE = [
     "NTSC",
     "NTSCJ",
     "PAL",
-    "PAL_M"
+    "PAL_M",
     "MESECAM",
     "405",
     "819",

--- a/vhsdecode/decode_launcher.py
+++ b/vhsdecode/decode_launcher.py
@@ -14,8 +14,9 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from vhsdecode.drop_paths import extract_dropped_file_paths
 try:
-    from PyQt6.QtCore import QTimer, QUrl, Qt, pyqtSignal
+    from PyQt6.QtCore import QTimer, Qt, pyqtSignal
     from PyQt6.QtGui import QColor, QIcon, QPalette
     from PyQt6.QtWidgets import (
         QApplication,
@@ -36,7 +37,7 @@ try:
     )
     ALIGN_TOP = Qt.AlignmentFlag.AlignTop
 except ImportError:
-    from PyQt5.QtCore import QTimer, QUrl, Qt, pyqtSignal
+    from PyQt5.QtCore import QTimer, Qt, pyqtSignal
     from PyQt5.QtGui import QColor, QIcon, QPalette
     from PyQt5.QtWidgets import (
         QApplication,
@@ -213,45 +214,7 @@ def _is_json_file_path(path: str) -> bool:
 
 
 def _extract_dropped_file_paths(mime_data) -> list[str]:
-    paths: list[str] = []
-    if mime_data is None:
-        return paths
-
-    if mime_data.hasUrls():
-        for url in mime_data.urls():
-            if not url.isLocalFile():
-                continue
-            local_path = url.toLocalFile().strip()
-            if local_path:
-                paths.append(local_path)
-
-    if not paths and mime_data.hasText():
-        raw_text = mime_data.text().strip()
-        if raw_text:
-            for line in raw_text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
-                candidate = line.strip()
-                if not candidate:
-                    continue
-                if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in {"\"", "'"}:
-                    candidate = candidate[1:-1].strip()
-                local_path = QUrl(candidate).toLocalFile() if candidate.startswith("file:") else ""
-                path = local_path or candidate
-                if path:
-                    paths.append(path)
-
-    deduped_paths: list[str] = []
-    seen: set[str] = set()
-    for path in paths:
-        expanded = str(Path(path).expanduser())
-        expanded_key = expanded.casefold() if os.name == "nt" else expanded
-        if expanded_key in seen:
-            continue
-        seen.add(expanded_key)
-        as_path = Path(expanded)
-        if as_path.exists() and as_path.is_dir():
-            continue
-        deduped_paths.append(expanded)
-    return deduped_paths
+    return extract_dropped_file_paths(mime_data)
 
 
 

--- a/vhsdecode/drop_paths.py
+++ b/vhsdecode/drop_paths.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+def _strip_wrapping_quotes(value: str) -> str:
+    trimmed = value.strip()
+    if (
+        len(trimmed) >= 2
+        and trimmed[0] == trimmed[-1]
+        and trimmed[0] in {"\"", "'"}
+    ):
+        return trimmed[1:-1].strip()
+    return trimmed
+
+
+def _is_file_uri(candidate: str) -> bool:
+    return candidate.casefold().startswith("file:")
+
+
+def _is_windows_drive_path(path: str) -> bool:
+    return len(path) >= 3 and path[1] == ":" and path[0].isalpha()
+
+
+def _file_uri_to_local_path(candidate: str, *, os_name: str) -> str | None:
+    split = urlsplit(candidate)
+    if split.scheme.casefold() != "file":
+        return None
+
+    netloc = split.netloc.strip()
+    path = unquote(split.path or split.netloc or "")
+
+    if netloc and netloc.casefold() != "localhost":
+        path = f"//{netloc}{unquote(split.path or '')}"
+
+    if os_name == "nt" and len(path) >= 3 and path[0] == "/" and _is_windows_drive_path(path[1:]):
+        path = path[1:]
+
+    return path.strip() or None
+
+
+def _iter_text_drop_candidates(raw_text: str):
+    normalized = (
+        raw_text.replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\x00", "\n")
+    )
+    for line in normalized.split("\n"):
+        candidate = _strip_wrapping_quotes(line)
+        if not candidate:
+            continue
+        lower_candidate = candidate.casefold()
+        if candidate.startswith("#"):
+            continue
+        if lower_candidate in {"copy", "cut"}:
+            continue
+        yield candidate
+
+
+def _path_dedupe_key(path: str, *, os_name: str, platform: str) -> str:
+    if os_name == "nt" or platform.startswith("darwin"):
+        return path.casefold()
+    return path
+
+
+def _paths_from_mime_urls(mime_data, *, os_name: str) -> list[str]:
+    paths: list[str] = []
+    for url in mime_data.urls():
+        local_path = ""
+        try:
+            if url.isLocalFile():
+                local_path = str(url.toLocalFile()).strip()
+        except Exception:
+            local_path = ""
+        if local_path:
+            paths.append(local_path)
+            continue
+
+        uri_candidate = ""
+        to_string = getattr(url, "toString", None)
+        if callable(to_string):
+            try:
+                uri_candidate = str(to_string()).strip()
+            except Exception:
+                uri_candidate = ""
+        local_path = (
+            _file_uri_to_local_path(uri_candidate, os_name=os_name)
+            if uri_candidate
+            else None
+        )
+        if local_path:
+            paths.append(local_path)
+    return paths
+
+
+def extract_dropped_file_paths(
+    mime_data,
+    *,
+    os_name: str | None = None,
+    platform: str | None = None,
+) -> list[str]:
+    if mime_data is None:
+        return []
+
+    os_name = os_name or os.name
+    platform = platform or sys.platform
+
+    paths: list[str] = []
+
+    if mime_data.hasUrls():
+        paths.extend(_paths_from_mime_urls(mime_data, os_name=os_name))
+
+    if mime_data.hasText():
+        raw_text = str(mime_data.text() or "")
+        for candidate in _iter_text_drop_candidates(raw_text):
+            if _is_file_uri(candidate):
+                local_path = _file_uri_to_local_path(candidate, os_name=os_name)
+                if local_path:
+                    paths.append(local_path)
+                continue
+            if "://" in candidate:
+                continue
+            paths.append(candidate)
+
+    deduped_paths: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        expanded = str(Path(path).expanduser())
+        key = _path_dedupe_key(expanded, os_name=os_name, platform=platform)
+        if key in seen:
+            continue
+        seen.add(key)
+        as_path = Path(expanded)
+        if as_path.exists() and as_path.is_dir():
+            continue
+        deduped_paths.append(expanded)
+    return deduped_paths

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -345,14 +345,23 @@ audio_processing_options_group.add_argument(
     metavar='',
     help="Manually adjust the gain/volume of the output audio. \n  1.0 [default]",
 )
+audio_mode_help_lines = []
+for mode_key, mode_description in audio_mode_to_ui.items():
+    mode_suffix = ""
+    if mode_key == DEFAULT_VHS_AUDIO_MODE:
+        mode_suffix += " [VHS default]"
+    if mode_key == DEFAULT_8MM_AUDIO_MODE:
+        mode_suffix += " [8mm default]"
+    audio_mode_help_lines.append(
+        f"  {mode_key} \t{mode_description}{mode_suffix}"
+    )
+audio_mode_help = "Audio modes \n" + "\n".join(audio_mode_help_lines)
 audio_processing_options_group.add_argument(
     "--audio_mode",
     dest="mode",
     type=str.lower,
     metavar='',
-    help=(
-        f'Audio modes \n{"\n".join([f"  {k} \t{v} {"[VHS default]" if k == DEFAULT_VHS_AUDIO_MODE else ''}{"[8mm default]" if k == DEFAULT_8MM_AUDIO_MODE else ''}" for k, v in audio_mode_to_ui.items()])}'
-    ),
+    help=audio_mode_help,
 )
 audio_processing_options_group.add_argument(
     "--audio_rate",

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -58,8 +58,15 @@ supported_tape_formats = {
 
 
 def main(args=None, use_gui=False):
-    # allows user to send SIGUSR1 via `kill -USR1 <pid>` to show a stack trace of the currently running code without killing the app
-    faulthandler.register(signal.SIGUSR1) 
+    # Allows stack-dump on Unix via `kill -USR1 <pid>` when supported.
+    # Windows does not provide SIGUSR1.
+    sigusr1 = getattr(signal, "SIGUSR1", None)
+    if sigusr1 is not None:
+        try:
+            faulthandler.register(sigusr1)
+        except (RuntimeError, ValueError, OSError):
+            # Ignore unsupported/runtime-specific registration failures and continue.
+            pass
 
     import vhsdecode.formats as f
 

--- a/vhsdecode/process.py
+++ b/vhsdecode/process.py
@@ -398,8 +398,14 @@ class VHSDecode(ldd.LDdecode):
         self.fields_written += 1
 
     def close(self):
+        if self.decodethread and self.decodethread.is_alive():
+            self.decodethread.join()
+            self.decodethread = None
         if self.rf.options.write_chroma:
             setattr(self, "outfile_chroma", None)
+
+        if self._processing_thread_pool is not None:
+            self._processing_thread_pool.shutdown(wait=True)
         super(VHSDecode, self).close()
 
     def computeMetricsPAL(self, metrics, f, fp=None):


### PR DESCRIPTION
## Summary

- harden macOS decode binary workflows, runtime path handling, and smoke diagnostics for x86_64 stability
- pin setuptools below 82 in macOS/Windows decode workflows to avoid PyInstaller runtime hook regressions
- guard Windows startup in `vhsdecode.main` (`SIGUSR1`) to prevent launch failure
- improve decode-launcher cross-platform drag-and-drop path parsing (Windows/macOS/Linux URI/text formats) with unit tests
- include TV-system stability fixes in launcher/process path handling

## Validation

- GitHub Actions: Build macOS decode (x86_64 + arm64) passing
- GitHub Actions: Build Windows decode passing with startup smoke step (`decode.exe vhs --help`)