### PR TITLE
hifi-decode: async reads, numa node support

### DIFF
--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -40,7 +40,7 @@ from vhsdecode.addons.gnuradioZMQ import ZMQSend, ZMQ_AVAILABLE
 from vhsdecode.utils import firdes_lowpass, firdes_highpass, StackableMA
 
 from vhsdecode.hifi.TimeProgressBar import TimeProgressBar
-from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray
+from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray, NUMA
 
 import matplotlib.pyplot as plt
 
@@ -2371,8 +2371,9 @@ class HiFiDecode:
 
     @staticmethod
     def hifi_decode_worker(
-        decoder_in_queue, decoder_out_queue, decode_options, standard
+        decoder_in_queue, decoder_out_queue, decode_options, standard, numa_node
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         measure_perf = False
         decoder = HiFiDecode(decode_options, is_main_process=False)

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -2202,7 +2202,7 @@ class HiFiDecode:
             start_if_resampler = perf_counter()
 
         if self.options["demod_type"] == DEMOD_HILBERT:
-            rf_data = rf_data.astype(np.float32, copy=False)
+            rf_data = rf_data.astype(REAL_DTYPE, copy=False)
             rf_data_resampled = self.if_resampler.resample_chunk(rf_data, True)
             self.if_resampler.clear()
         else:

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -196,7 +196,7 @@ class AFEFilterable:
     def work(self, data):
         return sosfiltfilt_rust(self.bandpass, data)
 
-class FMdemod:
+class FMDiscriminator:
     def __init__(
         self, sample_rate, carrier_center, deviation, max_iq_len, type
     ):
@@ -213,7 +213,7 @@ class FMdemod:
             iq_len = self._get_min_iq_length(max_iq_len)
             self.i_osc = np.empty(iq_len, dtype=DEMOD_DTYPE_NP, order="C")
             self.q_osc = np.empty(iq_len, dtype=DEMOD_DTYPE_NP, order="C")
-            FMdemod._generate_iq_oscillators(
+            FMDiscriminator._generate_iq_oscillators(
                 self.i_osc,
                 self.q_osc,
                 self.carrier,
@@ -387,41 +387,47 @@ class FMdemod:
         two_pi = 2 * pi
         phase_scale = sample_rate / (two_pi * deviation)
         carrier_scaled = carrier / deviation
+
         iq_len = len(i_osc)
         rf_len = len(in_rf)
-        prev_angle = 0  # doesn't matter since the final chunks have overlap
-        prev_unwrapped = prev_angle
+
+        # sign always start positive, iq index always starts at 0
+        prev_i = in_rf[0] * i_osc[0]
+        prev_q = in_rf[0] * q_osc[0]
 
         for i in range(1, rf_len):
-            #
-            # mix in i/q, reflect the sine and cosine
-            #
+            # i/q is only the positive side of the wave, and only one half rotation is stored
+            # * the index of the buffer loops around twice for one full rotation
             iq_index = i % iq_len
+            # * sign flips between the first and second loop (1st rotation: positive; 2nd rotation: negative)
             sign = 1 - 2 * ((i // iq_len) & 1)
-
+            # * flip the rf sign, to avoid extra multiplications below
             rf_signed = in_rf[i] * sign
+
             i_in = rf_signed * i_osc[iq_index]
             q_in = rf_signed * q_osc[iq_index]
 
-            #
-            # unwrap angles
-            #
-            current_angle = atan2(q_in, i_in)
-            delta = current_angle - prev_angle
-            delta += two_pi * ((delta < -pi) - (delta > pi))
-            unwrapped = prev_unwrapped + delta
+            # complex-conjugate discriminator, avoids phase error accumulation when wrapping the phase with amplitude
+            imag = q_in * prev_i - i_in * prev_q
+            real = i_in * prev_i + q_in * prev_q
 
+            # angular difference
+            delta = atan2(imag, real)
+
+            # scale up for later steps (may be able to be removed)
             out = carrier_scaled + delta * phase_scale
 
             out_demod[i - 1] = min(max(out, min_float), max_float)
 
-            prev_angle = current_angle
-            prev_unwrapped = unwrapped
+            prev_i = i_in
+            prev_q = q_in
 
+    # estimate carrier frequency deviation from phase changes in the I/Q reference frame
+    # which is like a series of +- values for clean signal, i.e. a fixed carrair wave)
     def work(self, input: np.array, output: np.array):
         if self.type == DEMOD_HILBERT:
-            FMdemod.compute_analytic_signal(input)
-            FMdemod.demod_hilbert(
+            FMDiscriminator.compute_analytic_signal(input)
+            FMDiscriminator.demod_hilbert(
                 input,
                 output,
                 self.min_float,
@@ -430,7 +436,7 @@ class FMdemod:
                 self.deviation,
             )
         elif self.type == DEMOD_QUADRATURE:
-            FMdemod.demod_quadrature(
+            FMDiscriminator.demod_quadrature(
                 input,
                 output,
                 self.min_float,
@@ -1364,14 +1370,14 @@ class HiFiDecode:
 
     def _get_fm_demod(self, if_rate, demod_type):
         return (
-            FMdemod(
+            FMDiscriminator(
                 if_rate,
                 self.standard.LCarrierRef,
                 self.standard.VCODeviation,
                 self.initialBlockResampledSize,
                 demod_type
             ),
-            FMdemod(
+            FMDiscriminator(
                 if_rate,
                 self.standard.RCarrierRef,
                 self.standard.VCODeviation,
@@ -1498,7 +1504,7 @@ class HiFiDecode:
 
     def auto_fine_tune(
         self, dcL: float, dcR: float
-    ) -> Tuple[AFEFilterable, AFEFilterable, FMdemod, FMdemod]:
+    ) -> Tuple[AFEFilterable, AFEFilterable, FMDiscriminator, FMDiscriminator]:
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
             left_carrier_dc_offset = (
                 self.standard.LCarrierRef - dcL * self.standard.VCODeviation
@@ -2125,7 +2131,7 @@ class HiFiDecode:
 
     @staticmethod
     def demod_process_audio(
-        filtered: np.array, fm: FMdemod, audio_process_params: HiFiAudioParams, audio_resampler, measure_perf: bool
+        filtered: np.array, fm: FMDiscriminator, audio_process_params: HiFiAudioParams, audio_resampler, measure_perf: bool
     ) -> Tuple[np.array, float, dict]:
         perf_measurements = {
             "start_demod": 0,
@@ -2144,11 +2150,13 @@ class HiFiDecode:
         if measure_perf:
             perf_measurements["start_demod"] = perf_counter()
         audio = np.empty(len(filtered), dtype=REAL_DTYPE, order="C")
+
+        # estimate carrier frequency deviation from phase changes in the I/Q reference frame
         fm.work(filtered, audio)
         if measure_perf:
             perf_measurements["end_demod"] = perf_counter()
 
-        # resample if sample rate to audio sample rate
+        # band-limited sinc interpolation to audio rate (i.e. downsample from IF rate to audio rate)
         if measure_perf:
             perf_measurements["start_audio_resample"] = perf_counter()
         audio: np.array = audio_resampler.resample_chunk(audio, True)

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -86,13 +86,24 @@ class FiltersClass:
 @dataclass
 class AFEParamsVHS:
     def __init__(self):
-        self.VCODeviation = 150e3
+        self.LVCODeviation = 150e3
+        self.RVCODeviation = 150e3
+
+        # Carson's bandwidth rule: 2 * (peak_frequency_deviation + highest frequency)
+        self.LNotchWidth = 2 * (self.LVCODeviation + 36e3)
+        self.RNotchWidth = 2 * (self.RVCODeviation + 36e3)
 
 
 @dataclass
 class AFEParams8mm:
     def __init__(self):
-        self.VCODeviation = 100e3
+        # IEC 60843-1 6.2.3
+        self.LVCODeviation = 100e3 # main channel deviation +-100kHz
+        self.RVCODeviation = 50e3 # sub channel deviation +-50kHz
+
+        self.LNotchWidth = 2 * (self.LVCODeviation + 20e3)
+        self.RNotchWidth = 1.5 * self.RVCODeviation # narrower notch for sub channel
+
         self.LCarrierRef = 1.5e6
         self.RCarrierRef = 1.7e6
 
@@ -120,47 +131,6 @@ class AFEParamsNTSC8mm(AFEParams8mm):
         super().__init__()
         self.Hfreq = 15.750e3
 
-# from scipy.signal import chirp
-# def plot_responses(*filters, n=2**20):
-#     plt.figure()
-# 
-#     # time axis
-#     t = np.arange(n)
-# 
-#     for i, filt in enumerate(filters):
-# 
-#         fs = filt.samp_rate
-#         t_sec = t / fs
-# 
-#         # log sweep from DC-ish to Nyquist (adjust as needed)
-#         f0 = 10          # start freq (Hz)
-#         f1 = fs / 2 * 0.9  # end freq (Hz)
-# 
-#         x = chirp(t_sec, f0=f0, f1=f1, t1=t_sec[-1], method='logarithmic')
-# 
-#         # run through filter
-#         y = filt.work(x)
-# 
-#         # FFT-based transfer estimate
-#         X = np.fft.rfft(x)
-#         Y = np.fft.rfft(y)
-# 
-#         H = Y / (X + 1e-12)
-#         f = np.fft.rfftfreq(n, 1 / fs)
-# 
-#         plt.plot(
-#             f / 1e6,
-#             20 * np.log10(np.abs(H) + 1e-12),
-#             label=f"Filter {i}"
-#         )
-# 
-#     plt.title("Filter Frequency Response (Sweep Method)")
-#     plt.xlabel("Frequency (MHz)")
-#     plt.ylabel("Magnitude (dB)")
-#     plt.grid(True)
-#     plt.xlim(0, 10)
-#     plt.legend()
-#     plt.show()
 
 @dataclass
 class AFEParamsPAL8mm(AFEParams8mm):
@@ -169,18 +139,61 @@ class AFEParamsPAL8mm(AFEParams8mm):
         self.Hfreq = 15.625e3
 
 
+from scipy.signal import chirp
+def plot_responses(*filters, n=2**20):
+    plt.figure()
+
+    # time axis
+    t = np.arange(n)
+
+    for i, filt in enumerate(filters):
+
+        fs = filt.samp_rate
+        t_sec = t / fs
+
+        # log sweep from DC-ish to Nyquist (adjust as needed)
+        f0 = 10          # start freq (Hz)
+        f1 = fs / 2 * 0.9  # end freq (Hz)
+
+        x = chirp(t_sec, f0=f0, f1=f1, t1=t_sec[-1], method='logarithmic')
+
+        # run through filter
+        y = filt.work(x)
+
+        # FFT-based transfer estimate
+        X = np.fft.rfft(x)
+        Y = np.fft.rfft(y)
+
+        H = Y / (X + 1e-12)
+        f = np.fft.rfftfreq(n, 1 / fs)
+
+        plt.plot(
+            f / 1e6,
+            20 * np.log10(np.abs(H) + 1e-12),
+            label=f"Filter {i}"
+        )
+
+    plt.title("Filter Frequency Response (Sweep Method)")
+    plt.xlabel("Frequency (MHz)")
+    plt.ylabel("Magnitude (dB)")
+    plt.grid(True)
+    plt.xlim(0, 10)
+    plt.legend()
+    plt.show()
+
+
 class AFEFilterable:
     def __init__(self, filters_params, sample_rate, channel=0):
         self.samp_rate = sample_rate
         self.filter_params = filters_params
 
         if channel == 0:
+            bandpass_width = self.filter_params.LNotchWidth
             center = self.filter_params.LCarrierRef
         else:
+            bandpass_width = self.filter_params.RNotchWidth
             center = self.filter_params.RCarrierRef
 
-        # Carson's bandwidth rule: 2 * (peak_frequency_deviation + highest frequency)
-        bandpass_width = 2 * (self.filter_params.VCODeviation + 36e3)
         bandpass_low = center - bandpass_width
         bandpass_high = center + bandpass_width
 
@@ -1074,6 +1087,7 @@ class HiFiDecode:
             options["format"],
             options["standard"],
             options["afe_vco_deviation"],
+            options["afe_vco_deviation"], # TODO: add user facing parameter to specify right deviation
             options["afe_left_carrier"],
             options["afe_right_carrier"],
         )
@@ -1202,7 +1216,7 @@ class HiFiDecode:
 
     @staticmethod
     def get_standard(
-        format, system, afe_vco_deviation, afe_left_carrier, afe_right_carrier
+        format, system, afe_left_vco_deviation, afe_right_vco_deviation, afe_left_carrier, afe_right_carrier
     ):
         if format == "vhs":
             if system == "p":
@@ -1219,8 +1233,10 @@ class HiFiDecode:
                 field_rate = 59.94
                 standard = AFEParamsNTSC8mm()
 
-        if afe_vco_deviation != 0:
-            standard.VCODeviation = afe_vco_deviation
+        if afe_left_vco_deviation != 0:
+            standard.LVCODeviation = afe_left_vco_deviation
+        if afe_right_vco_deviation != 0:
+            standard.RVCODeviation = afe_right_vco_deviation
         if afe_left_carrier != 0:
             standard.LCarrierRef = afe_left_carrier
         if afe_right_carrier != 0:
@@ -1373,14 +1389,14 @@ class HiFiDecode:
             FMDiscriminator(
                 if_rate,
                 self.standard.LCarrierRef,
-                self.standard.VCODeviation,
+                self.standard.LVCODeviation,
                 self.initialBlockResampledSize,
                 demod_type
             ),
             FMDiscriminator(
                 if_rate,
                 self.standard.RCarrierRef,
-                self.standard.VCODeviation,
+                self.standard.RVCODeviation,
                 self.initialBlockResampledSize,
                 demod_type
             )
@@ -1436,8 +1452,8 @@ class HiFiDecode:
             meanL.push(np.mean(preL))
             meanR.push(np.mean(preR))
 
-            meanLResult = meanL.pull() * self.standard.VCODeviation
-            meanRResult = meanR.pull() * self.standard.VCODeviation
+            meanLResult = meanL.pull() * self.standard.LVCODeviation
+            meanRResult = meanR.pull() * self.standard.RVCODeviation
 
             progressB.label = "Carrier L %.06f MHz, R %.06f MHz" % (
                 meanLResult / 10e5,
@@ -1507,7 +1523,7 @@ class HiFiDecode:
     ) -> Tuple[AFEFilterable, AFEFilterable, FMDiscriminator, FMDiscriminator]:
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_R:
             left_carrier_dc_offset = (
-                self.standard.LCarrierRef - dcL * self.standard.VCODeviation
+                self.standard.LCarrierRef - dcL * self.standard.LVCODeviation
             )
             left_carrier_updated = self.standard.LCarrierRef - round(left_carrier_dc_offset)
             self.standard.LCarrierRef = max(
@@ -1517,7 +1533,7 @@ class HiFiDecode:
             
         if self.audio_process_params.decode_mode != AUDIO_MODE_MONO_L:
             right_carrier_dc_offset = (
-                self.standard.RCarrierRef - dcR * self.standard.VCODeviation
+                self.standard.RCarrierRef - dcR * self.standard.RVCODeviation
             )
             right_carrier_updated = self.standard.RCarrierRef - round(
                 right_carrier_dc_offset

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -97,7 +97,7 @@ class AFEParamsVHS:
 @dataclass
 class AFEParams8mm:
     def __init__(self):
-        # IEC 60843-1 6.2.3
+        # IEC 60843-1 pg.71 (6.2.3 FM audio signal recording, Maximum deviation)
         self.LVCODeviation = 100e3 # main channel deviation +-100kHz
         self.RVCODeviation = 50e3 # sub channel deviation +-50kHz
 
@@ -837,15 +837,6 @@ class Expander:
 
         self.hold_state = 0
 
-        self.lowpass_iirb, self.lowpass_iira = firdes_lowpass(
-            self.audio_rate,
-            min(weighting_low_pass, self.audio_rate / 2 - 1), # limit to nyquist
-            weighting_low_pass_transition,
-        )
-        self.WeightedLowcut = FiltersClass(
-            np.array(self.lowpass_iirb), np.array(self.lowpass_iira), dtype=np.float64
-        )
-
         # weighted filter for envelope detector
         self.weighting_T1 = weighting_low_tau
         self.weighting_T2 = weighting_high_tau
@@ -876,7 +867,7 @@ class Expander:
     @njit(
         [(
             NumbaAudioArray,
-            numba.types.Array(numba.types.float64, 1, "C"),
+            numba.types.Array(numba.types.float32, 1, "C"),
             numba.types.float64,
             numba.types.float64,
             numba.types.float64,
@@ -960,11 +951,9 @@ class Expander:
         return env_lin, hold_state
 
     def process(self, pre_in, audio_out):
-        side_chain = self.WeightedLowcut.lfilt(pre_in)
-
         # high pass weighted input to envelope detector
         self.zi_x, self.zi_y = Deemphasis.lfilt_inplace(
-            side_chain,
+            pre_in,
             self.env_iirb[0],
             self.env_iirb[1],
             self.env_iira[1],
@@ -974,7 +963,7 @@ class Expander:
 
         self.env_lin, self.hold_state = Expander.expand(
             audio_out,
-            side_chain,
+            pre_in,
             self.env_lin,
             self.atkCoeff,
             self.relCoeff,

--- a/vhsdecode/hifi/HiFiDecode.py
+++ b/vhsdecode/hifi/HiFiDecode.py
@@ -40,7 +40,7 @@ from vhsdecode.addons.gnuradioZMQ import ZMQSend, ZMQ_AVAILABLE
 from vhsdecode.utils import firdes_lowpass, firdes_highpass, StackableMA
 
 from vhsdecode.hifi.TimeProgressBar import TimeProgressBar
-from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray, NUMA
+from vhsdecode.hifi.utils import DecoderSharedMemory, NumbaAudioArray
 
 import matplotlib.pyplot as plt
 
@@ -2373,7 +2373,6 @@ class HiFiDecode:
     def hifi_decode_worker(
         decoder_in_queue, decoder_out_queue, decode_options, standard, numa_node
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         measure_perf = False
         decoder = HiFiDecode(decode_options, is_main_process=False)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -29,6 +29,7 @@ import numpy as np
 import soundfile as sf
 
 from vhsdecode.hifi.utils import (
+    NUMA,
     DecoderSharedMemory,
     DecoderState,
     PostProcessorSharedMemory,
@@ -1131,6 +1132,7 @@ class PostProcessor:
         out_conn,
         peak_gain
     ):
+        self.numa_node = 0
         self.final_audio_rate = decode_options["audio_rate"]
         self.enable_expander = decode_options["enable_expander"]
         self.enable_deemphasis = decode_options["enable_deemphasis"]
@@ -1159,10 +1161,10 @@ class PostProcessor:
         self.post_processor_num_shared_memory = 16
         for i in range(self.post_processor_num_shared_memory):
             shared_memory = PostProcessorSharedMemory.get_shared_memory(
-                channel_size, f"hifi_post_mem_{i}"
+                channel_size, f"hifi_post_mem_{i}", numa_node=self.numa_node
             )
             self.post_processor_shared_memory.append(shared_memory)
-            self.post_processor_shared_memory_idle_queue.put(shared_memory.name)
+            self.post_processor_shared_memory_idle_queue.put((shared_memory.name, self.numa_node))
             atexit.register(shared_memory.close)
             atexit.register(shared_memory.unlink)
 
@@ -1172,6 +1174,7 @@ class PostProcessor:
             target=PostProcessor.block_sorter_worker,
             name="hifi_block_sort",
             args=(
+                self.numa_node,
                 self.decoder_out_queue,
                 self.decoder_shared_memory_idle_queue,
                 self.blocks_enqueued,
@@ -1189,6 +1192,7 @@ class PostProcessor:
             target=PostProcessor.dc_block_worker,
             name="hifi_dc_block_l",
             args=(
+                self.numa_node,
                 block_sort_l_in_rx,
                 dc_blocker_worker_l_tx,
                 self.final_audio_rate,
@@ -1203,6 +1207,7 @@ class PostProcessor:
             target=PostProcessor.dc_block_worker,
             name="hifi_dc_block_r",
             args=(
+                self.numa_node,
                 block_sort_r_in_rx,
                 dc_blocker_worker_r_tx,
                 self.final_audio_rate,
@@ -1217,6 +1222,7 @@ class PostProcessor:
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_l",
             args=(
+                self.numa_node,
                 dc_blocker_worker_l_rx,
                 spectral_nr_worker_l_tx,
                 self.spectral_nr_amount,
@@ -1232,6 +1238,7 @@ class PostProcessor:
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_r",
             args=(
+                self.numa_node,
                 dc_blocker_worker_r_rx,
                 spectral_nr_worker_r_tx,
                 self.spectral_nr_amount,
@@ -1249,6 +1256,7 @@ class PostProcessor:
             target=expander_worker,
             name="hifi_expander_l",
             args=(
+                self.numa_node,
                 spectral_nr_worker_l_rx,
                 expander_worker_l_out_tx,
                 self.enable_deemphasis,
@@ -1279,6 +1287,7 @@ class PostProcessor:
             target=expander_worker,
             name="hifi_expander_r",
             args=(
+                self.numa_node,
                 spectral_nr_worker_r_rx,
                 expander_worker_r_out_tx,
                 self.enable_deemphasis,
@@ -1308,6 +1317,7 @@ class PostProcessor:
             target=PostProcessor.mix_to_stereo_worker,
             name="hifi_stereo_mix",
             args=(
+                self.numa_node,
                 expander_worker_l_out_rx,
                 expander_worker_r_out_rx,
                 self.mix_to_stereo_worker_output,
@@ -1333,10 +1343,12 @@ class PostProcessor:
 
     @staticmethod
     def dc_block_worker(
+        numa_node,
         in_conn,
         out_conn,
         final_audio_rate
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         dc_blocker = DCBlocker(
@@ -1367,11 +1379,13 @@ class PostProcessor:
         
     @staticmethod
     def spectral_noise_reduction_worker(
+        numa_node,
         in_conn,
         out_conn,
         spectral_nr_amount,
         final_audio_rate,
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         spectral_nr = SpectralNoiseReduction(
@@ -1409,6 +1423,7 @@ class PostProcessor:
 
     @staticmethod
     def expander_vhs_worker(
+        numa_node,
         in_conn,
         out_conn,
         enable_deemphasis,
@@ -1429,6 +1444,7 @@ class PostProcessor:
         expander_weighting_low_pass,
         expander_weighting_low_pass_transition,
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         deemphasis_pre_1 = Deemphasis(
@@ -1500,6 +1516,7 @@ class PostProcessor:
 
     @staticmethod
     def expander_8mm_worker(
+        numa_node,
         in_conn,
         out_conn,
         enable_deemphasis,
@@ -1520,6 +1537,7 @@ class PostProcessor:
         expander_weighting_low_pass,
         expander_weighting_low_pass_transition,
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         deemphasis_2 = Deemphasis(
@@ -1583,8 +1601,9 @@ class PostProcessor:
 
     @staticmethod
     def mix_to_stereo_worker(
-        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
+        numa_node, expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         while True:
             while True:
@@ -1679,6 +1698,7 @@ class PostProcessor:
 
     @staticmethod
     def block_sorter_worker(
+        numa_node,
         decoder_out_queue,
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
@@ -1686,6 +1706,7 @@ class PostProcessor:
         l_tx,
         r_tx,
     ):
+        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         next_block = 0
         last_block_submitted = -1
@@ -1719,7 +1740,7 @@ class PostProcessor:
 
             buffer.close()
 
-            decoder_shared_memory_idle_queue.put(in_decoder_state.name)
+            decoder_shared_memory_idle_queue.put((in_decoder_state.name, in_decoder_state.numa_node))
             with blocks_enqueued.get_lock():
                 blocks_enqueued.value -= 1
 
@@ -1740,7 +1761,7 @@ class PostProcessor:
                 ):
                     while True:
                         try:
-                            name = post_processor_shared_memory_idle_queue.get()
+                            name, numa_node = post_processor_shared_memory_idle_queue.get()
                             break
                         except InterruptedError:
                             pass
@@ -2029,7 +2050,7 @@ def write_soundfile_process_worker(
                 player.play(stereo_copy)
 
             buffer.close()
-            post_processor_shared_memory_idle_queue.put(decoder_state.name)
+            post_processor_shared_memory_idle_queue.put((decoder_state.name, decoder_state.numa_node))
             with total_samples_decoded.get_lock():
                 total_samples_decoded.value = int(
                     total_samples_decoded.value + samples_decoded
@@ -2099,34 +2120,42 @@ async def decode_parallel(
 
     shared_memory_instances = []
     shared_memory_idle_queue = SimpleQueue()
+    max_numa_node = 0
     for i in range(num_shared_memory_instances):
+        numa_node = NUMA.next_node()
+        if numa_node > max_numa_node:
+            max_numa_node = numa_node
+
         buffer_instance = DecoderSharedMemory.get_shared_memory(
             decoder.initialBlockSize,
             decoder.blockOverlap,
             decoder.initialBlockFinalAudioSize,
             f"hifi_decoder_{i}",
+            numa_node=numa_node
         )
         shared_memory_instances.append(buffer_instance)
-        shared_memory_idle_queue.put(buffer_instance.name)
+        shared_memory_idle_queue.put((buffer_instance.name, numa_node))
 
         atexit.register(buffer_instance.close)
         atexit.register(buffer_instance.unlink)
 
     # spin up the decoders
     decoder_processes: list[Process] = []
-    decoder_in_queue = SimpleQueue()
+    decoder_in_queues = [SimpleQueue() for _ in range(max_numa_node + 1)]
     decoder_out_queue = SimpleQueue()
     decode_done = Event()
 
     for i in range(num_decoders):
+        numa_node = i % (max_numa_node + 1)
         decoder_process = Process(
             target=HiFiDecode.hifi_decode_worker,
             name=f"hifi_decode_worker_{i}",
             args=(
-                decoder_in_queue,
+                decoder_in_queues[numa_node],
                 decoder_out_queue,
                 decode_options,
                 decoder.standard,
+                numa_node
             ),
         )
         decoder_process.start()
@@ -2216,6 +2245,7 @@ async def decode_parallel(
                 new_block_length,
                 decoder_state.block_num,
                 decoder_state.is_last_block,
+                decoder_state.numa_node
             )
             buffer = DecoderSharedMemory(decoder_state)
             block = buffer.get_block()
@@ -2270,7 +2300,8 @@ async def decode_parallel(
 
         # submit the block to the decoder
         # blocks should complete roughly in the order that they are submitted
-        decoder_in_queue.put(decoder_state)
+        numa_node = decoder_state.numa_node
+        decoder_in_queues[numa_node].put(decoder_state)
 
         return decoder_state.is_last_block
 
@@ -2310,7 +2341,7 @@ async def decode_parallel(
             # get the next available shared memory buffer
             while True:
                 try:
-                    buffer_name = await loop.run_in_executor(
+                    buffer_name, numa_node = await loop.run_in_executor(
                         None, shared_memory_idle_queue.get
                     )
                     break
@@ -2320,7 +2351,7 @@ async def decode_parallel(
                     return
 
             decoder_state = DecoderState(
-                decoder, buffer_name, 0, block_size, block_num, False
+                decoder, buffer_name, 0, block_size, block_num, False, numa_node
             )
 
             if len(previous_overlap) == 0:

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -37,9 +37,6 @@ from vhsdecode.hifi.utils import (
     PeakGain,
     BLOCK_DTYPE,
     REAL_DTYPE,
-    FLAC_TOTAL_SAMPLES_FIELD_MOD,
-    check_flac_header_total_samples,
-    parse_flac_streaminfo,
 )
 
 import argparse
@@ -657,6 +654,7 @@ class FlacFileReader(BufferedInputStream):
             "-d",
             "-c",
             "-s",
+            "-F",
             "--force-raw-format",
             "--endian",
             "little",
@@ -684,6 +682,7 @@ class FFMpegFileReader(BufferedInputStream):
             "-loglevel",
             "error",
             "-ignore_unknown",
+            "-fflags", "nobuffer",
             "-i",
             file_path,
             "-f",
@@ -840,90 +839,21 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             endian="LITTLE",
         )
     elif "flac" == extension:
-        streaminfo = parse_flac_streaminfo(pathR)
-        if streaminfo is not None:
-            header_ok, corrected_total = check_flac_header_total_samples(
-                streaminfo, os.path.getsize(pathR)
+        if test_if_ffmpeg_is_installed():
+            return AsyncSoundFile(
+                FFMpegFileReader(pathR),
+                "r",
+                channels=1,
+                samplerate=int(sample_rate),
+                format="RAW",
+                subtype="PCM_16",
+                endian="LITTLE"
             )
-            if not header_ok:
-                declared = streaminfo["total_samples"]
-                print(
-                    f"WARN: The FLAC header sample count ({declared}) does not match the amount of audio data in the file."
-                )
-                print(
-                    f"WARN: The FLAC STREAMINFO total_samples field is 36 bits wide and wraps around every {FLAC_TOTAL_SAMPLES_FIELD_MOD} samples on very long captures."
-                )
-                if corrected_total is not None:
-                    print(
-                        f"WARN: Estimated true length of this capture is {corrected_total} samples."
-                    )
-                if streaminfo["bits_per_sample"] == 16 and test_if_flac_is_installed():
-                    print(
-                        "WARN: Decoding through the flac command line decoder so the whole file is decoded."
-                    )
-                    return AsyncSoundFile(
-                        FlacFileReader(pathR),
-                        "r",
-                        channels=streaminfo["channels"],
-                        samplerate=int(sample_rate),
-                        format="RAW",
-                        subtype="PCM_16",
-                        endian="LITTLE",
-                        frames_override=corrected_total,
-                    )
-                if test_if_ffmpeg_is_installed():
-                    print(
-                        "WARN: Decoding through ffmpeg so the whole file is decoded."
-                    )
-                    return AsyncSoundFile(
-                        FFMpegFileReader(pathR),
-                        "r",
-                        channels=streaminfo["channels"],
-                        samplerate=int(sample_rate),
-                        format="RAW",
-                        subtype="PCM_16",
-                        endian="LITTLE",
-                        frames_override=corrected_total,
-                    )
-                print(
-                    "WARN: Neither flac nor ffmpeg is installed (or in PATH). The decode will stop early at the wrapped header sample count!"
-                )
-        try:
+        else:
             return AsyncSoundFile(
                 pathR,
                 "r",
             )
-        except sf.LibsndfileError as e:
-            # libsndfile only implements FLAC bit depths 8/16/24/32. Native
-            # 12-bit FLAC captures (e.g. MISRC) fail to open with
-            # "unimplemented format"; ffmpeg decodes them fine and emits
-            # 16-bit left-aligned samples (value << 4), bit-identical to the
-            # same capture padded to 16 bits at record time.
-            if streaminfo is None:
-                raise
-            print(f"WARN: libsndfile could not open this FLAC file: {e}")
-            print(
-                f"WARN: FLAC stream is {streaminfo['bits_per_sample']}-bit "
-                f"({streaminfo['channels']} channel(s))."
-            )
-            if test_if_ffmpeg_is_installed():
-                print(
-                    "WARN: Decoding through ffmpeg instead (16-bit left-aligned output)."
-                )
-                return AsyncSoundFile(
-                    FFMpegFileReader(pathR),
-                    "r",
-                    channels=streaminfo["channels"],
-                    samplerate=int(sample_rate),
-                    format="RAW",
-                    subtype="PCM_16",
-                    endian="LITTLE",
-                    frames_override=streaminfo["total_samples"] or None,
-                )
-            print(
-                "ERROR: ffmpeg is not installed (or not in PATH), cannot decode this FLAC bit depth."
-            )
-            raise
     elif "ldf" == extension:
         try:
             for ldf_reader_tool in ("ld-ldf-reader", "ld-ldf-reader-py"):

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -831,13 +831,19 @@ def as_soundfile(pathR):
             input_format
         )
     elif "flac" == extension:
-        if test_if_ffmpeg_is_installed():
-            return AsyncReader(
-                FFMpegFileReader(pathR),
-                DEFAULT_BLOCK_DTYPE
-            )
-        else:
+        try:
             return AsyncSoundFileReader(pathR)
+        except sf.LibsndfileError as e:
+            print(f"WARN: libsndfile could not open this FLAC file: {e}")
+            if test_if_ffmpeg_is_installed():
+                return AsyncReader(
+                    FFMpegFileReader(pathR),
+                    DEFAULT_BLOCK_DTYPE
+                )
+            else:
+                print(
+                    "ERROR: ffmpeg is not installed (or not in PATH), cannot decode this FLAC bit depth."
+                )
     elif "ldf" == extension:
         try:
             for ldf_reader_tool in ("ld-ldf-reader", "ld-ldf-reader-py"):
@@ -2093,7 +2099,7 @@ async def decode_parallel(
 
         if block_num == 0:
             # save the read data
-            block_data_read = buffer.get_block_in().copy()
+            block_data_read = block_in.copy()
             buffer.close()
 
             # shift the actual data down by half so only the copied data is discarded
@@ -2148,11 +2154,11 @@ async def decode_parallel(
                 previous_overlap, block_in_overlap, len(block_in_overlap)
             )
 
-            # copy the the current overlap to use in the next iteration
-            current_overlap = buffer.get_block_in_end_overlap()
-            DecoderSharedMemory.copy_data(
-                current_overlap, previous_overlap, len(current_overlap)
-            )
+        # copy the the current overlap to use in the next iteration
+        current_overlap = buffer.get_block_in_end_overlap()
+        DecoderSharedMemory.copy_data(
+            current_overlap, previous_overlap, len(current_overlap)
+        )
 
         if not decoder_state.is_last_block:
             # save the full block for the next iteration, including previous overlap

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -704,33 +704,47 @@ class FFMpegFileReader(BufferedInputStream):
 
 
 class AsyncSoundFile(sf.SoundFile):
-    def __init__(
-        self,
-        file,
-        mode,
-        **kwargs
-    ):
+    def __init__(self, file, mode, **kwargs):
         if isinstance(file, str):
             self._file_handle = open(file, "rb")
         else:
             self._file_handle = file
-    
+
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="hifi_decode_reader"
+        )
+
         self._overlap = np.array([], dtype=np.int16)
+
         super().__init__(
             self._file_handle,
             mode,
-            **kwargs
+            **kwargs,
         )
-
 
     def seek(self, offset, whence=io.SEEK_SET):
         return self._file_handle.seek(offset, whence)
 
     async def buffer_read_into(self, out, dtype="int16"):
-        return await asyncio.to_thread(AsyncSoundFile._buffer_read_into, self._file_handle, out, dtype)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            self._buffer_read_into,
+            self._file_handle,
+            out,
+            dtype,
+        )
 
     def buffer_read_into_sync(self, out, dtype="int16"):
-        return AsyncSoundFile._buffer_read_into(self._file_handle, out, dtype)
+        return self._buffer_read_into(self._file_handle, out, dtype)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            super().close()
+        finally:
+            self._executor.shutdown(wait=True)
+        return False
 
     @staticmethod
     def _buffer_read_into(input, out, dtype):
@@ -738,9 +752,7 @@ class AsyncSoundFile(sf.SoundFile):
         bytes_read = input.readinto(out)
 
         assert bytes_read % item_size == 0, "data is misaligned"
-        bytes_read //= np.dtype(dtype).itemsize
-
-        return bytes_read
+        return bytes_read // item_size
 
 
 class UnSigned16BitFileReader(io.RawIOBase):

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -597,7 +597,7 @@ def test_if_ffmpeg_is_installed():
 class BufferedInputStream(io.RawIOBase):
     def __init__(self, buffer):
         self.buffer = buffer
-        self._pos: int = 0
+        self._pos = 0
 
     def readinto(self, buffer):
         bytes_read = self.buffer.readinto(buffer)
@@ -617,7 +617,7 @@ class BufferedInputStream(io.RawIOBase):
         return False
 
     def close(self):
-        pass
+        return self.buffer.close()
 
     def fileno(self):
         return self.buffer.fileno()
@@ -703,48 +703,39 @@ class FFMpegFileReader(BufferedInputStream):
         self._pos: int = 0
 
 
-class UnseekableSoundFile(sf.SoundFile):
+class AsyncSoundFile(sf.SoundFile):
     def __init__(
         self,
-        file_path,
+        file,
         mode,
-        channels,
-        samplerate,
-        format,
-        subtype,
-        endian,
-        frames_override=None,
+        **kwargs
     ):
-        self.file_path = file_path
+        if isinstance(file, str):
+            self._file_handle = open(file, "rb")
+        else:
+            self._file_handle = file
+    
         self._overlap = np.array([], dtype=np.int16)
-        self._frames_override = frames_override
         super().__init__(
-            file_path,
+            self._file_handle,
             mode,
-            channels=channels,
-            samplerate=samplerate,
-            format=format,
-            subtype=subtype,
-            endian=endian,
+            **kwargs
         )
 
-    @property
-    def frames(self):
-        """Number of frames, overridable for streams where libsndfile
-        cannot know the real length (e.g. piped input)."""
-        if self._frames_override is not None:
-            return self._frames_override
-        return super().frames
 
     def seek(self, offset, whence=io.SEEK_SET):
-        return self.file_path.seek(offset, whence)
+        return self._file_handle.seek(offset, whence)
 
-    def close(self):
-        pass
+    async def buffer_read_into(self, out, dtype="int16"):
+        return await asyncio.to_thread(AsyncSoundFile._buffer_read_into, self._file_handle, out, dtype)
 
-    def buffer_read_into(self, buffer, dtype="int16"):
+    def buffer_read_into_sync(self, out, dtype="int16"):
+        return AsyncSoundFile._buffer_read_into(self._file_handle, out, dtype)
+
+    @staticmethod
+    def _buffer_read_into(input, out, dtype):
         item_size = np.dtype(dtype).itemsize
-        bytes_read = self.file_path.readinto(buffer)
+        bytes_read = input.readinto(out)
 
         assert bytes_read % item_size == 0, "data is misaligned"
         bytes_read //= np.dtype(dtype).itemsize
@@ -796,7 +787,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
     path = pathR.lower()
     extension = pathR.lower().split(".")[-1]
     if "raw" == extension or "s16" == extension:
-        return sf.SoundFile(
+        return AsyncSoundFile(
             pathR,
             "r",
             channels=1,
@@ -806,7 +797,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             endian="LITTLE",
         )
     elif "u8" == extension or "r8" == extension:
-        return sf.SoundFile(
+        return AsyncSoundFile(
             pathR,
             "r",
             channels=1,
@@ -816,7 +807,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             endian="LITTLE",
         )
     elif "s8" == extension:
-        return sf.SoundFile(
+        return AsyncSoundFile(
             pathR,
             "r",
             channels=1,
@@ -826,7 +817,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             endian="LITTLE",
         )
     elif "u16" == extension or "r16" == extension:
-        return UnseekableSoundFile(
+        return AsyncSoundFile(
             UnSigned16BitFileReader(pathR),
             "r",
             channels=1,
@@ -857,7 +848,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     print(
                         "WARN: Decoding through the flac command line decoder so the whole file is decoded."
                     )
-                    return UnseekableSoundFile(
+                    return AsyncSoundFile(
                         FlacFileReader(pathR),
                         "r",
                         channels=streaminfo["channels"],
@@ -871,7 +862,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     print(
                         "WARN: Decoding through ffmpeg so the whole file is decoded."
                     )
-                    return UnseekableSoundFile(
+                    return AsyncSoundFile(
                         FFMpegFileReader(pathR),
                         "r",
                         channels=streaminfo["channels"],
@@ -885,7 +876,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     "WARN: Neither flac nor ffmpeg is installed (or in PATH). The decode will stop early at the wrapped header sample count!"
                 )
         try:
-            return sf.SoundFile(
+            return AsyncSoundFile(
                 pathR,
                 "r",
             )
@@ -906,7 +897,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                 print(
                     "WARN: Decoding through ffmpeg instead (16-bit left-aligned output)."
                 )
-                return UnseekableSoundFile(
+                return AsyncSoundFile(
                     FFMpegFileReader(pathR),
                     "r",
                     channels=streaminfo["channels"],
@@ -924,7 +915,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         try:
             for ldf_reader_tool in ("ld-ldf-reader", "ld-ldf-reader-py"):
                 if test_ld_tools(ldf_reader_tool):
-                    return UnseekableSoundFile(
+                    return AsyncSoundFile(
                         LDToolFileReader(ldf_reader_tool, pathR),
                         "r",
                         channels=1,
@@ -943,7 +934,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         
         try:    
             if test_if_flac_is_installed():
-                return UnseekableSoundFile(
+                return AsyncSoundFile(
                     FlacFileReader(pathR),
                     "r",
                     channels=1,
@@ -953,7 +944,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                     endian="LITTLE",
                 )
             if test_if_ffmpeg_is_installed():
-                return UnseekableSoundFile(
+                return AsyncSoundFile(
                     FFMpegFileReader(pathR),
                     "r",
                     channels=1,
@@ -965,7 +956,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         except Exception as e:
             pass
 
-        return sf.SoundFile(
+        return AsyncSoundFile(
             pathR,
             "r",
         )
@@ -976,7 +967,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                 ("ld-lds-converter", "-i"),
             ):
                 if test_ld_tools(lds_reader_tool):
-                    return UnseekableSoundFile(
+                    return AsyncSoundFile(
                         LDToolFileReader(lds_reader_tool, pathR, input_arg),
                         "r",
                         channels=1,
@@ -994,7 +985,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             )
     elif "-" == path:
         try:
-            return UnseekableSoundFile(
+            return AsyncSoundFile(
                 BufferedInputStream(sys.stdin.buffer),
                 "r",
                 channels=1,
@@ -1011,7 +1002,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         print("WARN: Attempting to decode with ffmpeg")
         try:
             if test_if_ffmpeg_is_installed():
-                return UnseekableSoundFile(
+                return AsyncSoundFile(
                     FFMpegFileReader(pathR),
                     "r",
                     channels=1,
@@ -1023,7 +1014,7 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         except Exception:
             pass
         print("WARN: Attempting to decode with SoundFile")
-        return sf.SoundFile(pathR, "r")
+        return AsyncSoundFile(pathR, "r")
 
 
 def get_normalize_filename(path, sample_rate):
@@ -1035,6 +1026,7 @@ def get_dual_mono_filename(path, channel_suffix):
 
 normalize_parameters = {
     "format": "RAW",  # TODO: update to FLAC 32 bit when supported by soundfile
+    "endian": "little",
     "subtype": "FLOAT",
 }
 
@@ -2168,7 +2160,7 @@ async def decode_parallel(
     atexit.register(output_file_process.terminate)
     atexit.register(output_file_process.join)
 
-    def read_and_send_to_decoder(
+    async def read_and_send_to_decoder(
         f,
         decoder,
         decoder_state,
@@ -2181,7 +2173,7 @@ async def decode_parallel(
         # read input data into the shared memory buffer
         block_in = buffer.get_block_in()
         try:
-            frames_read = f.buffer_read_into(block_in, "int16")
+            frames_read = await f.buffer_read_into(block_in, "int16")
         except sf.LibsndfileError as e:
             print("Error decoding input rf:", e)
             print("Stopping decode...")
@@ -2324,9 +2316,7 @@ async def decode_parallel(
                     decoder_state.block_read_overlap, dtype=np.int16, order="C"
                 )
 
-            is_last_block = await loop.run_in_executor(
-                None,
-                read_and_send_to_decoder,
+            is_last_block = await read_and_send_to_decoder(
                 f,
                 decoder,
                 decoder_state,
@@ -2385,30 +2375,30 @@ async def decode_parallel(
             if decode_options["normalize"]:
                 channel_1_output_file = get_dual_mono_filename(output_file, channel_1_suffix)
                 channel_1_input_file_post_gain = get_normalize_filename(channel_1_output_file, audio_rate)
-                normalize(channel_1_input_file_post_gain, channel_1_output_file, peak_gain.left, 1, audio_rate)
+                await normalize(channel_1_input_file_post_gain, channel_1_output_file, peak_gain.left, 1, audio_rate)
 
             print(f"\nChannel 2: Peak gain is {(peak_gain.right * 100):.2f}%.", end="")
             if decode_options["normalize"]:
                 channel_2_output_file = get_dual_mono_filename(output_file, channel_2_suffix)
                 channel_2_input_file_post_gain = get_normalize_filename(channel_2_output_file, audio_rate)
-                normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain.right, 1, audio_rate)
+                await normalize(channel_2_input_file_post_gain, channel_2_output_file, peak_gain.right, 1, audio_rate)
         else:
             peak_gain_stereo = max(peak_gain.left, peak_gain.right)
             print(f"\nPeak gain is {(peak_gain_stereo * 100):.2f}%.", end="")
             if decode_options["normalize"]:
                 input_file_post_gain = get_normalize_filename(output_file, audio_rate)
-                normalize(input_file_post_gain, output_file, peak_gain_stereo, 2, audio_rate)
+                await normalize(input_file_post_gain, output_file, peak_gain_stereo, 2, audio_rate)
 
     elapsed_time = datetime.now() - start_time
     dt_string = elapsed_time.total_seconds()
     print(f"\nDecode finished, seconds elapsed: {round(dt_string)}")
 
-def normalize(input_file_post_gain, output_file, peak_gain, channels, audio_rate):
+async def normalize(input_file_post_gain, output_file, peak_gain, channels, audio_rate):
     try:
         total_frames_read = 0
         buffer = np.empty(2**20, dtype=np.float32, order="C")
 
-        with sf.SoundFile(
+        with AsyncSoundFile(
             input_file_post_gain,
             "r",
             samplerate=int(audio_rate),
@@ -2423,18 +2413,17 @@ def normalize(input_file_post_gain, output_file, peak_gain, channels, audio_rate
             progressB = TimeProgressBar(f.frames, f.frames)
             done = False
             while not done:
-                frames_read = f.buffer_read_into(buffer, dtype="float32")
-                samples_read = frames_read * channels
+                frames_read = await f.buffer_read_into(buffer, dtype="float32")
 
-                if samples_read < len(buffer):
-                    buffer = buffer[0:samples_read]
+                if frames_read < len(buffer):
+                    buffer = buffer[0:frames_read]
                     done = True
 
                 PostProcessor.normalize(gain_adjust, buffer, buffer)
                 w.buffer_write(buffer, "float32")
 
                 total_frames_read += frames_read
-                progressB.print(total_frames_read, False)
+                progressB.print(total_frames_read / 2, False)
         print("")
     finally:
         os.remove(input_file_post_gain)
@@ -2446,7 +2435,7 @@ def guess_bias(decoder, input_file, block_size, blocks_limits=10):
     with as_soundfile(input_file) as f:
         while f.tell() < f.frames and len(blocks) <= blocks_limits:
             block_buffer = np.empty(block_size, dtype=np.int16, order="C")
-            f.buffer_read_into(block_buffer, "int16")
+            f.buffer_read_into_sync(block_buffer, "int16")
             blocks.append(block_buffer)
 
     decoder.guessBiases(blocks)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -35,7 +35,7 @@ from vhsdecode.hifi.utils import (
     PostProcessorSharedMemory,
     NumbaAudioArray,
     PeakGain,
-    BLOCK_DTYPE,
+    DEFAULT_BLOCK_DTYPE,
     REAL_DTYPE,
 )
 
@@ -703,169 +703,148 @@ class FFMpegFileReader(BufferedInputStream):
         self._pos: int = 0
 
 
-class AsyncSoundFile(sf.SoundFile):
-    def __init__(self, file, mode, **kwargs):
-        if isinstance(file, str):
-            self._file_handle = open(file, "rb")
+def get_raw_input_format(pathR, format=None):
+    if format is None:
+        format = pathR.lower().split(".")[-1]
+    
+    # format, is_raw_format
+    if format == "u8" or format == "r8":
+        return np.uint8, True
+    elif format == "s8":
+        return np.int8, True
+    elif format == "u16" or format == "r16":
+        return np.uint16, True
+    elif format == "raw" or format == "s16" or pathR == "-":
+        return np.int16, True
+    else:
+        return DEFAULT_BLOCK_DTYPE, False
+    
+
+class AsyncReader:
+    def __init__(self, file, dtype, channels=1):
+        self._file = file
+        self._dtype = dtype # input dtype also sets the output dtype
+        self._channels = channels
+
+    def __enter__(self):
+        if isinstance(self._file, str):
+            self._file_handle = open(self._file, "rb")
         else:
-            self._file_handle = file
+            self._file_handle = self._file
+        
+        self._frames = os.fstat(self._file_handle.fileno()).st_size / np.dtype(self.dtype).itemsize / self._channels
 
         self._executor = ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix="hifi_decode_reader"
         )
 
-        self._overlap = np.array([], dtype=np.int16)
+        return self
 
-        super().__init__(
-            self._file_handle,
-            mode,
-            **kwargs,
-        )
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            if isinstance(self._file, str):
+                self._file_handle.close()
+        finally:
+            self._executor.shutdown(wait=True)
+        return False
 
-    def seek(self, offset, whence=io.SEEK_SET):
-        return self._file_handle.seek(offset, whence)
+    @property
+    def frames(self):
+        return self._frames
 
-    async def buffer_read_into(self, out, dtype="int16"):
+    @property
+    def dtype(self):
+        return self._dtype
+
+    async def buffer_read_into(self, out):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
             self._executor,
             self._buffer_read_into,
             self._file_handle,
-            out,
-            dtype,
+            out
         )
 
-    def buffer_read_into_sync(self, out, dtype="int16"):
-        return self._buffer_read_into(self._file_handle, out, dtype)
+    def buffer_read_into_sync(self, out):
+        return self._buffer_read_into(self._file_handle, out)
+
+    @staticmethod
+    def _buffer_read_into(file_handle, out):
+        bytes_read = file_handle.readinto(out)
+        frames_read = bytes_read // out.itemsize
+
+        return frames_read
+
+
+class AsyncSoundFileReader(sf.SoundFile):
+    def __init__(self, file, **kwargs):
+        super().__init__(
+            file,
+            "r",
+            **kwargs,
+        )
+
+    def __enter__(self):
+        super().__enter__()
+
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="hifi_decode_reader"
+        )
+
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
-            super().close()
+            super().__exit__()
         finally:
             self._executor.shutdown(wait=True)
         return False
+    
+    @property
+    def dtype(self):
+        return DEFAULT_BLOCK_DTYPE
 
-    @staticmethod
-    def _buffer_read_into(input, out, dtype):
-        item_size = np.dtype(dtype).itemsize
-        bytes_read = input.readinto(out)
+    async def buffer_read_into(self, out):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            self._buffer_read_into,
+            out,
+        )
 
-        assert bytes_read % item_size == 0, "data is misaligned"
-        return bytes_read // item_size
+    def buffer_read_into_sync(self, out):
+        return self._buffer_read_into(out)
 
-
-class UnSigned16BitFileReader(io.RawIOBase):
-    def __init__(self, file_path):
-        self.file_path = file_path
-        self.file = open(file_path, "rb")
-
-    def readinto(self, buffer):
-        buffer_uint16 = np.frombuffer(buffer, dtype=np.uint16)
-        bytes_read = self.file.readinto(buffer_uint16)
-        UnSigned16BitFileReader.uint16_to_int16(buffer_uint16, buffer)
-        if not bytes_read:
-            return 0
-
-        return bytes_read
-
-    @staticmethod
-    @guvectorize(
-        [
-            (
-                numba.types.Array(numba.types.uint16, 1, "C"),
-                numba.types.Array(numba.types.int16, 1, "C"),
-            )
-        ],
-        "(n)->(n)",
-        cache=True,
-        fastmath=True,
-        nopython=True,
-    )
-    def uint16_to_int16(uint16_in, int16_out):
-        for i in range(len(uint16_in)):
-            int16_out[i] = uint16_in[i] - 2**15
-
-    def readable(self):
-        return True
-
-    def close(self):
-        self.file.close()
+    def _buffer_read_into(self, out):
+        return super().buffer_read_into(out, dtype="int16")
 
 
-# This part is what opens the file
-# The samplerate here could be anything
-def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
-    path = pathR.lower()
+def as_soundfile(pathR):
     extension = pathR.lower().split(".")[-1]
-    if "raw" == extension or "s16" == extension:
-        return AsyncSoundFile(
+    input_format, is_raw = get_raw_input_format(pathR)
+
+    if is_raw: # u8, s8, u16, s16, stdin
+        return AsyncReader(
             pathR,
-            "r",
-            channels=1,
-            samplerate=int(sample_rate),
-            format="RAW",
-            subtype="PCM_16",
-            endian="LITTLE",
-        )
-    elif "u8" == extension or "r8" == extension:
-        return AsyncSoundFile(
-            pathR,
-            "r",
-            channels=1,
-            samplerate=int(sample_rate),
-            format="RAW",
-            subtype="PCM_U8",
-            endian="LITTLE",
-        )
-    elif "s8" == extension:
-        return AsyncSoundFile(
-            pathR,
-            "r",
-            channels=1,
-            samplerate=int(sample_rate),
-            format="RAW",
-            subtype="PCM_S8",
-            endian="LITTLE",
-        )
-    elif "u16" == extension or "r16" == extension:
-        return AsyncSoundFile(
-            UnSigned16BitFileReader(pathR),
-            "r",
-            channels=1,
-            samplerate=int(sample_rate),
-            format="RAW",
-            subtype="PCM_16",
-            endian="LITTLE",
+            input_format
         )
     elif "flac" == extension:
         if test_if_ffmpeg_is_installed():
-            return AsyncSoundFile(
+            return AsyncReader(
                 FFMpegFileReader(pathR),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE"
+                DEFAULT_BLOCK_DTYPE
             )
         else:
-            return AsyncSoundFile(
-                pathR,
-                "r",
-            )
+            return AsyncSoundFileReader(pathR)
     elif "ldf" == extension:
         try:
             for ldf_reader_tool in ("ld-ldf-reader", "ld-ldf-reader-py"):
                 if test_ld_tools(ldf_reader_tool):
-                    return AsyncSoundFile(
+                    return AsyncReader(
                         LDToolFileReader(ldf_reader_tool, pathR),
-                        "r",
-                        channels=1,
-                        samplerate=int(sample_rate),
-                        format="RAW",
-                        subtype="PCM_16",
-                        endian="LITTLE",
+                        DEFAULT_BLOCK_DTYPE
                     )
             print(
                 "WARN: ld-ldf-reader/ld-ldf-reader-py not installed. LDF file format may not decode correctly"
@@ -877,32 +856,19 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
         
         try:    
             if test_if_flac_is_installed():
-                return AsyncSoundFile(
+                return AsyncReader(
                     FlacFileReader(pathR),
-                    "r",
-                    channels=1,
-                    samplerate=int(sample_rate),
-                    format="RAW",
-                    subtype="PCM_16",
-                    endian="LITTLE",
+                    DEFAULT_BLOCK_DTYPE
                 )
             if test_if_ffmpeg_is_installed():
-                return AsyncSoundFile(
+                return AsyncReader(
                     FFMpegFileReader(pathR),
-                    "r",
-                    channels=1,
-                    samplerate=int(sample_rate),
-                    format="RAW",
-                    subtype="PCM_16",
-                    endian="LITTLE",
+                    DEFAULT_BLOCK_DTYPE
                 )
         except Exception as e:
             pass
 
-        return AsyncSoundFile(
-            pathR,
-            "r",
-        )
+        return AsyncSoundFileReader(pathR)
     elif "lds" == extension:
         try:
             for lds_reader_tool, input_arg in (
@@ -910,14 +876,9 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
                 ("ld-lds-converter", "-i"),
             ):
                 if test_ld_tools(lds_reader_tool):
-                    return AsyncSoundFile(
+                    return AsyncReader(
                         LDToolFileReader(lds_reader_tool, pathR, input_arg),
-                        "r",
-                        channels=1,
-                        samplerate=int(sample_rate),
-                        format="RAW",
-                        subtype="PCM_16",
-                        endian="LITTLE",
+                        DEFAULT_BLOCK_DTYPE
                     )
             print(
                 "ERROR: Unable to decode LDS without ld-lds-reader or ld-lds-converter. Please install one of them and try again."
@@ -926,38 +887,19 @@ def as_soundfile(pathR, sample_rate=DEFAULT_FINAL_AUDIO_RATE):
             print(
                 "ERROR: Unexpected error opening LDS reader tool", e
             )
-    elif "-" == path:
-        try:
-            return AsyncSoundFile(
-                BufferedInputStream(sys.stdin.buffer),
-                "r",
-                channels=1,
-                samplerate=int(sample_rate),
-                format="RAW",
-                subtype="PCM_16",
-                endian="LITTLE",
-            )
-        except Exception as e:
-            print("Failed to open standard in, unable to decode")
-            raise e
     else:
         print("WARN: Unknown file format.")
         print("WARN: Attempting to decode with ffmpeg")
         try:
             if test_if_ffmpeg_is_installed():
-                return AsyncSoundFile(
+                return AsyncReader(
                     FFMpegFileReader(pathR),
-                    "r",
-                    channels=1,
-                    samplerate=int(sample_rate),
-                    format="RAW",
-                    subtype="PCM_16",
-                    endian="LITTLE",
+                    DEFAULT_BLOCK_DTYPE
                 )
         except Exception:
             pass
         print("WARN: Attempting to decode with SoundFile")
-        return AsyncSoundFile(pathR, "r")
+        return AsyncSoundFileReader(pathR)
 
 
 def get_normalize_filename(path, sample_rate):
@@ -2001,6 +1943,8 @@ async def decode_parallel(
     input_file = decode_options["input_file"]
     output_file = decode_options["output_file"]
 
+    input_format, _ = get_raw_input_format(input_file)
+
     channel_1_suffix = DEFAULT_CHANNEL_SUFFIX + "_1"
     channel_2_suffix = DEFAULT_CHANNEL_SUFFIX + "_2"
 
@@ -2045,6 +1989,7 @@ async def decode_parallel(
             decoder.blockOverlap,
             decoder.initialBlockFinalAudioSize,
             f"hifi_decoder_{i}",
+            input_format,
             numa_node=numa_node
         )
         shared_memory_instances.append(buffer_instance)
@@ -2134,7 +2079,7 @@ async def decode_parallel(
         # read input data into the shared memory buffer
         block_in = buffer.get_block_in()
         try:
-            frames_read = await f.buffer_read_into(block_in, "int16")
+            frames_read = await f.buffer_read_into(block_in)
         except sf.LibsndfileError as e:
             print("Error decoding input rf:", e)
             print("Stopping decode...")
@@ -2162,6 +2107,7 @@ async def decode_parallel(
                 decoder,
                 buffer.name,
                 decoder_state.block_frames_read,
+                decoder_state.block_dtype,
                 new_block_length,
                 decoder_state.block_num,
                 decoder_state.is_last_block,
@@ -2170,12 +2116,12 @@ async def decode_parallel(
             buffer = DecoderSharedMemory(decoder_state)
             block = buffer.get_block()
             # copy starting at half the normal read overlap
-            DecoderSharedMemory.copy_data_dst_offset_int16(
+            DecoderSharedMemory.copy_data_dst_offset(
                 block_data_read, block, start_overlap_end, len(block_data_read)
             )
 
             # this is the first block, fill in the empty data before half the read overlap, this will be discarded
-            DecoderSharedMemory.copy_data_int16(
+            DecoderSharedMemory.copy_data(
                 block_data_read, block, start_overlap_end
             )
         elif decoder_state.is_last_block and frames_read > 0:
@@ -2185,26 +2131,26 @@ async def decode_parallel(
             frames_read_with_overlap = frames_read + decoder_state.block_overlap
             block_in_offset = len(block) - frames_read_with_overlap
             block_data_read = block_in[0:frames_read].copy()
-            DecoderSharedMemory.copy_data_dst_offset_int16(
+            DecoderSharedMemory.copy_data_dst_offset(
                 block_data_read, block, block_in_offset, frames_read
             )
 
             # copy in the entire previous block to use as overlap
             # at the end of this decode worker, only the new audio will be returned
             previous_block_in_offset = len(previous_block) - block_in_offset
-            DecoderSharedMemory.copy_data_src_offset_int16(
+            DecoderSharedMemory.copy_data_src_offset(
                 previous_block, block, previous_block_in_offset, block_in_offset
             )
         else:
             # copy the overlapping data from the previous read
             block_in_overlap = buffer.get_block_in_start_overlap()
-            DecoderSharedMemory.copy_data_int16(
+            DecoderSharedMemory.copy_data(
                 previous_overlap, block_in_overlap, len(block_in_overlap)
             )
 
             # copy the the current overlap to use in the next iteration
             current_overlap = buffer.get_block_in_end_overlap()
-            DecoderSharedMemory.copy_data_int16(
+            DecoderSharedMemory.copy_data(
                 current_overlap, previous_overlap, len(current_overlap)
             )
 
@@ -2212,7 +2158,7 @@ async def decode_parallel(
             # save the full block for the next iteration, including previous overlap
             # will be used if the next block is the last block
             block = buffer.get_block()
-            DecoderSharedMemory.copy_data_int16(
+            DecoderSharedMemory.copy_data(
                 block, previous_block, len(previous_block)
             )
 
@@ -2253,7 +2199,7 @@ async def decode_parallel(
     with as_soundfile(input_file) as f:
         loop = asyncio.get_event_loop()
         previous_overlap = np.empty(0)
-        previous_block = np.empty(block_size, dtype=BLOCK_DTYPE)
+        previous_block = np.empty(block_size, dtype=f.dtype)
         progressB = TimeProgressBar(f.frames, f.frames)
         block_num = 0
 
@@ -2271,12 +2217,12 @@ async def decode_parallel(
                     return
 
             decoder_state = DecoderState(
-                decoder, buffer_name, 0, block_size, block_num, False, numa_node
+                decoder, buffer_name, 0, f.dtype, block_size, block_num, False, numa_node
             )
 
             if len(previous_overlap) == 0:
                 previous_overlap = np.empty(
-                    decoder_state.block_read_overlap, dtype=np.int16, order="C"
+                    decoder_state.block_read_overlap, dtype=f.dtype, order="C"
                 )
 
             is_last_block = await read_and_send_to_decoder(
@@ -2361,12 +2307,10 @@ async def normalize(input_file_post_gain, output_file, peak_gain, channels, audi
         total_frames_read = 0
         buffer = np.empty(2**20, dtype=np.float32, order="C")
 
-        with AsyncSoundFile(
+        with AsyncReader(
             input_file_post_gain,
-            "r",
-            samplerate=int(audio_rate),
-            channels=channels,
-            **normalize_parameters,
+            np.float32,
+            channels
         ) as f, as_outputfile(output_file, channels, audio_rate, False) as w:
             gain_adjust = (
                 1 / peak_gain - np.finfo(np.float16).eps
@@ -2376,7 +2320,7 @@ async def normalize(input_file_post_gain, output_file, peak_gain, channels, audi
             progressB = TimeProgressBar(f.frames, f.frames)
             done = False
             while not done:
-                frames_read = await f.buffer_read_into(buffer, dtype="float32")
+                frames_read = await f.buffer_read_into(buffer)
 
                 if frames_read < len(buffer):
                     buffer = buffer[0:frames_read]
@@ -2386,7 +2330,7 @@ async def normalize(input_file_post_gain, output_file, peak_gain, channels, audi
                 w.buffer_write(buffer, "float32")
 
                 total_frames_read += frames_read
-                progressB.print(total_frames_read / 2, False)
+                progressB.print(total_frames_read / channels, False)
         print("")
     finally:
         os.remove(input_file_post_gain)
@@ -2397,8 +2341,8 @@ def guess_bias(decoder, input_file, block_size, blocks_limits=10):
 
     with as_soundfile(input_file) as f:
         while f.tell() < f.frames and len(blocks) <= blocks_limits:
-            block_buffer = np.empty(block_size, dtype=np.int16, order="C")
-            f.buffer_read_into_sync(block_buffer, "int16")
+            block_buffer = np.empty(block_size, dtype=f.dtype, order="C")
+            f.buffer_read_into_sync(block_buffer)
             blocks.append(block_buffer)
 
     decoder.guessBiases(blocks)

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1367,7 +1367,7 @@ class PostProcessor:
             if enable_expander:
                 if decoder_state.block_num == 0:
                     # prime the expander's gain if this is the first block
-                    expander.process(pre, np.copy(post, order="C"))
+                    expander.process(np.copy(pre, order="C"), np.copy(post, order="C"))
                 expander.process(pre, post)
 
             buffer.close()

--- a/vhsdecode/hifi/main.py
+++ b/vhsdecode/hifi/main.py
@@ -1130,9 +1130,10 @@ class PostProcessor:
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
         out_conn,
-        peak_gain
+        peak_gain,
+        numa_node
     ):
-        self.numa_node = 0
+        self.numa_node = numa_node
         self.final_audio_rate = decode_options["audio_rate"]
         self.enable_expander = decode_options["enable_expander"]
         self.enable_deemphasis = decode_options["enable_deemphasis"]
@@ -1174,7 +1175,6 @@ class PostProcessor:
             target=PostProcessor.block_sorter_worker,
             name="hifi_block_sort",
             args=(
-                self.numa_node,
                 self.decoder_out_queue,
                 self.decoder_shared_memory_idle_queue,
                 self.blocks_enqueued,
@@ -1192,7 +1192,6 @@ class PostProcessor:
             target=PostProcessor.dc_block_worker,
             name="hifi_dc_block_l",
             args=(
-                self.numa_node,
                 block_sort_l_in_rx,
                 dc_blocker_worker_l_tx,
                 self.final_audio_rate,
@@ -1207,7 +1206,6 @@ class PostProcessor:
             target=PostProcessor.dc_block_worker,
             name="hifi_dc_block_r",
             args=(
-                self.numa_node,
                 block_sort_r_in_rx,
                 dc_blocker_worker_r_tx,
                 self.final_audio_rate,
@@ -1222,7 +1220,6 @@ class PostProcessor:
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_l",
             args=(
-                self.numa_node,
                 dc_blocker_worker_l_rx,
                 spectral_nr_worker_l_tx,
                 self.spectral_nr_amount,
@@ -1238,7 +1235,6 @@ class PostProcessor:
             target=PostProcessor.spectral_noise_reduction_worker,
             name="hifi_spec_nr_r",
             args=(
-                self.numa_node,
                 dc_blocker_worker_r_rx,
                 spectral_nr_worker_r_tx,
                 self.spectral_nr_amount,
@@ -1256,7 +1252,6 @@ class PostProcessor:
             target=expander_worker,
             name="hifi_expander_l",
             args=(
-                self.numa_node,
                 spectral_nr_worker_l_rx,
                 expander_worker_l_out_tx,
                 self.enable_deemphasis,
@@ -1287,7 +1282,6 @@ class PostProcessor:
             target=expander_worker,
             name="hifi_expander_r",
             args=(
-                self.numa_node,
                 spectral_nr_worker_r_rx,
                 expander_worker_r_out_tx,
                 self.enable_deemphasis,
@@ -1317,7 +1311,6 @@ class PostProcessor:
             target=PostProcessor.mix_to_stereo_worker,
             name="hifi_stereo_mix",
             args=(
-                self.numa_node,
                 expander_worker_l_out_rx,
                 expander_worker_r_out_rx,
                 self.mix_to_stereo_worker_output,
@@ -1343,12 +1336,10 @@ class PostProcessor:
 
     @staticmethod
     def dc_block_worker(
-        numa_node,
         in_conn,
         out_conn,
         final_audio_rate
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         dc_blocker = DCBlocker(
@@ -1379,13 +1370,11 @@ class PostProcessor:
         
     @staticmethod
     def spectral_noise_reduction_worker(
-        numa_node,
         in_conn,
         out_conn,
         spectral_nr_amount,
         final_audio_rate,
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         spectral_nr = SpectralNoiseReduction(
@@ -1423,7 +1412,6 @@ class PostProcessor:
 
     @staticmethod
     def expander_vhs_worker(
-        numa_node,
         in_conn,
         out_conn,
         enable_deemphasis,
@@ -1444,7 +1432,6 @@ class PostProcessor:
         expander_weighting_low_pass,
         expander_weighting_low_pass_transition,
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         deemphasis_pre_1 = Deemphasis(
@@ -1516,7 +1503,6 @@ class PostProcessor:
 
     @staticmethod
     def expander_8mm_worker(
-        numa_node,
         in_conn,
         out_conn,
         enable_deemphasis,
@@ -1537,7 +1523,6 @@ class PostProcessor:
         expander_weighting_low_pass,
         expander_weighting_low_pass_transition,
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         _ensure_hifi_engine_imported()
         deemphasis_2 = Deemphasis(
@@ -1601,9 +1586,8 @@ class PostProcessor:
 
     @staticmethod
     def mix_to_stereo_worker(
-        numa_node, expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
+        expander_l_in_conn, expander_r_in_conn, out_conn, peak_gain, sample_rate
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         while True:
             while True:
@@ -1698,7 +1682,6 @@ class PostProcessor:
 
     @staticmethod
     def block_sorter_worker(
-        numa_node,
         decoder_out_queue,
         decoder_shared_memory_idle_queue,
         blocks_enqueued,
@@ -1706,7 +1689,6 @@ class PostProcessor:
         l_tx,
         r_tx,
     ):
-        NUMA.bind_process(numa_node)
         setproctitle(current_process().name)
         next_block = 0
         last_block_submitted = -1
@@ -2123,6 +2105,8 @@ async def decode_parallel(
     max_numa_node = 0
     for i in range(num_shared_memory_instances):
         numa_node = NUMA.next_node()
+
+        NUMA.bind_process(numa_node)
         if numa_node > max_numa_node:
             max_numa_node = numa_node
 
@@ -2147,6 +2131,8 @@ async def decode_parallel(
 
     for i in range(num_decoders):
         numa_node = i % (max_numa_node + 1)
+
+        NUMA.bind_process(numa_node)
         decoder_process = Process(
             target=HiFiDecode.hifi_decode_worker,
             name=f"hifi_decode_worker_{i}",
@@ -2164,6 +2150,9 @@ async def decode_parallel(
         decoder_processes.append(decoder_process)
 
     # set up the post processor
+    # all new processes should be ont he same numa node at this point
+    post_processor_numa_node = 0
+    NUMA.bind_process(post_processor_numa_node)
     post_processor_out_rx_conn, post_processor_out_tx_conn = Pipe(duplex=False)
     post_processor_shared_memory_idle_queue = SimpleQueue()
     post_processor = PostProcessor(
@@ -2175,6 +2164,7 @@ async def decode_parallel(
         blocks_enqueued,
         post_processor_out_tx_conn,
         peak_gain,
+        post_processor_numa_node
     )
     atexit.register(post_processor.close)
 

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -27,7 +27,6 @@ NumbaAudioArray = numba.types.Array(numba.types.float32, 1, "C")
 # 2^36 samples (~28.6 minutes at 40 MSps) overflow it and the stored count
 # wraps around modulo 2^36. libsndfile trusts this count and stops reading
 # there, truncating the decode. See parse_flac_streaminfo() below.
-FLAC_TOTAL_SAMPLES_FIELD_MOD = 2**36
 
 
 def parse_flac_streaminfo(file_path):
@@ -81,79 +80,6 @@ def parse_flac_streaminfo(file_path):
             }
     except OSError:
         return None
-
-
-def check_flac_header_total_samples(streaminfo, file_size):
-    """Check whether the STREAMINFO total_samples count can be trusted.
-
-    A FLAC frame stores at most max_framesize bytes for at least
-    min_blocksize samples, so `total_samples` samples can never occupy more
-    than (total_samples / min_blocksize + 1) * max_framesize bytes of audio
-    payload. If the file holds substantially more audio data than that, the
-    36 bit total_samples field overflowed and wrapped (or was never
-    finalized), and the header length must not be trusted.
-
-    Returns (header_is_trustworthy, corrected_total_samples or None).
-    """
-    declared = streaminfo["total_samples"]
-    audio_bytes = file_size - streaminfo["audio_offset"]
-
-    if audio_bytes <= 0:
-        return True, None
-
-    if declared == 0:
-        # length marked as unknown (e.g. the encoder could not seek back to
-        # finalize the header)
-        return False, None
-
-    min_blocksize = streaminfo["min_blocksize"]
-    max_blocksize = streaminfo["max_blocksize"]
-    min_framesize = streaminfo["min_framesize"]
-    max_framesize = streaminfo["max_framesize"]
-
-    if min_blocksize > 0 and max_framesize > 0:
-        # largest possible payload for the declared sample count
-        declared_max_bytes = (declared // min_blocksize + 1) * max_framesize
-    else:
-        # min/max frame sizes may legally be 0 (unknown), fall back to the
-        # verbatim worst case (uncompressed samples) plus generous margin
-        declared_max_bytes = (
-            int(
-                declared
-                * streaminfo["channels"]
-                * (streaminfo["bits_per_sample"] / 8)
-                * 1.05
-            )
-            + 65536
-        )
-
-    if audio_bytes <= declared_max_bytes:
-        return True, None
-
-    # the header count is impossibly small for the amount of audio data in
-    # the file: it wrapped modulo 2^36. try to recover the true count using
-    # the frame size statistics, accepting it only if exactly one candidate
-    # fits between the possible payload bounds
-    corrected = None
-    if (
-        min_blocksize > 0
-        and max_blocksize > 0
-        and min_framesize > 0
-        and max_framesize > 0
-    ):
-        lower = audio_bytes / max_framesize * min_blocksize
-        upper = audio_bytes / min_framesize * max_blocksize
-        candidates = []
-        k = 1
-        while declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD <= upper:
-            candidate = declared + k * FLAC_TOTAL_SAMPLES_FIELD_MOD
-            if candidate >= lower:
-                candidates.append(candidate)
-            k += 1
-        if len(candidates) == 1:
-            corrected = candidates[0]
-
-    return False, corrected
 
 
 class NUMA:

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -205,7 +205,9 @@ class NUMA:
             return cycle([0])
 
         try:
-            return cycle(list(range(cls._lib.numa_max_node() + 1)))
+            max_node = cls._lib.numa_max_node()
+            nodes = [n for n in range(max_node + 1) if cls._cpus_for_node(n)]
+            return cycle(nodes or [0])
         except Exception:
             return cycle([0])
 

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -512,7 +512,6 @@ class DecoderSharedMemory:
             for _ in range(8)
         )
 
-
         # this instance must be saved in a variable that persists on both processes
         # Windows will remove the shared memory if it garbage collects the handle in any of the processes it is open in
         # https://stackoverflow.com/a/63717188

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -10,6 +10,12 @@ from random import SystemRandom
 
 from cProfile import Profile
 import ctypes
+import platform
+import mmap
+import os
+from functools import lru_cache
+from itertools import cycle
+
 from pstats import SortKey, Stats
 
 BLOCK_DTYPE = np.int16
@@ -150,13 +156,143 @@ def check_flac_header_total_samples(streaminfo, file_size):
 
     return False, corrected
 
+
+class NUMA:
+    _lib = None
+
+    class Bitmask(ctypes.Structure):
+        _fields_ = [
+            ("size", ctypes.c_ulong),
+            ("maskp", ctypes.POINTER(ctypes.c_ulong)),
+        ]
+
+    @classmethod
+    def _load_lib(cls):
+        if cls._lib is not None:
+            return cls._lib
+
+        try:
+            lib = ctypes.CDLL("libnuma.so.1")
+
+            lib.numa_available.restype = ctypes.c_int
+            lib.numa_max_node.restype = ctypes.c_int
+            lib.numa_node_to_cpus.argtypes = [ctypes.c_int, ctypes.c_void_p]
+            lib.numa_node_to_cpus.restype = ctypes.c_int
+            lib.numa_run_on_node.argtypes = [ctypes.c_int]
+            lib.numa_set_preferred.argtypes = [ctypes.c_int]
+            lib.numa_tonode_memory.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+                ctypes.c_int,
+            ]
+
+            cls._lib = lib
+            return lib
+
+        except Exception:
+            cls._lib = None
+            return None
+
+    @classmethod
+    def _available(cls):
+        lib = cls._load_lib()
+        return bool(lib and lib.numa_available() >= 0)
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def _nodes(cls):
+        if not cls._available():
+            return cycle([0])
+
+        try:
+            return cycle(list(range(cls._lib.numa_max_node() + 1)))
+        except Exception:
+            return cycle([0])
+
+    @classmethod
+    @lru_cache(maxsize=128)
+    def _cpus_for_node(cls, node: int):
+        if not cls._available():
+            return None
+
+        lib = cls._lib
+        MAX_CPUS = 1024
+
+        words = MAX_CPUS // (8 * ctypes.sizeof(ctypes.c_ulong))
+        mask = (ctypes.c_ulong * words)()
+
+        bm = cls.Bitmask()
+        bm.size = MAX_CPUS
+        bm.maskp = mask
+
+        if lib.numa_node_to_cpus(node, ctypes.byref(bm)) != 0:
+            return None
+
+        cpus = set()
+        bits = 8 * ctypes.sizeof(ctypes.c_ulong)
+
+        for cpu in range(MAX_CPUS):
+            word = mask[cpu // bits]
+            bit = cpu % bits
+            if word & (1 << bit):
+                cpus.add(cpu)
+
+        return cpus
+
+    @classmethod
+    def next_node(cls):
+        return next(cls._nodes())
+
+    @classmethod
+    def bind_process(cls, node: int) -> bool:
+        if not cls._available():
+            return False
+
+        cpus = cls._cpus_for_node(node)
+        if not cpus:
+            return False
+
+        try:
+            os.sched_setaffinity(0, cpus)
+            cls._lib.numa_run_on_node(node)
+            cls._lib.numa_set_preferred(node)
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def bind_shared_memory(cls, shm, node: int) -> bool:
+        if platform.system() != "Linux" or not cls._available():
+            return False
+
+        try:
+            lib = cls._lib
+            buf = memoryview(shm.buf)
+            addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+
+            lib.numa_tonode_memory(
+                ctypes.c_void_p(addr),
+                ctypes.c_size_t(len(buf)),
+                ctypes.c_int(node),
+            )
+
+            page = mmap.PAGESIZE
+            for i in range(0, len(buf), page):
+                buf[i] = 0
+
+            return True
+
+        except Exception:
+            return False
+
 @dataclass
 class DecoderState:
-    def __init__(self, decoder, buffer_name, block_frames_read, block_size, block_num, is_last_block):
+    def __init__(self, decoder, buffer_name, block_frames_read, block_size, block_num, is_last_block, numa_node):
         block_sizes = decoder.set_block_sizes(block_size)
         block_overlap = decoder.get_block_overlap()
 
         self.name = buffer_name
+        self.numa_node = numa_node
         self.block_num = block_num
         self.is_last_block = is_last_block
 
@@ -176,6 +312,7 @@ class DecoderState:
         self.block_audio_final_overlap = block_overlap["block_audio_final_overlap"]
 
     name: str
+    numa_node: int
     block_num: int
     is_last_block: bool
 
@@ -220,6 +357,7 @@ class PostProcessorSharedMemory:
         self.close = self.shared_memory.close
         self.unlink = self.shared_memory.unlink
 
+        self.numa_node = decoder_state.numa_node
         self.audio_dtype = decoder_state.audio_dtype
         self.channel_len = decoder_state.block_audio_final_len
         self.audio_dtype_item_size = np.dtype(self.audio_dtype).itemsize
@@ -259,7 +397,7 @@ class PostProcessorSharedMemory:
         self.r_post_bytes = self.r_post_len * self.audio_dtype_item_size
 
     @staticmethod
-    def get_shared_memory(channel_size, name, audio_dtype=REAL_DTYPE):
+    def get_shared_memory(channel_size, name, audio_dtype=REAL_DTYPE, numa_node=None):
         byte_size = (
             to_aligned_offset(channel_size * np.dtype(audio_dtype).itemsize * 4)
             + ALIGNMENT * 16
@@ -272,10 +410,15 @@ class PostProcessorSharedMemory:
             for _ in range(8)
         )
 
+        shm = SharedMemory(size=byte_size, name=name, create=True)
+
+        if numa_node is not None:
+            NUMA.bind_shared_memory(shm, numa_node)
+
         # this instance must be saved in a variable that persists on both processes
         # Windows will remove the shared memory if it garbage collects the handle in any of the processes it is open in
         # https://stackoverflow.com/a/63717188
-        return SharedMemory(size=byte_size, name=name, create=True)
+        return shm
 
     def get_pre_left(self) -> np.array:
         return np.ndarray(
@@ -334,6 +477,7 @@ class DecoderSharedMemory:
         self.close = self.shared_memory.close
         self.unlink = self.shared_memory.unlink
 
+        self.numa_node = decoder_state.numa_node
         self.block_dtype = decoder_state.block_dtype
         self.block_dtype_item_size = np.dtype(self.block_dtype).itemsize
 
@@ -389,6 +533,7 @@ class DecoderSharedMemory:
         name,
         block_dtype=BLOCK_DTYPE,
         audio_dtype=REAL_DTYPE,
+        numa_node=None,
     ):
         max_audio_size = (
             block_audio_final_size + to_aligned_offset(block_audio_final_size)
@@ -404,10 +549,15 @@ class DecoderSharedMemory:
             for _ in range(8)
         )
 
+        shm = SharedMemory(size=byte_size, name=name, create=True)
+
+        if numa_node is not None:
+            NUMA.bind_shared_memory(shm, numa_node)
+
         # this instance must be saved in a variable that persists on both processes
         # Windows will remove the shared memory if it garbage collects the handle in any of the processes it is open in
         # https://stackoverflow.com/a/63717188
-        return SharedMemory(size=byte_size, name=name, create=True)
+        return shm
 
     ## Decoder methods
 

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -10,7 +10,6 @@ from random import SystemRandom
 
 from cProfile import Profile
 import ctypes
-import platform
 import mmap
 import os
 from functools import lru_cache
@@ -158,7 +157,8 @@ def check_flac_header_total_samples(streaminfo, file_size):
 
 
 class NUMA:
-    _lib = None
+    _libnuma = None
+    _libc = None
 
     class Bitmask(ctypes.Structure):
         _fields_ = [
@@ -167,36 +167,52 @@ class NUMA:
         ]
 
     @classmethod
-    def _load_lib(cls):
-        if cls._lib is not None:
-            return cls._lib
+    def _load_libnuma(cls):
+        if cls._libnuma is not None:
+            return cls._libnuma
 
         try:
-            lib = ctypes.CDLL("libnuma.so.1")
+            libnuma = ctypes.CDLL("libnuma.so.1")
 
-            lib.numa_available.restype = ctypes.c_int
-            lib.numa_max_node.restype = ctypes.c_int
-            lib.numa_node_to_cpus.argtypes = [ctypes.c_int, ctypes.c_void_p]
-            lib.numa_node_to_cpus.restype = ctypes.c_int
-            lib.numa_run_on_node.argtypes = [ctypes.c_int]
-            lib.numa_set_preferred.argtypes = [ctypes.c_int]
-            lib.numa_tonode_memory.argtypes = [
+            libnuma.numa_available.restype = ctypes.c_int
+            libnuma.numa_max_node.restype = ctypes.c_int
+            libnuma.numa_node_to_cpus.argtypes = [ctypes.c_int, ctypes.c_void_p]
+            libnuma.numa_node_to_cpus.restype = ctypes.c_int
+            libnuma.numa_run_on_node.argtypes = [ctypes.c_int]
+            libnuma.numa_set_preferred.argtypes = [ctypes.c_int]
+            libnuma.numa_tonode_memory.argtypes = [
                 ctypes.c_void_p,
                 ctypes.c_size_t,
                 ctypes.c_int,
             ]
 
-            cls._lib = lib
-            return lib
+            cls._libnuma = libnuma
+            return libnuma
 
         except Exception:
-            cls._lib = None
+            cls._libnuma = None
             return None
 
     @classmethod
+    def _load_libc(cls):
+        if cls._libc is not None:
+            return cls._libc
+
+        try:
+            libc = ctypes.CDLL("libc.so.6", use_errno=True)
+
+            cls._libc = libc
+            return libc
+
+        except Exception:
+            cls._libc = None
+            return None      
+
+    @classmethod
     def _available(cls):
-        lib = cls._load_lib()
-        return bool(lib and lib.numa_available() >= 0)
+        libnuma = cls._load_libnuma()
+        libc = cls._load_libc()
+        return bool(libc and libnuma and libnuma.numa_available() >= 0)
 
     @classmethod
     @lru_cache(maxsize=1)
@@ -205,7 +221,7 @@ class NUMA:
             return cycle([0])
 
         try:
-            max_node = cls._lib.numa_max_node()
+            max_node = cls._libnuma.numa_max_node()
             nodes = [n for n in range(max_node + 1) if cls._cpus_for_node(n)]
             return cycle(nodes or [0])
         except Exception:
@@ -217,7 +233,7 @@ class NUMA:
         if not cls._available():
             return None
 
-        lib = cls._lib
+        lib = cls._libnuma
         MAX_CPUS = 1024
 
         words = MAX_CPUS // (8 * ctypes.sizeof(ctypes.c_ulong))
@@ -256,36 +272,53 @@ class NUMA:
 
         try:
             os.sched_setaffinity(0, cpus)
-            cls._lib.numa_run_on_node(node)
-            cls._lib.numa_set_preferred(node)
+            cls._libnuma.numa_run_on_node(node)
+            cls._libnuma.numa_set_preferred(node)
             return True
         except Exception:
             return False
 
     @classmethod
-    def bind_shared_memory(cls, shm, node: int) -> bool:
-        if platform.system() != "Linux" or not cls._available():
-            return False
+    def get_shared_memory(
+        cls,
+        name: str,
+        size: int,
+        numa_node: int | None = None,
+    ):
+        shm = SharedMemory(name=name, size=size, create=True)
 
-        try:
-            lib = cls._lib
-            buf = memoryview(shm.buf)
-            addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+        if cls._available() and numa_node is not None:
+            try:
+                MPOL_BIND = 2
+                MPOL_MF_STRICT = 1
+                MPOL_MF_MOVE = 2
+                SYS_mbind = 237
 
-            lib.numa_tonode_memory(
-                ctypes.c_void_p(addr),
-                ctypes.c_size_t(len(buf)),
-                ctypes.c_int(node),
-            )
+                buf = shm.buf
 
-            page = mmap.PAGESIZE
-            for i in range(0, len(buf), page):
-                buf[i] = 0
+                addr = ctypes.addressof(
+                    ctypes.c_char.from_buffer(buf)
+                )
 
-            return True
+                nodemask = ctypes.c_ulong(1 << numa_node)
 
-        except Exception:
-            return False
+                cls._libc.syscall(
+                    SYS_mbind,
+                    ctypes.c_void_p(addr),
+                    ctypes.c_ulong(len(buf)),
+                    MPOL_BIND,
+                    ctypes.byref(nodemask),
+                    ctypes.sizeof(nodemask) * 8,
+                    MPOL_MF_MOVE | MPOL_MF_STRICT,
+                )
+
+                for offset in range(0, len(buf), mmap.PAGESIZE):
+                    buf[offset] = 0
+
+            except Exception:
+                pass
+
+        return shm
 
 @dataclass
 class DecoderState:
@@ -412,15 +445,10 @@ class PostProcessorSharedMemory:
             for _ in range(8)
         )
 
-        shm = SharedMemory(size=byte_size, name=name, create=True)
-
-        if numa_node is not None:
-            NUMA.bind_shared_memory(shm, numa_node)
-
         # this instance must be saved in a variable that persists on both processes
         # Windows will remove the shared memory if it garbage collects the handle in any of the processes it is open in
         # https://stackoverflow.com/a/63717188
-        return shm
+        return NUMA.get_shared_memory(name, byte_size, numa_node)
 
     def get_pre_left(self) -> np.array:
         return np.ndarray(
@@ -551,15 +579,11 @@ class DecoderSharedMemory:
             for _ in range(8)
         )
 
-        shm = SharedMemory(size=byte_size, name=name, create=True)
-
-        if numa_node is not None:
-            NUMA.bind_shared_memory(shm, numa_node)
 
         # this instance must be saved in a variable that persists on both processes
         # Windows will remove the shared memory if it garbage collects the handle in any of the processes it is open in
         # https://stackoverflow.com/a/63717188
-        return shm
+        return NUMA.get_shared_memory(name, byte_size, numa_node)
 
     ## Decoder methods
 

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -157,6 +157,11 @@ def check_flac_header_total_samples(streaminfo, file_size):
 
 
 class NUMA:
+    MPOL_BIND = 2
+    MPOL_MF_MOVE = 2
+    MPOL_MF_STRICT = 1
+    SYS_mbind = 237 # x86_64
+
     _libnuma = None
     _libc = None
 
@@ -206,7 +211,7 @@ class NUMA:
 
         except Exception:
             cls._libc = None
-            return None      
+            return None
 
     @classmethod
     def _available(cls):
@@ -271,8 +276,15 @@ class NUMA:
             return False
 
         try:
-            os.sched_setaffinity(0, cpus)
-            cls._libnuma.numa_run_on_node(node)
+            cpus = cls._cpus_for_node(node)
+            if cpus:
+                os.sched_setaffinity(0, cpus)
+
+            mask = cls._libnuma.numa_allocate_nodemask()
+            cls._libnuma.numa_bitmask_clearall(mask)
+            cls._libnuma.numa_bitmask_setbit(mask, node)
+
+            cls._libnuma.numa_run_on_node_mask(mask)
             cls._libnuma.numa_set_preferred(node)
             return True
         except Exception:
@@ -289,11 +301,6 @@ class NUMA:
 
         if cls._available() and numa_node is not None:
             try:
-                MPOL_BIND = 2
-                MPOL_MF_STRICT = 1
-                MPOL_MF_MOVE = 2
-                SYS_mbind = 237
-
                 buf = shm.buf
 
                 addr = ctypes.addressof(
@@ -303,13 +310,13 @@ class NUMA:
                 nodemask = ctypes.c_ulong(1 << numa_node)
 
                 cls._libc.syscall(
-                    SYS_mbind,
+                    NUMA.SYS_mbind,
                     ctypes.c_void_p(addr),
                     ctypes.c_ulong(len(buf)),
-                    MPOL_BIND,
+                    NUMA.MPOL_BIND,
                     ctypes.byref(nodemask),
                     ctypes.sizeof(nodemask) * 8,
-                    MPOL_MF_MOVE | MPOL_MF_STRICT,
+                    NUMA.MPOL_MF_MOVE | NUMA.MPOL_MF_STRICT,
                 )
 
                 for offset in range(0, len(buf), mmap.PAGESIZE):

--- a/vhsdecode/hifi/utils.py
+++ b/vhsdecode/hifi/utils.py
@@ -17,7 +17,7 @@ from itertools import cycle
 
 from pstats import SortKey, Stats
 
-BLOCK_DTYPE = np.int16
+DEFAULT_BLOCK_DTYPE = np.int16
 REAL_DTYPE = np.float32
 ALIGNMENT = 64
 
@@ -255,7 +255,7 @@ class NUMA:
 
 @dataclass
 class DecoderState:
-    def __init__(self, decoder, buffer_name, block_frames_read, block_size, block_num, is_last_block, numa_node):
+    def __init__(self, decoder, buffer_name, block_frames_read, block_dtype, block_size, block_num, is_last_block, numa_node):
         block_sizes = decoder.set_block_sizes(block_size)
         block_overlap = decoder.get_block_overlap()
 
@@ -266,7 +266,7 @@ class DecoderState:
 
         # block data for input rf
         self.block_frames_read = block_frames_read
-        self.block_dtype = BLOCK_DTYPE
+        self.block_dtype = block_dtype
         self.block_size = block_sizes["block_size"]
         self.block_overlap = block_overlap["block_overlap"]
         self.block_read_overlap = block_overlap["block_read_overlap"]
@@ -494,7 +494,7 @@ class DecoderSharedMemory:
         block_overlap,
         block_audio_final_size,
         name,
-        block_dtype=BLOCK_DTYPE,
+        block_dtype,
         audio_dtype=REAL_DTYPE,
         numa_node=None,
     ):
@@ -581,6 +581,114 @@ class DecoderSharedMemory:
 
     @staticmethod
     @njit(
+        [
+            numba.types.void(
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.int64,
+            ),
+        ],
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def copy_data(src: np.array, dst: np.array, length: int):
+        for i in range(length):
+            dst[i] = src[i]
+
+    @staticmethod
+    @njit(
+        [
+            numba.types.void(
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+        ],
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def copy_data_dst_offset(
+        src: np.array, dst: np.array, dst_offset: int, length: int
+    ):
+        for i in range(length):
+            dst[i + dst_offset] = src[i]
+
+    @staticmethod
+    @njit(
+        [
+            numba.types.void(
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.Array(numba.uint8, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.Array(numba.int8, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.Array(numba.uint16, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+            numba.types.void(
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.Array(numba.int16, 1, "C"),
+                numba.types.int64,
+                numba.types.int64,
+            ),
+        ],
+        cache=True,
+        fastmath=True,
+        nogil=True,
+    )
+    def copy_data_src_offset(
+        src: np.array, dst: np.array, src_offset: int, length: int
+    ):
+        for i in range(length):
+            dst[i] = src[i + src_offset]
+
+    @staticmethod
+    @njit(
         numba.types.void(NumbaAudioArray, NumbaAudioArray, numba.types.int64),
         cache=True,
         fastmath=True,
@@ -590,57 +698,6 @@ class DecoderSharedMemory:
         # ctypes.memmove(dst.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), src.ctypes.data_as(ctypes.POINTER(ctypes.c_float)), length)
         for i in range(length):
             dst[i] = src[i]
-
-    @staticmethod
-    @njit(
-        numba.types.void(
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.int64,
-        ),
-        cache=True,
-        fastmath=True,
-        nogil=True,
-    )
-    def copy_data_int16(src: np.array, dst: np.array, length: int):
-        for i in range(length):
-            dst[i] = src[i]
-
-    @staticmethod
-    @njit(
-        numba.types.void(
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.int64,
-            numba.types.int64,
-        ),
-        cache=True,
-        fastmath=True,
-        nogil=True,
-    )
-    def copy_data_dst_offset_int16(
-        src: np.array, dst: np.array, dst_offset: int, length: int
-    ):
-        for i in range(length):
-            dst[i + dst_offset] = src[i]
-
-    @staticmethod
-    @njit(
-        numba.types.void(
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.Array(numba.int16, 1, "C"),
-            numba.types.int64,
-            numba.types.int64,
-        ),
-        cache=True,
-        fastmath=True,
-        nogil=True,
-    )
-    def copy_data_src_offset_int16(
-        src: np.array, dst: np.array, src_offset: int, length: int
-    ):
-        for i in range(length):
-            dst[i] = src[i + src_offset]
 
     @staticmethod
     @njit(


### PR DESCRIPTION
* Make input file reads async (threaded) so they don't lock other tasks in the main thread.
* Simplify input file reading, add full support for raw formats.
* Fix 8mm filtering (right channel / sub channel has a different max deviation)
* Use complex conjugation in discriminator. This is more numerically stable, especially for large amplitudes.
* Add numa node support. This speeds up performance on large servers, i.e. more than 1 CPU socket.
  * Distribute hifi-decode worker threads across nodes
  * Distribute shared memory blocks across nodes
  * Match up shared memory blocks and hifi-decode worker processes by numa node