### PR TITLE
Fix ffmpeg path resolution for Windows smoke test

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import traceback
+import warnings
 
 import threading
 from queue import Queue

--- a/tests/unit/test_ffmpeg_path_resolution.py
+++ b/tests/unit/test_ffmpeg_path_resolution.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import lddecode.utils as utils
+
+
+def test_ensure_ffmpeg_on_path_uses_static_ffmpeg_add_paths(monkeypatch):
+    calls: list[bool] = []
+
+    def _add_paths(*, weak: bool = False) -> None:
+        calls.append(weak)
+
+    fake_static_ffmpeg = types.SimpleNamespace(add_paths=_add_paths)
+    monkeypatch.setitem(sys.modules, "static_ffmpeg", fake_static_ffmpeg)
+
+    assert utils._ensure_ffmpeg_on_path() is True
+    assert calls == [True]
+
+
+def test_ensure_ffmpeg_on_path_returns_false_when_add_paths_fails(monkeypatch):
+    def _add_paths(*, weak: bool = False) -> None:
+        raise RuntimeError("boom")
+
+    fake_static_ffmpeg = types.SimpleNamespace(add_paths=_add_paths)
+    monkeypatch.setitem(sys.modules, "static_ffmpeg", fake_static_ffmpeg)
+
+    assert utils._ensure_ffmpeg_on_path() is False


### PR DESCRIPTION
## Summary

- Fix ffmpeg path resolution by importing warnings in lddecode/utils.py so _ensure_ffmpeg_on_path() can call static_ffmpeg.add_paths().
- Add regression tests for _ensure_ffmpeg_on_path() success/failure behavior.

## Testing

- python -m pytest tests/unit/test_ffmpeg_path_resolution.py -q
- https://github.com/harrypm/ld-decode/actions/runs/27967205886