### PR TITLE
Fix lddecode package data missing in dists and standalone runnables.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ git_describe_command = "git describe --dirty --tags --long --match [0-9]* --matc
 tag_regex = '^(?:v)?(?P<version>\d+(?:\.\d+)*(?:(?:a|b|rc)\d*)?)$'
 
 [tool.setuptools.package-data]
-vhs_decode = ["*.txt", "py.typed", "version", "sinc_lut.npz"]
+vhs_decode = ["*.txt"]
+lddecode = ["py.typed", "version", "sinc_lut.npz"]
 
 [tool.black]
 line-length = 100

--- a/scripts/ci/build-macos-decode-bin.py
+++ b/scripts/ci/build-macos-decode-bin.py
@@ -52,6 +52,8 @@ PyInstaller.__main__.run(
         "llvmlite",
         "--add-data",
         "vhsdecode/format_defs:vhsdecode/format_defs",
+        "--collect-data",
+        "lddecode",
         "--add-data",
         "assets:assets",
         "--hidden-import",

--- a/scripts/ci/build-windows-decode-bin.py
+++ b/scripts/ci/build-windows-decode-bin.py
@@ -66,6 +66,8 @@ PyInstaller.__main__.run(
         "vhsd_rust",
         "--add-data",
         "vhsdecode/format_defs;vhsdecode/format_defs",
+        "--collect-data",
+        "lddecode",
         "--collect-all",
         "PyQt6",
         "--collect-all",


### PR DESCRIPTION
### Checklist

<!--
✅ Please make sure that you have completed the following steps before submitting the pull request:
-->

- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
New package data for the `lddecode` package was introduced when upstream commits were merged via 536efc133c96b0f269a224fedf85327878c1f183. However, the data files were added in pyproject.toml for the `vhs_decode` package instead, where they don't live and aren't referenced. This probably happened as a result of conflict resolution because both projects had updated pyproject.toml's package data directives recently.

In addition, because upstream ld-decode project doesn't have PyInstaller standalones, the data wasn't incorporated in our PyInstaller builds.
<!--
Provide a clear and concise description of the changes in this pull request.
-->

### Motivation
To fix the sdist, wheels, and executables to be able to find that new sinc LUT artifact when a decode starts.

### Changes Made
- Re-split data files between `lddecode` and `vhs_decode` packages in pyproject.toml, honoring original intent from both parents of the original merge.
- Add `lddecode` to the data files search path in PyInstaller bin/bundle construction.

### Testing
Wheels and PyInstaller .app created and tested on arm64 macOS.
- [x] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with: lddecode against Harry's S-VHS test lds.<!-- describe your test case -->
- [ ] New tests added for: <!-- describe what was tested, or N/A -->