### PR TITLE
Fix missing filter_tune and cx-expander breaking sdist buildability.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,10 +15,10 @@ exclude .flake8
 exclude vcpkg*
 exclude ld-ldf-reader.c
 prune .github
-prune filter_tune
 prune tools
 prune notebooks
 prune scripts
+include scripts/cx-expander
 prune vhs_scripts
 prune cmake_modules
 prune docs


### PR DESCRIPTION
Our source distribution (sdist) is no longer buildable to a wheel due to some referenced code being missing.

### Checklist

<!--
✅ Please make sure that you have completed the following steps before submitting the pull request:
-->

- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
filter_tune from ld-decode was given an entry point in ef6b2be387cd629a9a3f63f741b84727f1e6b5a7 but never restored in our `MANIFEST.in` script entry point `cx-expander` was moved to `scripts` dir in 84ca63775f7447beb1b48f868d2072fc5253a3fe, but that whole `scripts` dir was already excluded in MANIFEST.in.

### Motivation
If our wheels get out of date for users' environments, they should be able to rely upon being able to build a runnable version of the project tools using the source distribution (sdist).

### Changes Made
This PR ensures both the filter_tune and cx-expander code is included in the source distribution so that they're available for the final wheel.

### Testing
- [X] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with: Harry's S-VHS lds sample
- [ ] New tests added for: <!-- describe what was tested, or N/A -->