### PR TITLE
hifi-decode: long FLAC fix, 12-bit FLAC support, and GUI input/UX improvements

### DIFF
--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -1,9 +1,12 @@
 import os.path
 import sys
 import math
+from multiprocessing import cpu_count
 from pathlib import Path
 
 import numpy as np
+
+from vhsdecode.hifi.utils import parse_flac_streaminfo
 
 try:
     from PyQt6.QtGui import QIcon
@@ -117,6 +120,51 @@ PLAY_STATE = 1
 PAUSE_STATE = 2
 PREVIEW_STATE = 3
 
+_SPINBOX_ARROW_CACHE = {}
+
+
+def _spinbox_arrow_icon_path(direction: str, color: str = "#eeeeee") -> str:
+    """Render a small arrow to a PNG for use in the stylesheet.
+
+    Qt's stylesheet engine has no reliable way to draw triangles, so the
+    up/down spin box arrows are rendered to temp images once per process.
+    Requires a QApplication to exist.
+    """
+    cache_key = (direction, color)
+    cached = _SPINBOX_ARROW_CACHE.get(cache_key)
+    if cached and os.path.isfile(cached):
+        return cached
+
+    import tempfile
+
+    width, height = 8, 5
+    pixmap = QtGui.QPixmap(width, height)
+    pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(pixmap)
+    painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
+    painter.setBrush(QtGui.QColor(color))
+    painter.setPen(QtCore.Qt.PenStyle.NoPen)
+    if direction == "up":
+        points = [
+            QtCore.QPoint(0, height),
+            QtCore.QPoint(width, height),
+            QtCore.QPoint(width // 2, 0),
+        ]
+    else:
+        points = [
+            QtCore.QPoint(0, 0),
+            QtCore.QPoint(width, 0),
+            QtCore.QPoint(width // 2, height),
+        ]
+    painter.drawPolygon(QtGui.QPolygon(points))
+    painter.end()
+
+    fd, path = tempfile.mkstemp(prefix=f"hifi_spin_{direction}_", suffix=".png")
+    os.close(fd)
+    pixmap.save(path, "PNG")
+    _SPINBOX_ARROW_CACHE[cache_key] = path
+    return path
+
 
 class MainUIParameters:
     def __init__(self):
@@ -124,7 +172,11 @@ class MainUIParameters:
         self.normalize = False
         self.expander_gain: float = DEFAULT_VHS_EXPANDER_GAIN
         self.expander_ratio: float = DEFAULT_VHS_EXPANDER_RATIO
-        self.expander_env_detection = DEFAULT_ENV_DETECTION
+        # UI label, not the internal constant (the combos and the
+        # ui_to_* lookups in ui_parameters_to_decode_options expect labels)
+        self.expander_env_detection = expander_env_detection_to_ui[
+            DEFAULT_ENV_DETECTION
+        ]
         self.expander_attack_tau: float = DEFAULT_VHS_EXPANDER_ATTACK_TAU
         self.expander_hold_tau: float = DEFAULT_VHS_EXPANDER_HOLD_TAU
         self.expander_release_tau: float = DEFAULT_VHS_EXPANDER_RELEASE_TAU
@@ -151,12 +203,15 @@ class MainUIParameters:
         self.audio_mode: str = audio_mode_to_ui[DEFAULT_VHS_AUDIO_MODE]
         self.resampler_quality = DEFAULT_RESAMPLER_QUALITY
         self.demod_type: str = DEFAULT_DEMOD.capitalize()
-        self.input_sample_rate: float = 40.0
+        # in Hz: setValues() converts to MHz for display (matches the
+        # decode_options "input_rate" value this field mirrors)
+        self.input_sample_rate: float = 40.0e6
         self.input_file: str = ""
         self.output_file: str = ""
         # bool: setChecked() requires a bool (PyQt6 rejects the old "on" str)
         self.head_switching_interpolation = True
-        self.doc = DEFAULT_DOC_MODE
+        self.doc = doc_mode_to_ui[DEFAULT_DOC_MODE]
+        self.threads: int = cpu_count()
 
 
 def decode_options_to_ui_parameters(decode_options):
@@ -196,6 +251,7 @@ def decode_options_to_ui_parameters(decode_options):
     values.output_file = decode_options["output_file"]
     values.head_switching_interpolation = decode_options["head_switching_interpolation"]
     values.doc = doc_mode_to_ui[decode_options["doc"]]
+    values.threads = decode_options.get("threads", values.threads)
     return values
 
 
@@ -236,7 +292,8 @@ def ui_parameters_to_decode_options(values: MainUIParameters):
         "resampler_quality": values.resampler_quality,
         "head_switching_interpolation": values.head_switching_interpolation,
         "doc": ui_to_doc_mode[values.doc],
-        "mode": ui_to_audio_mode[values.audio_mode]
+        "mode": ui_to_audio_mode[values.audio_mode],
+        "threads": max(1, int(values.threads)),
     }
     return decode_options
 
@@ -367,13 +424,12 @@ class HifiUi(QMainWindow):
         self.build_plot_window()
 
         # Apply dark theme with improved text visibility
-        self.setStyleSheet(
-            """
+        stylesheet = """
             QMainWindow {
                 background-color: #333;
                 color: #eee;
             }
-            QDial, QLineEdit, QCheckBox, QComboBox, QPushButton {
+            QDial, QLineEdit, QCheckBox, QComboBox, QPushButton, QSpinBox {
                 background-color: #555;
                 color: #eee;
                 border: 1px solid #777;
@@ -391,10 +447,34 @@ class HifiUi(QMainWindow):
                 background-color: #555;
                 color: #eee;
             }
+            QSpinBox::up-button, QSpinBox::down-button {
+                background-color: #666;
+                border: 1px solid #777;
+                width: 14px;
+            }
+            QSpinBox::up-button:hover, QSpinBox::down-button:hover {
+                background-color: #777;
+            }
+            QSpinBox::up-arrow {
+                image: url(__UP_ARROW__);
+                width: 8px;
+                height: 5px;
+            }
+            QSpinBox::down-arrow {
+                image: url(__DOWN_ARROW__);
+                width: 8px;
+                height: 5px;
+            }
             QLabel {
                 color: #eee;
             }
         """
+        up_arrow = _spinbox_arrow_icon_path("up").replace("\\", "/")
+        down_arrow = _spinbox_arrow_icon_path("down").replace("\\", "/")
+        self.setStyleSheet(
+            stylesheet.replace("__UP_ARROW__", up_arrow).replace(
+                "__DOWN_ARROW__", down_arrow
+            )
         )
         self.change_button_color(self.stop_button, "#eee")
         # disables maximize button
@@ -516,6 +596,20 @@ class HifiUi(QMainWindow):
             self.on_input_samplerate_changed
         )
         input_options_frame.inner_layout.addLayout(input_samplerate_layout)
+
+        # decode thread count
+        threads_layout = QHBoxLayout()
+        threads_label = QLabel("Decode Threads")
+        self.threads_spinbox = QSpinBox(self)
+        self.threads_spinbox.setMinimum(1)
+        self.threads_spinbox.setMaximum(256)
+        self.threads_spinbox.setValue(cpu_count())
+        self.threads_spinbox.setToolTip(
+            f"Number of CPU threads to use for decoding ({cpu_count()} available on this machine)"
+        )
+        threads_layout.addWidget(threads_label)
+        threads_layout.addWidget(self.threads_spinbox)
+        input_options_frame.inner_layout.addLayout(threads_layout)
 
         return layout
 
@@ -1008,6 +1102,8 @@ class HifiUi(QMainWindow):
             self.demod_type_combo.findText(values.demod_type)
         )
 
+        self.threads_spinbox.setValue(max(1, int(values.threads)))
+
         self.input_sample_rate = values.input_sample_rate / 1e6
         found_rate = False
         for i, rate in enumerate(self._input_combo_rates):
@@ -1081,6 +1177,7 @@ class HifiUi(QMainWindow):
         values.input_sample_rate = self.input_sample_rate
         values.input_file = self.input_file
         values.output_file = self.output_file
+        values.threads = self.threads_spinbox.value()
         return values
 
     def update_afe_values(
@@ -1243,7 +1340,24 @@ class HifiUi(QMainWindow):
         print("[STOP] Stop command issued.")
         self._transport_state = STOP_STATE
 
+    def set_input_sample_rate_mhz(self, mhz: float):
+        """Set the input sample rate, selecting a matching preset when one
+        exists, otherwise showing it as "Other (X)"."""
+        self.input_sample_rate = mhz
+        for i, rate in enumerate(self._input_combo_rates):
+            if abs((rate - mhz) * 1e6) < 5000:
+                self.input_samplerate_combo.setCurrentIndex(i)
+                # use the preset value so the displayed selection and the
+                # rate used for decoding always match
+                self.input_sample_rate = rate
+                return
+        self.input_samplerate_combo.setPlaceholderText(f"Other ({mhz:g})")
+        self.input_samplerate_combo.setCurrentIndex(-1)
+
     def on_input_samplerate_changed(self):
+        if self.input_samplerate_combo.currentIndex() < 0:
+            # placeholder ("Other (X)") is showing, rate was set directly
+            return
         print("Input sample rate changed.")
         if "Other" in self.input_samplerate_combo.currentText():
             input_dialog = InputDialog(
@@ -1583,10 +1697,30 @@ class FileIODialogUI(HifiUi):
             self.file_output_textbox.setText(derived)
             print(f"Output file auto set to: {derived}")
 
+    def auto_set_input_frequency(self, input_path: str):
+        """Initialize the input sample rate from a FLAC capture's header.
+
+        RF FLAC captures store the capture rate in kHz (e.g. MISRC writes
+        40000 for 40 MSps) because the STREAMINFO field cannot hold MHz
+        rates.
+        """
+        if not input_path.lower().endswith(".flac"):
+            return
+        streaminfo = parse_flac_streaminfo(input_path)
+        if streaminfo is None or streaminfo["sample_rate"] <= 0:
+            return
+        mhz = streaminfo["sample_rate"] / 1000.0
+        if not 1.0 <= mhz <= 200.0:
+            # does not look like an RF capture rate, leave the setting alone
+            return
+        self.set_input_sample_rate_mhz(mhz)
+        print(f"Input sample rate auto set to {mhz:g} MHz from the FLAC header")
+
     def set_input_file(self, file_name: str):
         self.file_input_textbox.setText(file_name)
         self._last_input_path = file_name
         self.auto_populate_output_file(file_name)
+        self.auto_set_input_frequency(file_name)
 
     def on_input_editing_finished(self):
         # auto fill the output when the user typed/pasted a new input path
@@ -1594,6 +1728,7 @@ class FileIODialogUI(HifiUi):
         if text and text != self._last_input_path:
             self._last_input_path = text
             self.auto_populate_output_file(text)
+            self.auto_set_input_frequency(text)
 
     def dragEnterEvent(self, event):
         mime_data = event.mimeData()

--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -154,7 +154,8 @@ class MainUIParameters:
         self.input_sample_rate: float = 40.0
         self.input_file: str = ""
         self.output_file: str = ""
-        self.head_switching_interpolation = "on"
+        # bool: setChecked() requires a bool (PyQt6 rejects the old "on" str)
+        self.head_switching_interpolation = True
         self.doc = DEFAULT_DOC_MODE
 
 
@@ -1502,6 +1503,8 @@ class CollapsableSection(QVBoxLayout):
 
 
 class FileIODialogUI(HifiUi):
+    OUTPUT_FILE_SUFFIX = "_HiFi_Decoded.flac"
+
     def __init__(
         self,
         params: MainUIParameters,
@@ -1509,11 +1512,23 @@ class FileIODialogUI(HifiUi):
         main_layout_callback=None,
     ):
         super(FileIODialogUI, self).__init__(params, title, self._layout_callback)
+        # accept files dragged from a file manager anywhere on the window
+        self.setAcceptDrops(True)
 
     def _layout_callback(self, main_layout):
         # Add file input widgets
         self.file_input_label = QLabel("Input file")
         self.file_input_textbox = QLineEdit(self)
+        self.file_input_textbox.setPlaceholderText(
+            "Select, type or drag && drop the RF capture file here"
+        )
+        # let drops fall through to the window-level drop handler instead of
+        # QLineEdit pasting a file:// url as plain text
+        self.file_input_textbox.setAcceptDrops(False)
+        self.file_input_textbox.editingFinished.connect(
+            self.on_input_editing_finished
+        )
+        self._last_input_path = ""
         self.file_input_button = QPushButton("Browse", self)
         self.file_input_button.clicked.connect(self.on_file_input_button_clicked)
         self.file_input_layout = QHBoxLayout()
@@ -1554,6 +1569,53 @@ class FileIODialogUI(HifiUi):
         self.file_input_label.setMinimumWidth(max_label_width)
         self.file_output_label.setMinimumWidth(max_label_width)
 
+    @staticmethod
+    def derive_output_file(input_path: str) -> str:
+        """Build <input dir>/<input basename>_HiFi_Decoded.flac"""
+        root, _ = os.path.splitext(input_path)
+        return f"{root}{FileIODialogUI.OUTPUT_FILE_SUFFIX}"
+
+    def auto_populate_output_file(self, input_path: str):
+        if not input_path:
+            return
+        derived = FileIODialogUI.derive_output_file(input_path)
+        if self.file_output_textbox.text() != derived:
+            self.file_output_textbox.setText(derived)
+            print(f"Output file auto set to: {derived}")
+
+    def set_input_file(self, file_name: str):
+        self.file_input_textbox.setText(file_name)
+        self._last_input_path = file_name
+        self.auto_populate_output_file(file_name)
+
+    def on_input_editing_finished(self):
+        # auto fill the output when the user typed/pasted a new input path
+        text = self.file_input_textbox.text()
+        if text and text != self._last_input_path:
+            self._last_input_path = text
+            self.auto_populate_output_file(text)
+
+    def dragEnterEvent(self, event):
+        mime_data = event.mimeData()
+        if mime_data.hasUrls() and any(
+            url.isLocalFile() for url in mime_data.urls()
+        ):
+            event.acceptProposedAction()
+            return
+        event.ignore()
+
+    def dropEvent(self, event):
+        for url in event.mimeData().urls():
+            if not url.isLocalFile():
+                continue
+            path = url.toLocalFile()
+            if os.path.isfile(path):
+                self.set_input_file(path)
+                print(f"Input file set by drag and drop: {path}")
+                event.acceptProposedAction()
+                return
+        event.ignore()
+
     def on_file_input_button_clicked(self):
         qdialog = QFileDialog(self)
         qdialog.setFileMode(QFileDialog.FileMode.AnyFile)
@@ -1564,7 +1626,7 @@ class FileIODialogUI(HifiUi):
         )
 
         if os.path.exists(file_name):
-            self.file_input_textbox.setText(file_name)
+            self.set_input_file(file_name)
         print("Input browse button clicked.")
 
     def on_file_output_button_clicked(self):
@@ -1588,7 +1650,11 @@ class FileIODialogUI(HifiUi):
     def setValues(self, values: MainUIParameters):
         super(FileIODialogUI, self).setValues(values)
         self.file_input_textbox.setText(values.input_file)
+        self._last_input_path = values.input_file
         self.file_output_textbox.setText(values.output_file)
+        # an input was provided without an output: derive the output name
+        if values.input_file and not values.output_file:
+            self.auto_populate_output_file(values.input_file)
 
     def on_decode_finished(self, decoded_filename: str = "input stream"):
         decoded_filename = os.path.basename(self.file_input_textbox.text())

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -36,6 +36,9 @@ from vhsdecode.hifi.utils import (
     PeakGain,
     BLOCK_DTYPE,
     REAL_DTYPE,
+    FLAC_TOTAL_SAMPLES_FIELD_MOD,
+    check_flac_header_total_samples,
+    parse_flac_streaminfo,
 )
 
 import argparse
@@ -668,139 +671,6 @@ class FlacFileReader(BufferedInputStream):
         )
         self.buffer = p.stdout
         self._pos: int = 0
-
-
-# The STREAMINFO total_samples field is 36 bits wide, so captures longer than
-# 2^36 samples (~28.6 minutes at 40 MSps) overflow it and the stored count
-# wraps around modulo 2^36. libsndfile trusts this count and stops reading
-# there, truncating the decode. See parse_flac_streaminfo() below.
-FLAC_TOTAL_SAMPLES_FIELD_MOD = 2**36
-
-
-def parse_flac_streaminfo(file_path):
-    """Parse the FLAC STREAMINFO metadata block directly from the file.
-
-    Returns a dict with the STREAMINFO fields and the offset where the
-    audio frames start, or None if the file could not be parsed as FLAC.
-    """
-    try:
-        with open(file_path, "rb") as f:
-            if f.read(4) != b"fLaC":
-                return None
-
-            streaminfo = None
-            audio_offset = None
-            while True:
-                header = f.read(4)
-                if len(header) != 4:
-                    return None
-                is_last = bool(header[0] & 0x80)
-                block_type = header[0] & 0x7F
-                length = int.from_bytes(header[1:4], "big")
-
-                if block_type == 0 and streaminfo is None:
-                    data = f.read(length)
-                    if len(data) < 34:
-                        return None
-                    streaminfo = data
-                else:
-                    f.seek(length, io.SEEK_CUR)
-
-                if is_last:
-                    audio_offset = f.tell()
-                    break
-
-            if streaminfo is None or audio_offset is None:
-                return None
-
-            d = streaminfo
-            return {
-                "min_blocksize": int.from_bytes(d[0:2], "big"),
-                "max_blocksize": int.from_bytes(d[2:4], "big"),
-                "min_framesize": int.from_bytes(d[4:7], "big"),
-                "max_framesize": int.from_bytes(d[7:10], "big"),
-                "sample_rate": (d[10] << 12) | (d[11] << 4) | (d[12] >> 4),
-                "channels": ((d[12] >> 1) & 0x7) + 1,
-                "bits_per_sample": (((d[12] & 1) << 4) | (d[13] >> 4)) + 1,
-                "total_samples": ((d[13] & 0xF) << 32)
-                | int.from_bytes(d[14:18], "big"),
-                "audio_offset": audio_offset,
-            }
-    except OSError:
-        return None
-
-
-def check_flac_header_total_samples(streaminfo, file_size):
-    """Check whether the STREAMINFO total_samples count can be trusted.
-
-    A FLAC frame stores at most max_framesize bytes for at least
-    min_blocksize samples, so `total_samples` samples can never occupy more
-    than (total_samples / min_blocksize + 1) * max_framesize bytes of audio
-    payload. If the file holds substantially more audio data than that, the
-    36 bit total_samples field overflowed and wrapped (or was never
-    finalized), and the header length must not be trusted.
-
-    Returns (header_is_trustworthy, corrected_total_samples or None).
-    """
-    declared = streaminfo["total_samples"]
-    audio_bytes = file_size - streaminfo["audio_offset"]
-
-    if audio_bytes <= 0:
-        return True, None
-
-    if declared == 0:
-        # length marked as unknown (e.g. the encoder could not seek back to
-        # finalize the header)
-        return False, None
-
-    min_blocksize = streaminfo["min_blocksize"]
-    max_blocksize = streaminfo["max_blocksize"]
-    min_framesize = streaminfo["min_framesize"]
-    max_framesize = streaminfo["max_framesize"]
-
-    if min_blocksize > 0 and max_framesize > 0:
-        # largest possible payload for the declared sample count
-        declared_max_bytes = (declared // min_blocksize + 1) * max_framesize
-    else:
-        # min/max frame sizes may legally be 0 (unknown), fall back to the
-        # verbatim worst case (uncompressed samples) plus generous margin
-        declared_max_bytes = (
-            int(
-                declared
-                * streaminfo["channels"]
-                * (streaminfo["bits_per_sample"] / 8)
-                * 1.05
-            )
-            + 65536
-        )
-
-    if audio_bytes <= declared_max_bytes:
-        return True, None
-
-    # the header count is impossibly small for the amount of audio data in
-    # the file: it wrapped modulo 2^36. try to recover the true count using
-    # the frame size statistics, accepting it only if exactly one candidate
-    # fits between the possible payload bounds
-    corrected = None
-    if (
-        min_blocksize > 0
-        and max_blocksize > 0
-        and min_framesize > 0
-        and max_framesize > 0
-    ):
-        lower = audio_bytes / max_framesize * min_blocksize
-        upper = audio_bytes / min_framesize * max_blocksize
-        candidates = []
-        k = 1
-        while declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD <= upper:
-            candidate = declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD
-            if candidate >= lower:
-                candidates.append(candidate)
-            k += 1
-        if len(candidates) == 1:
-            corrected = candidates[0]
-
-    return False, corrected
 
 
 # executes ffmpeg and reads stdout as a file
@@ -2716,6 +2586,7 @@ def build_decode_options_from_args(args):
         "input_file": filename,
         "output_file": outname,
         "mode": real_mode,
+        "threads": args.threads,
     }
 
     return decode_options, real_mode
@@ -2726,6 +2597,8 @@ def _run_ui_transport_action(args, ui_t):
     options = ui_parameters_to_decode_options(ui_t.window.getValues())
     previous_state = ui_t.window.transport_state
     options["preview"] = previous_state == PREVIEW_STATE
+    # apply the thread count chosen in the UI (run_decoder reads args.threads)
+    args.threads = max(1, int(options.get("threads", args.threads)))
 
     working_directory = os.getcwd()
     try:

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1014,10 +1014,42 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                 print(
                     "WARN: Neither flac nor ffmpeg is installed (or in PATH). The decode will stop early at the wrapped header sample count!"
                 )
-        return sf.SoundFile(
-            pathR,
-            "r",
-        )
+        try:
+            return sf.SoundFile(
+                pathR,
+                "r",
+            )
+        except sf.LibsndfileError as e:
+            # libsndfile only implements FLAC bit depths 8/16/24/32. Native
+            # 12-bit FLAC captures (e.g. MISRC) fail to open with
+            # "unimplemented format"; ffmpeg decodes them fine and emits
+            # 16-bit left-aligned samples (value << 4), bit-identical to the
+            # same capture padded to 16 bits at record time.
+            if streaminfo is None:
+                raise
+            print(f"WARN: libsndfile could not open this FLAC file: {e}")
+            print(
+                f"WARN: FLAC stream is {streaminfo['bits_per_sample']}-bit "
+                f"({streaminfo['channels']} channel(s))."
+            )
+            if test_if_ffmpeg_is_installed():
+                print(
+                    "WARN: Decoding through ffmpeg instead (16-bit left-aligned output)."
+                )
+                return UnseekableSoundFile(
+                    FFMpegFileReader(pathR),
+                    "r",
+                    channels=streaminfo["channels"],
+                    samplerate=int(sample_rate),
+                    format="RAW",
+                    subtype="PCM_16",
+                    endian="LITTLE",
+                    frames_override=streaminfo["total_samples"] or None,
+                )
+            print(
+                "ERROR: ffmpeg is not installed (or not in PATH), cannot decode this FLAC bit depth."
+            )
+            raise
     elif "ldf" == extension:
         try:
             for ldf_reader_tool in ("ld-ldf-reader", "ld-ldf-reader-py"):

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -670,6 +670,139 @@ class FlacFileReader(BufferedInputStream):
         self._pos: int = 0
 
 
+# The STREAMINFO total_samples field is 36 bits wide, so captures longer than
+# 2^36 samples (~28.6 minutes at 40 MSps) overflow it and the stored count
+# wraps around modulo 2^36. libsndfile trusts this count and stops reading
+# there, truncating the decode. See parse_flac_streaminfo() below.
+FLAC_TOTAL_SAMPLES_FIELD_MOD = 2**36
+
+
+def parse_flac_streaminfo(file_path):
+    """Parse the FLAC STREAMINFO metadata block directly from the file.
+
+    Returns a dict with the STREAMINFO fields and the offset where the
+    audio frames start, or None if the file could not be parsed as FLAC.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            if f.read(4) != b"fLaC":
+                return None
+
+            streaminfo = None
+            audio_offset = None
+            while True:
+                header = f.read(4)
+                if len(header) != 4:
+                    return None
+                is_last = bool(header[0] & 0x80)
+                block_type = header[0] & 0x7F
+                length = int.from_bytes(header[1:4], "big")
+
+                if block_type == 0 and streaminfo is None:
+                    data = f.read(length)
+                    if len(data) < 34:
+                        return None
+                    streaminfo = data
+                else:
+                    f.seek(length, io.SEEK_CUR)
+
+                if is_last:
+                    audio_offset = f.tell()
+                    break
+
+            if streaminfo is None or audio_offset is None:
+                return None
+
+            d = streaminfo
+            return {
+                "min_blocksize": int.from_bytes(d[0:2], "big"),
+                "max_blocksize": int.from_bytes(d[2:4], "big"),
+                "min_framesize": int.from_bytes(d[4:7], "big"),
+                "max_framesize": int.from_bytes(d[7:10], "big"),
+                "sample_rate": (d[10] << 12) | (d[11] << 4) | (d[12] >> 4),
+                "channels": ((d[12] >> 1) & 0x7) + 1,
+                "bits_per_sample": (((d[12] & 1) << 4) | (d[13] >> 4)) + 1,
+                "total_samples": ((d[13] & 0xF) << 32)
+                | int.from_bytes(d[14:18], "big"),
+                "audio_offset": audio_offset,
+            }
+    except OSError:
+        return None
+
+
+def check_flac_header_total_samples(streaminfo, file_size):
+    """Check whether the STREAMINFO total_samples count can be trusted.
+
+    A FLAC frame stores at most max_framesize bytes for at least
+    min_blocksize samples, so `total_samples` samples can never occupy more
+    than (total_samples / min_blocksize + 1) * max_framesize bytes of audio
+    payload. If the file holds substantially more audio data than that, the
+    36 bit total_samples field overflowed and wrapped (or was never
+    finalized), and the header length must not be trusted.
+
+    Returns (header_is_trustworthy, corrected_total_samples or None).
+    """
+    declared = streaminfo["total_samples"]
+    audio_bytes = file_size - streaminfo["audio_offset"]
+
+    if audio_bytes <= 0:
+        return True, None
+
+    if declared == 0:
+        # length marked as unknown (e.g. the encoder could not seek back to
+        # finalize the header)
+        return False, None
+
+    min_blocksize = streaminfo["min_blocksize"]
+    max_blocksize = streaminfo["max_blocksize"]
+    min_framesize = streaminfo["min_framesize"]
+    max_framesize = streaminfo["max_framesize"]
+
+    if min_blocksize > 0 and max_framesize > 0:
+        # largest possible payload for the declared sample count
+        declared_max_bytes = (declared // min_blocksize + 1) * max_framesize
+    else:
+        # min/max frame sizes may legally be 0 (unknown), fall back to the
+        # verbatim worst case (uncompressed samples) plus generous margin
+        declared_max_bytes = (
+            int(
+                declared
+                * streaminfo["channels"]
+                * (streaminfo["bits_per_sample"] / 8)
+                * 1.05
+            )
+            + 65536
+        )
+
+    if audio_bytes <= declared_max_bytes:
+        return True, None
+
+    # the header count is impossibly small for the amount of audio data in
+    # the file: it wrapped modulo 2^36. try to recover the true count using
+    # the frame size statistics, accepting it only if exactly one candidate
+    # fits between the possible payload bounds
+    corrected = None
+    if (
+        min_blocksize > 0
+        and max_blocksize > 0
+        and min_framesize > 0
+        and max_framesize > 0
+    ):
+        lower = audio_bytes / max_framesize * min_blocksize
+        upper = audio_bytes / min_framesize * max_blocksize
+        candidates = []
+        k = 1
+        while declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD <= upper:
+            candidate = declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD
+            if candidate >= lower:
+                candidates.append(candidate)
+            k += 1
+        if len(candidates) == 1:
+            corrected = candidates[0]
+
+    return False, corrected
+
+
 # executes ffmpeg and reads stdout as a file
 class FFMpegFileReader(BufferedInputStream):
     def __init__(self, file_path):
@@ -701,9 +834,20 @@ class FFMpegFileReader(BufferedInputStream):
 
 
 class UnseekableSoundFile(sf.SoundFile):
-    def __init__(self, file_path, mode, channels, samplerate, format, subtype, endian):
+    def __init__(
+        self,
+        file_path,
+        mode,
+        channels,
+        samplerate,
+        format,
+        subtype,
+        endian,
+        frames_override=None,
+    ):
         self.file_path = file_path
         self._overlap = np.array([], dtype=np.int16)
+        self._frames_override = frames_override
         super().__init__(
             file_path,
             mode,
@@ -713,6 +857,14 @@ class UnseekableSoundFile(sf.SoundFile):
             subtype=subtype,
             endian=endian,
         )
+
+    @property
+    def frames(self):
+        """Number of frames, overridable for streams where libsndfile
+        cannot know the real length (e.g. piped input)."""
+        if self._frames_override is not None:
+            return self._frames_override
+        return super().frames
 
     def seek(self, offset, whence=io.SEEK_SET):
         return self.file_path.seek(offset, whence)
@@ -814,6 +966,54 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             endian="LITTLE",
         )
     elif "flac" == extension:
+        streaminfo = parse_flac_streaminfo(pathR)
+        if streaminfo is not None:
+            header_ok, corrected_total = check_flac_header_total_samples(
+                streaminfo, os.path.getsize(pathR)
+            )
+            if not header_ok:
+                declared = streaminfo["total_samples"]
+                print(
+                    f"WARN: The FLAC header sample count ({declared}) does not match the amount of audio data in the file."
+                )
+                print(
+                    f"WARN: The FLAC STREAMINFO total_samples field is 36 bits wide and wraps around every {FLAC_TOTAL_SAMPLES_FIELD_MOD} samples on very long captures."
+                )
+                if corrected_total is not None:
+                    print(
+                        f"WARN: Estimated true length of this capture is {corrected_total} samples."
+                    )
+                if streaminfo["bits_per_sample"] == 16 and test_if_flac_is_installed():
+                    print(
+                        "WARN: Decoding through the flac command line decoder so the whole file is decoded."
+                    )
+                    return UnseekableSoundFile(
+                        FlacFileReader(pathR),
+                        "r",
+                        channels=streaminfo["channels"],
+                        samplerate=int(sample_rate),
+                        format="RAW",
+                        subtype="PCM_16",
+                        endian="LITTLE",
+                        frames_override=corrected_total,
+                    )
+                if test_if_ffmpeg_is_installed():
+                    print(
+                        "WARN: Decoding through ffmpeg so the whole file is decoded."
+                    )
+                    return UnseekableSoundFile(
+                        FFMpegFileReader(pathR),
+                        "r",
+                        channels=streaminfo["channels"],
+                        samplerate=int(sample_rate),
+                        format="RAW",
+                        subtype="PCM_16",
+                        endian="LITTLE",
+                        frames_override=corrected_total,
+                    )
+                print(
+                    "WARN: Neither flac nor ffmpeg is installed (or in PATH). The decode will stop early at the wrapped header sample count!"
+                )
         return sf.SoundFile(
             pathR,
             "r",

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -4,6 +4,7 @@ import numba
 import numpy as np
 from dataclasses import dataclass
 
+import io
 import string
 from random import SystemRandom
 
@@ -16,6 +17,138 @@ REAL_DTYPE = np.float32
 ALIGNMENT = 64
 
 NumbaAudioArray = numba.types.Array(numba.types.float32, 1, "C")
+
+# The STREAMINFO total_samples field is 36 bits wide, so captures longer than
+# 2^36 samples (~28.6 minutes at 40 MSps) overflow it and the stored count
+# wraps around modulo 2^36. libsndfile trusts this count and stops reading
+# there, truncating the decode. See parse_flac_streaminfo() below.
+FLAC_TOTAL_SAMPLES_FIELD_MOD = 2**36
+
+
+def parse_flac_streaminfo(file_path):
+    """Parse the FLAC STREAMINFO metadata block directly from the file.
+
+    Returns a dict with the STREAMINFO fields and the offset where the
+    audio frames start, or None if the file could not be parsed as FLAC.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            if f.read(4) != b"fLaC":
+                return None
+
+            streaminfo = None
+            audio_offset = None
+            while True:
+                header = f.read(4)
+                if len(header) != 4:
+                    return None
+                is_last = bool(header[0] & 0x80)
+                block_type = header[0] & 0x7F
+                length = int.from_bytes(header[1:4], "big")
+
+                if block_type == 0 and streaminfo is None:
+                    data = f.read(length)
+                    if len(data) < 34:
+                        return None
+                    streaminfo = data
+                else:
+                    f.seek(length, io.SEEK_CUR)
+
+                if is_last:
+                    audio_offset = f.tell()
+                    break
+
+            if streaminfo is None or audio_offset is None:
+                return None
+
+            d = streaminfo
+            return {
+                "min_blocksize": int.from_bytes(d[0:2], "big"),
+                "max_blocksize": int.from_bytes(d[2:4], "big"),
+                "min_framesize": int.from_bytes(d[4:7], "big"),
+                "max_framesize": int.from_bytes(d[7:10], "big"),
+                "sample_rate": (d[10] << 12) | (d[11] << 4) | (d[12] >> 4),
+                "channels": ((d[12] >> 1) & 0x7) + 1,
+                "bits_per_sample": (((d[12] & 1) << 4) | (d[13] >> 4)) + 1,
+                "total_samples": ((d[13] & 0xF) << 32)
+                | int.from_bytes(d[14:18], "big"),
+                "audio_offset": audio_offset,
+            }
+    except OSError:
+        return None
+
+
+def check_flac_header_total_samples(streaminfo, file_size):
+    """Check whether the STREAMINFO total_samples count can be trusted.
+
+    A FLAC frame stores at most max_framesize bytes for at least
+    min_blocksize samples, so `total_samples` samples can never occupy more
+    than (total_samples / min_blocksize + 1) * max_framesize bytes of audio
+    payload. If the file holds substantially more audio data than that, the
+    36 bit total_samples field overflowed and wrapped (or was never
+    finalized), and the header length must not be trusted.
+
+    Returns (header_is_trustworthy, corrected_total_samples or None).
+    """
+    declared = streaminfo["total_samples"]
+    audio_bytes = file_size - streaminfo["audio_offset"]
+
+    if audio_bytes <= 0:
+        return True, None
+
+    if declared == 0:
+        # length marked as unknown (e.g. the encoder could not seek back to
+        # finalize the header)
+        return False, None
+
+    min_blocksize = streaminfo["min_blocksize"]
+    max_blocksize = streaminfo["max_blocksize"]
+    min_framesize = streaminfo["min_framesize"]
+    max_framesize = streaminfo["max_framesize"]
+
+    if min_blocksize > 0 and max_framesize > 0:
+        # largest possible payload for the declared sample count
+        declared_max_bytes = (declared // min_blocksize + 1) * max_framesize
+    else:
+        # min/max frame sizes may legally be 0 (unknown), fall back to the
+        # verbatim worst case (uncompressed samples) plus generous margin
+        declared_max_bytes = (
+            int(
+                declared
+                * streaminfo["channels"]
+                * (streaminfo["bits_per_sample"] / 8)
+                * 1.05
+            )
+            + 65536
+        )
+
+    if audio_bytes <= declared_max_bytes:
+        return True, None
+
+    # the header count is impossibly small for the amount of audio data in
+    # the file: it wrapped modulo 2^36. try to recover the true count using
+    # the frame size statistics, accepting it only if exactly one candidate
+    # fits between the possible payload bounds
+    corrected = None
+    if (
+        min_blocksize > 0
+        and max_blocksize > 0
+        and min_framesize > 0
+        and max_framesize > 0
+    ):
+        lower = audio_bytes / max_framesize * min_blocksize
+        upper = audio_bytes / min_framesize * max_blocksize
+        candidates = []
+        k = 1
+        while declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD <= upper:
+            candidate = declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD
+            if candidate >= lower:
+                candidates.append(candidate)
+            k += 1
+        if len(candidates) == 1:
+            corrected = candidates[0]
+
+    return False, corrected
 
 @dataclass
 class DecoderState:


### PR DESCRIPTION
## Summary
This PR brings three focused hifi-decode improvements on top of current `vhs_decode`:

1. Fix truncation on long FLAC RF captures where FLAC STREAMINFO `total_samples` wraps at 36 bits.
2. Add robust 12-bit FLAC input handling.
3. Improve hifi GUI workflow and usability (drag/drop, output naming, input rate auto-detect, threads control, dark-mode spinbox styling).

## What changed
### 1) Long-capture FLAC truncation fix
- Parse FLAC STREAMINFO and validate whether header `total_samples` is trustworthy against payload/frame-size bounds.
- Detect wrapped counts and recover corrected sample totals when uniquely inferable.
- Route flagged streams through decoding paths that read to true EOF (flac CLI for 16-bit sources, ffmpeg fallback), with corrected frame accounting.

### 2) 12-bit FLAC support
- Handle libsndfile-open failures for native 12-bit FLAC by falling back to ffmpeg decode path.
- Preserve correct channel/length metadata through UI/progress paths.

### 3) GUI input/UX improvements
- Drag-and-drop input file support.
- Auto-populate output path as `<basename>_HiFi_Decoded.flac` in the same directory.
- Auto-initialize input sample rate from FLAC header convention used by RF captures.
- Add decode thread count control in input options and wire it into decode execution.
- Dark-mode styling updates for spinboxes, including explicit rendered up/down arrows.

## Validation performed
- End-to-end decode verification on long real capture (previously truncated; now full duration).
- Synthetic/controlled 12-bit FLAC validation and smoke decode.
- GUI behavior validation for drag/drop, auto output naming, rate auto-detection, and thread wiring.
- Local package sanity build (`sdist` + `wheel`) completed successfully.

## Commits

- `73a7644d` fix(hifi): decode full FLAC captures whose 36-bit total_samples wrapped
- `abf4b126` feat(hifi): 12-bit FLAC input, GUI drag & drop and auto output name
- `f23870f2` feat(hifi-gui): auto input rate from FLAC header, decode threads box, dark spin boxes