### PR TITLE
add option to auto adjust levels using hsync to sync ratio

### DIFF
--- a/vhsdecode/field.py
+++ b/vhsdecode/field.py
@@ -1089,24 +1089,38 @@ class FieldShared:
                 return input.astype(np.single)
             else:
                 ire0 = self.rf.DecoderParams["ire0"]
-                if (
-                    self.rf.options.ire0_adjust
-                    and input.size == self.outlinecount * self.outlinelen
-                ):
-                    hsync_start, hsync_end = self.ire0_backporch
+                hz_ire = self.rf.DecoderParams["hz_ire"]
 
-                    ire0_adjust_padding = 4 # 4fsc, prevents noise around the hsync transition from interfering with this measurement
-                    hsync_start += ire0_adjust_padding
-                    hsync_end -= ire0_adjust_padding
+                if input.size == self.outlinecount * self.outlinelen:
+                    ire0_adjust_padding = 4 # 4fsc, prevents noise around the hsync transitions from interfering with this measurement
 
-                    blank_levels = np.sort([
-                        np.median(input[i * self.outlinelen + hsync_start :
-                                        i * self.outlinelen + hsync_end])
-                        for i in range(0, self.outlinecount)
-                    ])
-                    ire0 = np.mean(blank_levels[self.outlinecount // 3 : (self.outlinecount * 2) // 3])
+                    if "backporch" in self.rf.options.ire0_adjust:
+                        backporch_start = self.ire0_backporch[0] + ire0_adjust_padding
+                        backporch_end = self.ire0_backporch[1] - ire0_adjust_padding
+                        blank_levels = np.sort([
+                            np.median(input[i * self.outlinelen + backporch_start :
+                                            i * self.outlinelen + backporch_end])
+                            for i in range(0, self.outlinecount)
+                        ])
+                        ire0 = np.mean(blank_levels[self.outlinecount // 3 : (self.outlinecount * 2) // 3])
 
-                    ldd.logger.debug("calculated ire0: %.02f", ire0)
+                        ldd.logger.debug("calculated ire0: %.02f", ire0)
+
+                    if "hsync" in self.rf.options.ire0_adjust:
+                        # measure the hsync pulse level
+                        hsync_start = ire0_adjust_padding
+                        hsync_end = self.ire0_backporch[0] - ire0_adjust_padding
+                        hsync_levels = np.sort([
+                            np.median(input[i * self.outlinelen + hsync_start :
+                                            i * self.outlinelen + hsync_end])
+                            for i in range(0, self.outlinecount)
+                        ])
+                        hsync_level = np.mean(hsync_levels[self.outlinecount // 3 : (self.outlinecount * 2) // 3])
+
+                        # calculate scaling based difference between hsync pulse and ire0
+                        hz_ire = (ire0 - hsync_level) / -self.rf.DecoderParams["vsync_ire"]
+
+                        ldd.logger.debug("calculated hz_ire: %.02f", hz_ire)
 
                 if self.rf.track_phase is not None:
                     ire0 += self.rf.DecoderParams["track_ire0_offset"][self.rf.track_phase ^ (self.field_number % 2)]
@@ -1114,7 +1128,7 @@ class FieldShared:
                 return hz_to_output_array(
                     input,
                     ire0,
-                    self.rf.DecoderParams["hz_ire"],
+                    hz_ire,
                     self.rf.SysParams["outputZero"],
                     self.rf.DecoderParams["vsync_ire"],
                     self.out_scale,

--- a/vhsdecode/main.py
+++ b/vhsdecode/main.py
@@ -133,9 +133,22 @@ def main(args=None, use_gui=False):
     luma_group.add_argument(
         "--ire0_adjust",
         dest="ire0_adjust",
-        action="store_true",
+        nargs="?",
+        const="backporch",
         default=False,
-        help="Automatic adjust of ire0 based blanking level",
+        type=lambda v: (
+            v.lower()
+            if all(p.strip().lower() in {"hsync", "backporch"} for p in v.split(","))
+            else (_ for _ in ()).throw(
+                argparse.ArgumentTypeError("Allowed values: hsync, backporch")
+            )
+        ),
+        help=(
+            "Automatically adjust video levels after vsync and TBC."
+            "\nAdd this flag with no arguments for the default, or supply one or more of the below options as a comma separated string. "
+            "\n  backporch [default] adjusts the black level based on the backporch level"
+            "\n  hsync               adjusts the level scaling based on the measured hsync / backporch ratio. This can correct automatic gain control issues with second generation tapes."
+        )
     )
     luma_group.add_argument(
         "--high_boost",


### PR DESCRIPTION
### Description

Adds optional functionality to `--ire0_adjust` that fixes brightness variations caused by automatic gain control.

### Motivation

Some VCRs have automatic gain control that change the video levels of the source before recording to tape. When decoding a tape that had AGC enabled and active, this can result in sudden changes in amount of frequency deviation assigned to 1 IRE unit. This visually appears as sudden overall brightness changes.

This change automatically corrects levels on a per-field basis using the measured ratio between the hsync pulse levels and the black level so the video maintains a consistent brightness.

### Changes Made

<!--
List the key changes made in this pull request.
-->

- Add optional arguments to the `--ire0_adjust` option
  * `backporch` What `ire0_adjust` uses currently, and is defaulted when `--ire0_adjust` is supplied without an argument
  * `hsync` The new level correction that uses the ratio between the hsync pulse and the black level
